### PR TITLE
Adds the operator post code page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       phonelib
       rails (= 4.2.11)
       rest-client (~> 2.0)
+      uk_postcode
       validates_email_format_of
 
 GEM
@@ -205,6 +206,7 @@ GEM
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    uk_postcode (2.1.3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)

--- a/app/controllers/waste_exemptions_engine/operator_postcode_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/operator_postcode_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OperatorPostcodeFormsController < PostcodeFormsController
+    def new
+      super(OperatorPostcodeForm, "operator_postcode_form")
+    end
+
+    def create
+      super(OperatorPostcodeForm, "operator_postcode_form")
+    end
+  end
+end

--- a/app/controllers/waste_exemptions_engine/postcode_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/postcode_forms_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class PostcodeFormsController < FormsController
+    def skip_to_manual_address
+      find_or_initialize_enrollment(params[:token])
+
+      @enrollment.skip_to_manual_address! if form_matches_state?
+      redirect_to_correct_form
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/operator_postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_postcode_form.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OperatorPostcodeForm < PostcodeForm
+    include CanNavigateFlexibly
+
+    attr_accessor :business_type, :operator_postcode
+
+    def initialize(enrollment)
+      super
+
+      self.operator_postcode = @enrollment.interim.operator_postcode
+      # We only use this for the correct microcopy
+      self.business_type = @enrollment.business_type
+    end
+
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method
+      # for updating
+      self.operator_postcode = params[:operator_postcode]
+      format_postcode(operator_postcode)
+      attributes = {}
+
+      # While we won't proceed if the postcode isn't valid, we should always
+      # save it in case it's needed for manual entry
+      @enrollment.interim.update_attributes(operator_postcode: operator_postcode)
+
+      super(attributes, params[:token])
+    end
+
+    validates :operator_postcode, "waste_exemptions_engine/postcode": true
+  end
+end

--- a/app/forms/waste_exemptions_engine/postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/postcode_form.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class PostcodeForm < BaseForm
+    private
+
+    def format_postcode(postcode)
+      return unless postcode.present?
+
+      postcode.upcase!
+      postcode.strip!
+    end
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -37,6 +37,7 @@ module WasteExemptionsEngine
         state :business_type_form
         state :registration_number_form
         state :operator_name_form
+        state :operator_postcode_form
 
         # Contact details
         state :contact_name_form
@@ -96,6 +97,9 @@ module WasteExemptionsEngine
                       to: :operator_name_form
 
           transitions from: :operator_name_form,
+                      to: :operator_postcode_form
+
+          transitions from: :operator_postcode_form,
                       to: :contact_name_form
 
           transitions from: :contact_name_form,
@@ -157,9 +161,12 @@ module WasteExemptionsEngine
           transitions from: :operator_name_form,
                       to: :registration_number_form
 
+          transitions from: :operator_postcode_form,
+                      to: :operator_name_form
+
           # Contact details
           transitions from: :contact_name_form,
-                      to: :operator_name_form
+                      to: :operator_postcode_form
 
           transitions from: :contact_position_form,
                       to: :contact_name_form

--- a/app/models/waste_exemptions_engine/enrollment.rb
+++ b/app/models/waste_exemptions_engine/enrollment.rb
@@ -4,6 +4,13 @@ module WasteExemptionsEngine
   class Enrollment < ActiveRecord::Base
     include CanChangeWorkflowStatus
 
+    self.table_name = "enrollments"
+
+    # We want to create the interim record at the same time as the enrollment
+    # is initialized. With activerecord objects overriding the initializer is
+    # seen as an anti-pattern, so instead we rely on its callbacks.
+    after_create :create_interim
+
     # HasSecureToken provides an easy way to generate unique random tokens for
     # any model in ruby on rails. We use it to uniquely identify an enrollment
     # by something other than it's db ID, or its reference number. We can then
@@ -14,7 +21,7 @@ module WasteExemptionsEngine
     has_secure_token
     validates_presence_of :token, on: :save
 
-    self.table_name = "enrollments"
+    has_one :interim, autosave: true
 
     # Some business types should not have a company_no
     def company_no_required?

