### PR TITLE
Add operator address lookup selection page

### DIFF
--- a/app/controllers/waste_exemptions_engine/address_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/address_forms_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class AddressFormsController < FormsController
+    def skip_to_manual_address
+      find_or_initialize_enrollment(params[:token])
+
+      @enrollment.skip_to_manual_address! if form_matches_state?
+      redirect_to_correct_form
+    end
+  end
+end

--- a/app/controllers/waste_exemptions_engine/operator_address_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/operator_address_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OperatorAddressFormsController < AddressFormsController
+    def new
+      super(OperatorAddressForm, "operator_address_form")
+    end
+
+    def create
+      super(OperatorAddressForm, "operator_address_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/address_form.rb
+++ b/app/forms/waste_exemptions_engine/address_form.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class AddressForm < BaseForm
+    attr_accessor :temp_addresses
+    attr_accessor :temp_address
+    attr_accessor :addresses
+
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      self.addresses = add_or_replace_address(params[:temp_address])
+      attributes = { addresses: addresses }
+
+      super(attributes, params[:token])
+    end
+
+    validates :addresses, presence: true
+
+    private
+
+    # Look up addresses based on the temp_postcode
+    def look_up_addresses
+      if temp_postcode.present?
+        address_finder = AddressFinderService.new(temp_postcode)
+        self.temp_addresses = address_finder.search_by_postcode
+      else
+        self.temp_addresses = []
+      end
+    end
+
+    # If an address has already been assigned to the enrollment, pre-select it
+    def preselect_existing_address
+      return unless can_preselect_address?
+
+      selected_address = temp_addresses.detect { |address| address["uprn"].to_s == saved_address.uprn }
+      self.temp_address = selected_address["uprn"] if selected_address.present?
+    end
+
+    def can_preselect_address?
+      return false unless saved_address
+      return false unless saved_address.uprn.present?
+
+      true
+    end
+
+    def add_or_replace_address(selected_address_uprn)
+      return if selected_address_uprn.blank?
+
+      data = temp_addresses.detect { |address| address["uprn"] == selected_address_uprn.to_i }
+      address = Address.create_from_address_finder_data(data)
+      address.assign_attributes(address_type: address_type)
+
+      # Update the enrollment's nested addresses, replacing any existing address of the same type
+      updated_addresses = @enrollment.addresses
+      updated_addresses.delete(saved_address) if saved_address
+      updated_addresses << address
+      updated_addresses
+    end
+
+    # Methods which are called in this class but defined in subclasses
+    # We should throw descriptive errors in case an additional subclass of ManualAddressForm is ever added
+
+    def temp_postcode
+      implemented_in_subclass
+    end
+
+    def saved_address
+      implemented_in_subclass
+    end
+
+    def address_type
+      implemented_in_subclass
+    end
+
+    def implemented_in_subclass
+      raise NotImplementedError, "This #{self.class} cannot respond to:"
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/operator_address_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_form.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OperatorAddressForm < AddressForm
+    include CanNavigateFlexibly
+
+    attr_accessor :business_type
+    attr_accessor :operator_postcode
+
+    def initialize(enrollment)
+      super
+      # We only use this for the correct microcopy
+      self.business_type = @enrollment.business_type
+      self.operator_postcode = @enrollment.interim.operator_postcode
+
+      look_up_addresses
+      preselect_existing_address
+    end
+
+    private
+
+    def temp_postcode
+      operator_postcode
+    end
+
+    def saved_address
+      @enrollment.operator_address
+    end
+
+    def address_type
+      Address.address_types[:operator]
+    end
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -38,6 +38,7 @@ module WasteExemptionsEngine
         state :registration_number_form
         state :operator_name_form
         state :operator_postcode_form
+        state :operator_address_form
 
         # Contact details
         state :contact_name_form
@@ -100,6 +101,9 @@ module WasteExemptionsEngine
                       to: :operator_postcode_form
 
           transitions from: :operator_postcode_form,
+                      to: :operator_address_form
+
+          transitions from: :operator_address_form,
                       to: :contact_name_form
 
           transitions from: :contact_name_form,
@@ -164,9 +168,12 @@ module WasteExemptionsEngine
           transitions from: :operator_postcode_form,
                       to: :operator_name_form
 
+          transitions from: :operator_address_form,
+                      to: :operator_postcode_form
+
           # Contact details
           transitions from: :contact_name_form,
-                      to: :operator_postcode_form
+                      to: :operator_address_form
 
           transitions from: :contact_position_form,
                       to: :contact_name_form

--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class Address < ActiveRecord::Base
+    belongs_to :enrollment
+
+    self.table_name = "addresses"
+
+    enum address_type: { unknown: 0, operator: 1 }
+
+    def self.create_from_address_finder_data(data)
+      data = data.except("address").except("state_date")
+      data["uprn"] = data["uprn"].to_s
+      data["x"] = data["x"].to_f
+      data["y"] = data["y"].to_f
+
+      Address.create(data)
+    end
+  end
+end

--- a/app/models/waste_exemptions_engine/enrollment.rb
+++ b/app/models/waste_exemptions_engine/enrollment.rb
@@ -22,10 +22,17 @@ module WasteExemptionsEngine
     validates_presence_of :token, on: :save
 
     has_one :interim, autosave: true
+    has_many :addresses
 
     # Some business types should not have a company_no
     def company_no_required?
       %w[limitedCompany limitedLiabilityPartnership].include?(business_type)
+    end
+
+    def operator_address
+      return nil unless addresses.present?
+
+      addresses.where(address_type: Address.address_types[:operator]).first
     end
   end
 end

--- a/app/services/waste_exemptions_engine/address_finder_service.rb
+++ b/app/services/waste_exemptions_engine/address_finder_service.rb
@@ -16,7 +16,7 @@ module WasteExemptionsEngine
       begin
         response = RestClient::Request.execute(method: :get,
                                                url: @url)
-        JSON.parse(response)
+        JSON.parse(response)["results"]
       rescue JSON::ParserError => e
         handle_error(e)
         :error

--- a/app/validators/waste_exemptions_engine/address_validator.rb
+++ b/app/validators/waste_exemptions_engine/address_validator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class AddressValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      return false unless value_is_present?(record, attribute, value)
+
+      valid_uk_address?(record, attribute, value)
+    end
+
+    private
+
+    def value_is_present?(record, attribute, value)
+      return true if value.present?
+
+      record.errors[attribute] << error_message(record, attribute, "blank")
+      false
+    end
+
+    def valid_uk_address?(record, attribute, value)
+      return true if value.address_mode == "address-results"
+      return true if value.address_mode == "manual-uk"
+
+      record.errors[attribute] << error_message(record, attribute, "should_be_uk")
+      false
+    end
+
+    def error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/app/views/waste_exemptions_engine/operator_address_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_address_forms/new.html.erb
@@ -1,0 +1,28 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_operator_address_forms_path(@operator_address_form.token)) %>
+
+<div class="text">
+  <%= form_for(@operator_address_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @operator_address_form) %>
+
+    <h1 class="heading-large"><%= t(".heading.#{@operator_address_form.business_type}") %></h1>
+
+    <div class="form-group">
+      <label class="form-label"><%= t(".postcode_label") %></label>
+      <span class="postcode"><%= @operator_address_form.operator_postcode %></span>
+      <%= link_to(t(".postcode_change_link"), back_operator_address_forms_path(@operator_address_form.token)) %>
+    </div>
+
+    <%= render("waste_exemptions_engine/shared/select_address", form: @operator_address_form, f: f) %>
+
+    <div class="form-group">
+      <%= link_to(t(".manual_address_link"), skip_to_manual_address_operator_address_forms_path(@operator_address_form.token)) %>
+    </div>
+
+    <%= f.hidden_field :token, value: @operator_address_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+
+  <%= render("waste_exemptions_engine/shared/os_terms_footer") %>
+</div>

