### PR TITLE
Add is a farm page

### DIFF
--- a/app/controllers/waste_exemptions_engine/is_a_farm_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/is_a_farm_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class IsAFarmFormsController < FormsController
+    def new
+      super(IsAFarmForm, "is_a_farm_form")
+    end
+
+    def create
+      super(IsAFarmForm, "is_a_farm_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/is_a_farm_form.rb
+++ b/app/forms/waste_exemptions_engine/is_a_farm_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class IsAFarmForm < BaseForm
+    include CanNavigateFlexibly
+
+    attr_accessor :is_a_farm
+
+    def initialize(enrollment)
+      super
+      self.is_a_farm = @enrollment.is_a_farm
+    end
+
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      self.is_a_farm = params[:is_a_farm]
+      attributes = { is_a_farm: is_a_farm }
+
+      super(attributes, params[:token])
+    end
+
+    validates :is_a_farm, "waste_exemptions_engine/yes_no": true
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -44,6 +44,9 @@ module WasteExemptionsEngine
         state :contact_phone_form
         state :contact_email_form
 
+        # Farm questions
+        state :is_a_farm_form
+
         # Transitions
         event :next do
           # Start
@@ -102,6 +105,10 @@ module WasteExemptionsEngine
 
           transitions from: :contact_phone_form,
                       to: :contact_email_form
+
+          # Farm questions
+          transitions from: :contact_email_form,
+                      to: :is_a_farm_form
         end
 
         event :back do
@@ -158,6 +165,10 @@ module WasteExemptionsEngine
 
           transitions from: :contact_email_form,
                       to: :contact_phone_form
+
+          # Farm questions
+          transitions from: :is_a_farm_form,
+                      to: :contact_email_form
         end
       end
     end

--- a/app/validators/waste_exemptions_engine/yes_no_validator.rb
+++ b/app/validators/waste_exemptions_engine/yes_no_validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class YesNoValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      valid_values = %w[true false]
+      return true if valid_values.include?(value)
+
+      record.errors[attribute] << error_message(record, attribute, "inclusion")
+      false
+    end
+
+    private
+
+    def error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/app/views/waste_exemptions_engine/is_a_farm_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/is_a_farm_forms/new.html.erb
@@ -1,0 +1,39 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_is_a_farm_forms_path(@is_a_farm_form.token)) %>
+
+<div class="text">
+  <%= form_for(@is_a_farm_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @is_a_farm_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <% if @is_a_farm_form.errors[:is_a_farm].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset class="inline" id="is_a_farm">
+        <legend class="visuallyhidden">
+          <%= t(".heading") %>
+        </legend>
+
+        <% if @is_a_farm_form.errors[:is_a_farm].any? %>
+        <span class="error-message"><%= @is_a_farm_form.errors[:is_a_farm].join(", ") %></span>
+        <% end %>
+
+        <div class="multiple-choice">
+          <%= f.radio_button :is_a_farm, "true" %>
+          <%= f.label :is_a_farm, t(".options.yes"), value: "true" %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :is_a_farm, "false" %>
+          <%= f.label :is_a_farm, t(".options.no"), value: "false" %>
+        </div>
+      </fieldset>
+    </div>
+
+    <%= f.hidden_field :token, value: @is_a_farm_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/forms/is_a_farm_forms/en.yml
+++ b/config/locales/forms/is_a_farm_forms/en.yml
@@ -1,0 +1,21 @@
+en:
+  waste_exemptions_engine:
+    is_a_farm_forms:
+      new:
+        title: Is a farm
+        heading: Will this waste operation take place on a farm?
+        options:
+          "yes": "Yes"
+          "no": "No"
+        error_heading: Something is wrong
+        next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/is_a_farm_form:
+          attributes:
+            is_a_farm:
+              inclusion: "You must answer this question"
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,16 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :is_a_farm_forms,
+            only: [:new, :create],
+            path: "is-a-farm",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "is_a_farm_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   # See http://patrickperey.com/railscast-053-handling-exceptions/
   get "(errors)/:id", to: "errors#show", as: "error"
 

--- a/db/migrate/20181217234231_add_is_a_farm_to_enrollments.rb
+++ b/db/migrate/20181217234231_add_is_a_farm_to_enrollments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIsAFarmToEnrollments < ActiveRecord::Migration
+  def change
+    add_column :enrollments, :is_a_farm, :boolean
+  end
+end


### PR DESCRIPTION
This deviates slightly from the pattern set down in Waste Carriers Renewals in that rather than holding a string value for the answer (either "yes" or "no") we are able to do what we should of done which is hold the result as a boolean. The field permits null and this represents an unanswered result.

Other than that it implements the WCR pattern for a Yes/No page.