--- a/app/models/waste_exemptions_engine/interim.rb
+++ b/app/models/waste_exemptions_engine/interim.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class Interim < ActiveRecord::Base
+    belongs_to :enrollment
+
+    self.table_name = "interims"
+  end
+end

--- a/app/services/waste_exemptions_engine/address_finder_service.rb
+++ b/app/services/waste_exemptions_engine/address_finder_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rest-client"
+
+module WasteExemptionsEngine
+  class AddressFinderService
+    def initialize(postcode)
+      # Strip out non-alphanumeric characters
+      @postcode = postcode.gsub(/[^a-z0-9]/i, "")
+      @url = Rails.configuration.addressbase_url +
+             "/address-service/v1/addresses/postcode?postcode=#{@postcode}&client-id=0&key=client1"
+    end
+
+    def search_by_postcode
+      Rails.logger.debug "Sending request to Address lookup service"
+      begin
+        response = RestClient::Request.execute(method: :get,
+                                               url: @url)
+        JSON.parse(response)
+      rescue JSON::ParserError => e
+        handle_error(e)
+        :error
+      rescue RestClient::BadRequest
+        handle_error(e)
+        :not_found
+      rescue StandardError => e
+        handle_error(e)
+        :error
+      end
+    end
+
+    private
+
+    def handle_error(error)
+      Airbrake.notify(e, url: @url) if defined?(Airbrake)
+      Rails.logger.error "Address Finder error: #{error}"
+    end
+  end
+end

--- a/app/validators/waste_exemptions_engine/postcode_validator.rb
+++ b/app/validators/waste_exemptions_engine/postcode_validator.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "uk_postcode"
+
+module WasteExemptionsEngine
+  class PostcodeValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      return unless value_is_present?(record, attribute, value)
+      return unless value_uses_correct_format?(record, attribute, value)
+
+      postcode_returns_results?(record, attribute, value)
+    end
+
+    private
+
+    def value_is_present?(record, attribute, value)
+      return true if value.present?
+
+      record.errors[attribute] << error_message(record, attribute, "blank")
+      false
+    end
+
+    def value_uses_correct_format?(record, attribute, value)
+      return true if UKPostcode.parse(value).full_valid?
+
+      record.errors[attribute] << error_message(record, attribute, "wrong_format")
+      false
+    end
+
+    def postcode_returns_results?(record, attribute, value)
+      address_finder = AddressFinderService.new(value)
+      case address_finder.search_by_postcode
+      when :not_found
+        record.errors[attribute] << error_message(record, attribute, "no_results")
+        false
+      when :error
+        record.enrollment.interim.address_finder_error = true
+        true
+      else
+        record.enrollment.interim.address_finder_error = false
+        true
+      end
+    end
+
+    def error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
@@ -1,0 +1,45 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_operator_postcode_forms_path(@operator_postcode_form.token)) %>
+
+<div class="text">
+  <%= form_for(@operator_postcode_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @operator_postcode_form) %>
+
+    <h1 class="heading-large"><%= t(".heading.#{@operator_postcode_form.business_type}") %></h1>
+
+    <% if @operator_postcode_form.errors[:operator_postcode].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="operator_postcode">
+        <legend class="visuallyhidden">
+          <%= t(".heading.#{@operator_postcode_form.business_type}") %>
+        </legend>
+
+        <% if @operator_postcode_form.errors[:operator_postcode].any? %>
+        <span class="error-message"><%= @operator_postcode_form.errors[:operator_postcode].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :operator_postcode, class: "form-label" do %>
+          <%= t(".operator_postcode_label") %>
+          <span class='form-hint'><%= t(".operator_postcode_hint") %></span>
+        <% end %>
+        <%= f.text_field :operator_postcode, value: @operator_postcode_form.operator_postcode, class: "form-control" %>
+
+      </fieldset>
+    </div>
+
+    <%= f.hidden_field :token, value: @operator_postcode_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+
+    <% if @operator_postcode_form.errors.added?(:operator_postcode, :no_results) %>
+    <div class="form-group">
+      <%= link_to(t(".manual_address_link"), skip_to_manual_address_operator_postcode_forms_path(@operator_postcode_form.token)) %>
+    </div>
+    <% end %>
+  <% end %>
+
+  <%= render("waste_exemptions_engine/shared/os_terms_footer") %>
+</div>

