### PR TITLE
Integrate the project with our standard CI tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=40a6febb0a056fa9236dec7ffab8afc58cf5fd5973cad5f047fc14f32484203e
+
+language: ruby
+rvm: 2.4.2
+cache: bundler
+
+# Travis CI clones repositories to a depth of 50 commits, which is only really
+# useful if you are performing git operations.
+# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+git:
+  depth: 3
+
+before_install:
+  - export TZ=UTC
+
+before_script:
+  # Setup to support the CodeClimate test coverage submission
+  # As per CodeClimate's documentation, they suggest only running
+  # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all
+  # the codeclimate test coverage related commands in a check that tests if we
+  # are in a pull request or not.
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
+  # Run rubocop. It's installed as a dependency (hence no install step) as this
+  # allows projects to control the version they are using (rather than getting)
+  # surprise build failures.
+  - bundle exec rubocop
+  # Replace database.yml with database.travis.yml (but leave filename as
+  # database.yml). database.travis.yml is the config needed for Travis, and it
+  # needs to be in place before we run the migrations.
+  - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
+  - RAILS_ENV=test bundle exec rake db:create --trace
+
+after_script:
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Waste Exemptions Engine
 
+[![Build Status](https://travis-ci.com/DEFRA/waste-exemptions-engine.svg?branch=master)](https://travis-ci.com/DEFRA/waste-exemptions-engine)
+[![Maintainability](https://api.codeclimate.com/v1/badges/cf17f3b143d5481d1515/maintainability)](https://codeclimate.com/github/DEFRA/waste-exemptions-engine/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/cf17f3b143d5481d1515/test_coverage)](https://codeclimate.com/github/DEFRA/waste-exemptions-engine/test_coverage)
+
 A Rails Engine for the [Waste Exemptions](https://github.com/DEFRA/waste-exemptions) digital service.
 
 ## Prerequisites
@@ -10,7 +14,7 @@ Make sure you already have:
 - [Bundler](http://bundler.io/) – for installing Ruby gems
 - PostgreSql
 
-# Mounting the engine
+## Mounting the engine
 
 Add the engine to your Gemfile:
 

--- a/spec/dummy/config/database.travis.yml
+++ b/spec/dummy/config/database.travis.yml
@@ -1,0 +1,4 @@
+test:
+  adapter: postgresql
+  database: travis_ci_test
+  username: postgres


### PR DESCRIPTION
For all our ruby projects we integrate the GitHub project with

- Travis-CI
- Codeclimate (maintainability)
- Codeclimate (test coverage)

These changes cover what is needed to do this from the code perspective.