### PR TITLE
Add registration no page + comp. house support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
       pg (~> 0.18.4)
       phonelib
       rails (= 4.2.11)
+      rest-client (~> 2.0)
       validates_email_format_of
 
 GEM
@@ -62,6 +63,8 @@ GEM
     database_cleaner (1.7.0)
     diff-lcs (1.3)
     docile (1.3.1)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.5.0)
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
@@ -90,6 +93,8 @@ GEM
       activerecord (>= 3.0)
     hashdiff (0.3.7)
     high_voltage (3.1.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)
@@ -99,11 +104,15 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
+    netrc (0.11.0)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     octokit (4.13.0)
@@ -144,6 +153,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.1)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (2.1.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
@@ -192,6 +205,9 @@ GEM
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
     unicode-display_width (1.4.0)
     validates_email_format_of (1.6.3)
       i18n
@@ -219,4 +235,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/app/controllers/waste_exemptions_engine/registration_number_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/registration_number_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RegistrationNumberFormsController < FormsController
+    def new
+      super(RegistrationNumberForm, "registration_number_form")
+    end
+
+    def create
+      super(RegistrationNumberForm, "registration_number_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/registration_number_form.rb
+++ b/app/forms/waste_exemptions_engine/registration_number_form.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RegistrationNumberForm < BaseForm
+    include CanNavigateFlexibly
+
+    attr_accessor :company_no, :business_type
+
+    def initialize(enrollment)
+      super
+      self.company_no = @enrollment.company_no
+      # We only use this for the correct microcopy
+      self.business_type = @enrollment.business_type
+    end
+
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      # If param isn't set, use a blank string instead to avoid errors with the validator
+      self.company_no = params[:company_no] || ""
+      self.company_no = process_company_no(company_no) if company_no.present?
+      attributes = { company_no: company_no }
+
+      super(attributes, params[:token])
+    end
+
+    validates :company_no, "waste_exemptions_engine/company_no": true
+
+    private
+
+    def process_company_no(company_no)
+      number = company_no.to_s
+      # Should be 8 characters, so if it's not, add 0s to the start
+      number = "0#{number}" while number.length < 8
+      number
+    end
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -31,6 +31,7 @@ module WasteExemptionsEngine
 
         # Operator details
         state :business_type_form
+        state :registration_number_form
         state :operator_name_form
 
         # Transitions
@@ -71,7 +72,11 @@ module WasteExemptionsEngine
 
           # Operator details
           transitions from: :business_type_form,
-                      to: :operator_name_form
+                      to: :operator_name_form,
+                      if: :skip_registration_number?
+
+          transitions from: :business_type_form,
+                      to: :registration_number_form
         end
 
         event :back do
@@ -108,6 +113,9 @@ module WasteExemptionsEngine
           # Operator details
           transitions from: :operator_name_form,
                       to: :business_type_form
+
+          transitions from: :registration_number_form,
+                      to: :business_type_form
         end
       end
     end
@@ -129,6 +137,12 @@ module WasteExemptionsEngine
 
     def should_register_in_wales?
       location == "wales"
+    end
+
+    def skip_registration_number?
+      return false if company_no_required?
+
+      true
     end
   end
 end

--- a/app/models/waste_exemptions_engine/enrollment.rb
+++ b/app/models/waste_exemptions_engine/enrollment.rb
@@ -15,5 +15,10 @@ module WasteExemptionsEngine
     validates_presence_of :token, on: :save
 
     self.table_name = "enrollments"
+
+    # Some business types should not have a company_no
+    def company_no_required?
+      %w[limitedCompany limitedLiabilityPartnership].include?(business_type)
+    end
   end
 end

--- a/app/services/waste_exemptions_engine/companies_house_service.rb
+++ b/app/services/waste_exemptions_engine/companies_house_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rest-client"
+
+module WasteExemptionsEngine
+  class CompaniesHouseService
+    def initialize(company_no)
+      @company_no = company_no
+      @url = "#{Rails.configuration.companies_house_host}#{@company_no}"
+      @api_key = Rails.configuration.companies_house_api_key
+    end
+
+    def status
+      Rails.logger.debug "Sending request to Companies House"
+
+      begin
+        response = RestClient::Request.execute(
+          method: :get,
+          url: @url,
+          user: @api_key,
+          password: ""
+        )
+
+        json = JSON.parse(response)
+
+        status_is_allowed?(json["company_status"]) ? :active : :inactive
+      rescue RestClient::ResourceNotFound
+        Rails.logger.debug "Companies House: resource not found"
+        :not_found
+      rescue StandardError => e
+        Airbrake.notify(e) if defined?(Airbrake)
+        Rails.logger.error "Companies House error: " + e.to_s
+        :error
+      end
+    end
+
+    private
+
+    def status_is_allowed?(status)
+      %w[active voluntary-arrangement].include?(status)
+    end
+  end
+end

--- a/app/validators/waste_exemptions_engine/company_no_validator.rb
+++ b/app/validators/waste_exemptions_engine/company_no_validator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class CompanyNoValidator < ActiveModel::EachValidator
+    VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX = Regexp.new(/\A(\d{8,8}$)|([a-zA-Z]{2}\d{6}$)\z/i).freeze
+
+    def validate_each(record, attribute, value)
+      valid_company_no?(record, attribute, value) if company_no_required?(record)
+    end
+
+    private
+
+    def company_no_required?(record)
+      record.enrollment.company_no_required?
+    end
+
+    def valid_company_no?(record, attribute, value)
+      return false unless value_is_present?(record, attribute, value)
+      return false unless format_is_valid?(record, attribute, value)
+
+      validate_with_companies_house(record, attribute, value)
+    end
+
+    def value_is_present?(record, attribute, value)
+      return true if value.present?
+
+      record.errors[attribute] << error_message(record, attribute, "blank")
+      false
+    end
+
+    def format_is_valid?(record, attribute, value)
+      return true if value.match?(VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX)
+
+      record.errors[attribute] << error_message(record, attribute, "invalid_format")
+      false
+    end
+
+    def validate_with_companies_house(record, attribute, value)
+      case CompaniesHouseService.new(value).status
+      when :active
+        true
+      when :inactive
+        record.errors[attribute] << error_message(record, attribute, "inactive")
+      when :not_found
+        record.errors[attribute] << error_message(record, attribute, "not_found")
+      when :error
+        record.errors[attribute] << error_message(record, attribute, "error")
+      end
+    end
+
+    def error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/app/views/waste_exemptions_engine/registration_number_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/registration_number_forms/new.html.erb
@@ -1,0 +1,50 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_registration_number_forms_path(@registration_number_form.token)) %>
+
+<div class="text">
+  <%= form_for(@registration_number_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @registration_number_form) %>
+
+    <h1 class="heading-large"><%= t(".heading.#{@registration_number_form.business_type}") %></h1>
+
+    <% if @registration_number_form.errors[:company_no].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="company_no">
+        <legend class="visuallyhidden">
+          <%= t(".heading.#{@registration_number_form.business_type}") %>
+        </legend>
+
+        <% if @registration_number_form.errors[:company_no].any? %>
+        <span class="error-message"><%= @registration_number_form.errors[:company_no].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :company_no, class: "form-label" do %>
+          <%= t(".company_no_label") %>
+          <span class='form-hint'><%= t(".company_no_hint") %></span>
+        <% end %>
+        <%= f.text_field :company_no, value: @registration_number_form.company_no, class: "form-control" %>
+
+      </fieldset>
+    </div>
+
+    <div class="form-group">
+      <details>
+        <summary>
+          <span class="summary"><%= t(".detail_subheading") %></span>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <p><%= t(".detail.#{@registration_number_form.business_type}") %></p>
+        </div>
+      </details>
+    </div>
+
+    <p><%= t(".explanation.#{@registration_number_form.business_type}") %></p>
+
+    <%= f.hidden_field :token, value: @registration_number_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/forms/operator_name_forms/en.yml
+++ b/config/locales/forms/operator_name_forms/en.yml
@@ -10,7 +10,7 @@ en:
           overseas: What's the name of the business or organisation?
           partnership: What's the name of the partnership?
           soleTrader: Who’s carrying out the waste operation?
-          charity: What's the name of the charity?
+          charity: What's the name of the charity or trust?
         description: This is the name of the operator responsible for the waste operation
         operator_name_label:
           localAuthority: Local authority or public body name
@@ -19,6 +19,7 @@ en:
           overseas: Trading name
           partnership: Partnership trading name
           soleTrader: Full name
+          charity: Charity or trust name
         error_heading: Something is wrong
         next_button: Continue
   activemodel:

--- a/config/locales/forms/registration_number_forms/en.yml
+++ b/config/locales/forms/registration_number_forms/en.yml
@@ -1,0 +1,33 @@
+en:
+  waste_exemptions_engine:
+    registration_number_forms:
+      new:
+        title: Companies House registration number
+        heading:
+          limitedCompany: What's the registration number of the company?
+          limitedLiabilityPartnership: What's the registration number of the limited liability partnership?
+        company_no_label: Registration number
+        company_no_hint: An 8 digit number, or 2 letters followed by a 6 digit number
+        detail_subheading: What's a registration number?
+        detail:
+          limitedCompany: This is issued when the company is registered, and can be found on your Certificate of Incorporation and any paperwork from Companies House.
+          limitedLiabilityPartnership: This is issued when the limited liability partnership is registered, and can be found on your Certificate of Incorporation and any paperwork from Companies House.
+        explanation:
+          limitedCompany: We'll look this number up in the Companies House register to make sure it belongs to an active company.
+          limitedLiabilityPartnership: We'll look this number up in the Companies House register to make sure it belongs to an active limited liability partnership.
+        error_heading: Something is wrong
+        next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/registration_number_form:
+          attributes:
+            company_no:
+              invalid_format: "Enter a valid number - it should have 8 digits, or 2 letters followed by 6 digits. If your number has only 7 digits, enter it with a zero at the start."
+              inactive: "Your company must be registered as an active company"
+              not_found: "Companies House couldn't find a company with this number"
+              error: "There was an error with Companies House"
+              blank: "Enter a company registration number"
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,16 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :registration_number_forms,
+            only: [:new, :create],
+            path: "registration-number",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "registration_number_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   resources :operator_name_forms,
             only: [:new, :create],
             path: "operator-name",

--- a/db/migrate/20181217183917_add_company_no_to_enrollments.rb
+++ b/db/migrate/20181217183917_add_company_no_to_enrollments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCompanyNoToEnrollments < ActiveRecord::Migration
+  def change
+    add_column :enrollments, :company_no, :string
+  end
+end

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |s|
   s.add_dependency "has_secure_token"
   s.add_dependency "high_voltage", "~> 3.1"
   s.add_dependency "rails", "4.2.11"
+  # Use rest-client for external requests, eg. to Companies House
+  s.add_dependency "rest-client", "~> 2.0"
 
   s.add_dependency "pg", "~> 0.18.4"
 


### PR DESCRIPTION
This change adds the company registration number page. This is only shown to those who select either limited company or LLP as their business type. They are required to enter their companies house registration number.

In the previous version of the service the only validation performed was on the format of the number. It never actually validated the reference against companies house.

The changes here not only bring over the WCR registration number page, but also its companies house validation and lookup service. So going forward the WEX service will also be able to validate that a registration not only exists, but belongs to an active company.