--- a/app/views/waste_exemptions_engine/shared/_os_terms_footer.html.erb
+++ b/app/views/waste_exemptions_engine/shared/_os_terms_footer.html.erb
@@ -1,0 +1,4 @@
+<hr>
+<p class="font-xsmall">
+  <%= t(".text") %> <%= link_to(t(".link_text"), page_path("os-terms"), target: "_blank") %>.
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,9 @@ en:
         back_link: Back
       errors:
         heading: A problem to fix
+      os_terms_footer:
+        text: © Crown copyright and database rights 2018 Ordnance Survey 100024198. Use of this addressing data is subject to the
+        link_text: address data terms and conditions (opens new tab)
 
   # Custom error pages
   invalid_id_title: Invalid ID

--- a/config/locales/forms/operator_postcode_forms/en.yml
+++ b/config/locales/forms/operator_postcode_forms/en.yml
@@ -1,0 +1,29 @@
+en:
+  waste_exemptions_engine:
+    operator_postcode_forms:
+      new:
+        title: Business address postcode
+        heading:
+          localAuthority: What's the address of the local authority or public body?
+          limitedCompany: What's the company address?
+          limitedLiabilityPartnership: What's the address of the limited liability partnership?
+          partnership: What's the address of the partnership?
+          soleTrader: What's the address of the business?
+          charity: What's the address of the charity or trust?
+        operator_postcode_label: Please enter a UK postcode
+        operator_postcode_hint: For example, BS1 5AH
+        error_heading: A problem to fix
+        next_button: Find address
+        manual_address_link: "Enter address manually"
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/operator_postcode_form:
+          attributes:
+            operator_postcode:
+              blank: "Enter a postcode"
+              wrong_format: "Enter a valid UK postcode"
+              no_results: "We cannot find any addresses for that postcode. Check the postcode or enter the address manually."
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,21 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :operator_postcode_forms,
+            only: [:new, :create],
+            path: "operator-postcode",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "operator_postcode_forms#go_back",
+              as: "back",
+              on: :collection
+
+              get "skip_to_manual_address/:token",
+              to: "operator_postcode_forms#skip_to_manual_address",
+              as: "skip_to_manual_address",
+              on: :collection
+            end
+
   resources :contact_name_forms,
             only: [:new, :create],
             path: "contact-name",

--- a/db/migrate/20181218182531_create_interims.rb
+++ b/db/migrate/20181218182531_create_interims.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateInterims < ActiveRecord::Migration
+  def change
+    create_table :interims do |t|
+      t.string :operator_postcode
+      t.boolean :address_finder_error, default: false
+      t.belongs_to :enrollment, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |s|
   # Validations
   # Use to ensure phone numbers are in a valid and recognised format
   s.add_dependency "phonelib"
+  # UK postcode parsing and validation for Ruby
+  s.add_dependency "uk_postcode"
   # Use to validate e-mail addresses against RFC 2822 and RFC 3696
   s.add_dependency "validates_email_format_of"
 


### PR DESCRIPTION
This is the first page in the process of adding an address for the operator, but also setups up a few other things to support this.

**New interim object**

The old version of the WEX service essentially returned you to the same page, though now with a populated lookup list of addresses found. This meant it didn't need to retain the postcode within the db as part of the round trip. However it also meant a very complex implementation, and not our best user experience.

WCR where we are copying the code from has the latest version of looking up an address, which splits the postcode lookup, result selection and manual address entry into completely separate pages. However it relies on there being a temporary postcode field on the underlying object. This is fine in WCR because when a transient registration is renewed, these temporary fields get dropped and the transient record deleted.

In WEX we are not creating a transient object during the registration, so don't really want these temporary fields polluting our main object and database table. Hence as part of this change we have created a new `Interim` object which will be used for holding any interim/temporary fields or data used as part of the registration process.

This change incorporates this new object into the postcode lookup and validation process.

**New address lookup service**

The WEX service uses the addressbase facade service and not the [OS Place address lookup](https://github.com/DEFRA/os-places-address-lookup) used by WCR. So we have also had to make changes to the WCR address finder service copied from WCR to account for the change in how the API works.