--- a/app/views/waste_exemptions_engine/shared/_select_address.html.erb
+++ b/app/views/waste_exemptions_engine/shared/_select_address.html.erb
@@ -1,0 +1,13 @@
+<% if form.errors[:addresses].any? %>
+<div class="form-group form-group-error">
+<% else %>
+<div class="form-group">
+<% end %>
+  <fieldset id="addresses">
+    <%= f.label :temp_address, t(".address_label"), class: "form-label" %>
+    <%= f.select(:temp_address,
+                 options_for_select(form.temp_addresses.map { |a| [a["address"], a["uprn"]] }, form.temp_address),
+                 { include_blank: t(".address_blank_option", count: form.temp_addresses.length ) },
+                 { class: "form-control" }) %>
+  </fieldset>
+</div>

--- a/config/locales/forms/operator_address_forms/en.yml
+++ b/config/locales/forms/operator_address_forms/en.yml
@@ -1,0 +1,27 @@
+en:
+  waste_exemptions_engine:
+    operator_address_forms:
+      new:
+        title: Operator address selection
+        heading:
+          localAuthority: What's the address of the local authority or public body?
+          limitedCompany: What's the company address?
+          limitedLiabilityPartnership: What's the address of the limited liability partnership?
+          partnership: What's the address of the partnership?
+          soleTrader: What's the address of the business?
+          charity: What's the address of the charity or trust?
+        postcode_label: Postcode
+        postcode_change_link: "Change postcode"
+        manual_address_link: "I cannot find the address in the list"
+        error_heading: Something is wrong
+        next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/operator_address_form:
+          attributes:
+            addresses:
+              blank: "You must select an address"
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,21 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :operator_address_forms,
+            only: [:new, :create],
+            path: "operator-address",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "operator_address_forms#go_back",
+              as: "back",
+              on: :collection
+
+              get "skip_to_manual_address/:token",
+              to: "operator_address_forms#skip_to_manual_address",
+              as: "skip_to_manual_address",
+              on: :collection
+            end
+
   resources :contact_name_forms,
             only: [:new, :create],
             path: "contact-name",

--- a/db/migrate/20181219171050_create_addresses.rb
+++ b/db/migrate/20181219171050_create_addresses.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CreateAddresses < ActiveRecord::Migration
+  def change
+    create_table :addresses do |t|
+      t.integer :address_type, default: 0
+      t.string :uprn
+      t.string :organisation
+      t.string :premises
+      t.string :street_address
+      t.string :locality
+      t.string :city
+      t.string :postcode
+      t.float :x
+      t.float :y
+      t.string :coordinate_system
+      t.string :blpu_state_code
+      t.string :postal_address_code
+      t.string :logical_status_code
+      t.string :source_data_type
+      t.string :country_iso
+      t.belongs_to :enrollment, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end


### PR DESCRIPTION
Following on from adding the first postcode lookup page, we can now add the address selection page.

Again we have taken the WCR code as a basis, however we have had to make a number of changes. First, the results we get back are in a slightly different format because we are using the addressbase facade in WEX. Secondly we are dealing with active record associations.

We have also needed to add another model for holding the address, and linked it to enrollment via a has_many association.

Other than that though, the implementation follows a standard model controller, form objects, validation and locales.