### PR TITLE
Add contact position field

### DIFF
--- a/app/controllers/waste_exemptions_engine/contact_position_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_position_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ContactPositionFormsController < FormsController
+    def new
+      super(ContactPositionForm, "contact_position_form")
+    end
+
+    def create
+      super(ContactPositionForm, "contact_position_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/contact_position_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_position_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ContactPositionForm < BaseForm
+    include CanNavigateFlexibly
+
+    attr_accessor :position
+
+    def initialize(enrollment)
+      super
+      self.position = @enrollment.contact_position
+    end
+
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      self.position = params[:position]
+      attributes = { contact_position: position }
+
+      super(attributes, params[:token])
+    end
+
+    validates :position, "waste_exemptions_engine/position": true
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
+  # We believe in the case of the different states and transitions for the
+  # exemption journey, its better to see them all in one place. However this
+  # does mean the module length breaks rubocops rules hence the exception.
+  # rubocop:disable Metrics/ModuleLength
   module CanChangeWorkflowStatus
     extend ActiveSupport::Concern
 
     # We believe in the case of the different states and transitions for the
     # exemption journey, its better to see them all in one place. However this
-    # does mean the block legnth breaks rubocops rules hence the exception.
+    # does mean the block length breaks rubocops rules hence the exception.
     # rubocop:disable Metrics/BlockLength
     included do
       include AASM
@@ -36,6 +40,7 @@ module WasteExemptionsEngine
 
         # Contact details
         state :contact_name_form
+        state :contact_position_form
 
         # Transitions
         event :next do
@@ -86,6 +91,9 @@ module WasteExemptionsEngine
 
           transitions from: :operator_name_form,
                       to: :contact_name_form
+
+          transitions from: :contact_name_form,
+                      to: :contact_position_form
         end
 
         event :back do
@@ -130,8 +138,12 @@ module WasteExemptionsEngine
           transitions from: :operator_name_form,
                       to: :registration_number_form
 
+          # Contact details
           transitions from: :contact_name_form,
                       to: :operator_name_form
+
+          transitions from: :contact_position_form,
+                      to: :contact_name_form
         end
       end
     end
@@ -161,4 +173,5 @@ module WasteExemptionsEngine
       true
     end
   end
+  # rubocop:enable Metrics/ModuleLength
 end

--- a/app/validators/waste_exemptions_engine/position_validator.rb
+++ b/app/validators/waste_exemptions_engine/position_validator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class PositionValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      # Position is an optional field so its immediately valid if it's blank
+      return true if value.blank?
+
+      value_is_not_too_long?(record, attribute, value)
+      value_has_no_invalid_characters?(record, attribute, value)
+    end
+
+    private
+
+    def value_is_not_too_long?(record, attribute, value)
+      return true if value.length < 71
+
+      record.errors[attribute] << error_message(record, attribute, "too_long")
+      false
+    end
+
+    def value_has_no_invalid_characters?(record, attribute, value)
+      # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
+      return true if value.match?(/\A[-a-z\s,.']+\z/i)
+
+      record.errors[attribute] << error_message(record, attribute, "invalid")
+      false
+    end
+
+    def error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/app/views/waste_exemptions_engine/contact_position_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_position_forms/new.html.erb
@@ -1,0 +1,32 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_contact_position_forms_path(@contact_position_form.token)) %>
+
+<div class="text">
+  <%= form_for(@contact_position_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @contact_position_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <% if @contact_position_form.errors[:position].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="position">
+        <% if @contact_position_form.errors[:position].any? %>
+        <span class="error-message"><%= @contact_position_form.errors[:position].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :position, class: "form-label" do %>
+          <%= t(".position_label") %>
+          <span class='form-hint'><%= t(".position_hint") %></span>
+        <% end %>
+        <%= f.text_field :position, value: @contact_position_form.position, class: "form-control" %>
+      </fieldset>
+    </div>
+
+    <%= f.hidden_field :token, value: @contact_position_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/forms/contact_position_forms/en.yml
+++ b/config/locales/forms/contact_position_forms/en.yml
@@ -1,0 +1,21 @@
+en:
+  waste_exemptions_engine:
+    contact_position_forms:
+      new:
+        title: Contact position
+        heading: What is their position?
+        position_label: Position (optional)
+        position_hint: For example, Manager
+        error_heading: Something is wrong
+        next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/contact_position_form:
+          attributes:
+            position:
+              invalid: "The position must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+              too_long: "The position must have no more than 70 characters"
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,16 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :contact_position_forms,
+            only: [:new, :create],
+            path: "contact-position",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "contact_position_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   # See http://patrickperey.com/railscast-053-handling-exceptions/
   get "(errors)/:id", to: "errors#show", as: "error"
 

--- a/db/migrate/20181217223323_add_contact_position_to_enrollments.rb
+++ b/db/migrate/20181217223323_add_contact_position_to_enrollments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddContactPositionToEnrollments < ActiveRecord::Migration
+  def change
+    add_column :enrollments, :contact_position, :string
+  end
+end


### PR DESCRIPTION
This change follows the existing pattern for adding pages, though there is a slight change in its validator. Position is an optional field in the waste exemptions service and as such we have added a new position validator that permits a blank field.

If its not blank then we validate its not too long and doesn't contain any characters we would not expect in a position.