### PR TITLE
Add operator manual address entry page

### DIFF
--- a/app/controllers/waste_exemptions_engine/operator_address_manual_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/operator_address_manual_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OperatorAddressManualFormsController < FormsController
+    def new
+      super(OperatorAddressManualForm, "operator_address_manual_form")
+    end
+
+    def create
+      super(OperatorAddressManualForm, "operator_address_manual_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/manual_address_form.rb
+++ b/app/forms/waste_exemptions_engine/manual_address_form.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ManualAddressForm < BaseForm
+    include CanNavigateFlexibly
+
+    attr_accessor :business_type
+    attr_accessor :addresses
+    attr_accessor :address_finder_error
+    # We pass the following attributes in to create a new Address
+    attr_accessor :premises, :street_address, :locality, :city, :postcode
+
+    def initialize(enrollment)
+      super
+      # We use this for the correct microcopy and to determine what fields to show
+      self.business_type = @enrollment.business_type
+
+      # Check if the user reached this page through an Address finder error.
+      # Then wipe the temp attribute as we only need it for routing
+      self.address_finder_error = @enrollment.interim.address_finder_error
+      @enrollment.interim.update_attributes(address_finder_error: nil)
+
+      # Prefill the existing address unless the temp_postcode has changed from the existing address's postcode
+      # Otherwise, just fill in the temp_postcode
+      saved_address_still_valid? ? prefill_existing_address : self.postcode = saved_temp_postcode
+    end
+
+    def submit(params)
+      # Strip out whitespace from start and end
+      params.each { |_key, value| value.strip! }
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      self.premises = params[:premises]
+      self.street_address = params[:street_address]
+      self.locality = params[:locality]
+      self.city = params[:city]
+      self.postcode = params[:postcode]
+      attributes = { addresses: add_or_replace_address(params) }
+
+      super(attributes, params[:token])
+    end
+
+    validates :premises, presence: true, length: { maximum: 200 }
+    validates :street_address, presence: true, length: { maximum: 160 }
+    validates :locality, length: { maximum: 70 }
+    validates :city, presence: true, length: { maximum: 30 }
+    validates :postcode, length: { maximum: 8 }
+
+    private
+
+    def saved_address_still_valid?
+      return false unless existing_address
+      return true if saved_temp_postcode.blank?
+      return true if saved_temp_postcode == existing_address.postcode
+
+      false
+    end
+
+    def prefill_existing_address
+      return unless existing_address
+
+      self.premises = existing_address.premises
+      self.street_address = existing_address.street_address
+      self.locality = existing_address.locality
+      self.city = existing_address.city
+      self.postcode = existing_address.postcode
+    end
+
+    def add_or_replace_address(params)
+      address = Address.create_from_manual_entry_data(
+        sanitize_params(params),
+        address_type
+      )
+
+      # Update the enrollment's nested addresses, replacing any existing operator address
+      updated_addresses = @enrollment.addresses
+      updated_addresses.delete(existing_address) if existing_address
+      updated_addresses << address
+      updated_addresses
+    end
+
+    # Now that we are dealing with Activerecord it has protections in place to
+    # stop us mass assigning attributes on a model that come direct from the
+    # params object. In a typical rails project you would have a method in your
+    # controller in which you would call
+    # params.require(:my_model).permit!(:email, :amount, :paid). This does also
+    # work with form objects (just replace my_model for my_form) however it
+    # assumes we are passing the data to the object via calling the method e.g.
+    # @my_form = MyForm.new(sanitize_params)
+    # For the following reasons we have chosen instead to create our own santize
+    # method rather than follow this pattern
+    #   - the complexity of the form->sub-form->base-form relationship we have
+    #     in this instance
+    #   - attempting to follow the pattern could lead to a refactor of the
+    #     underlying base form objects and controllers
+    #   - that manual address is the only instance we have of mass assigning
+    #     params to a model
+    def sanitize_params(params)
+      {
+        premises: params["premises"],
+        street_address: params["street_address"],
+        locality: params["locality"],
+        city: params["city"],
+        postcode: params["postcode"]
+      }
+    end
+
+    # Methods which are called in this class but defined in subclasses
+    # We should throw descriptive errors in case an additional subclass of ManualAddressForm is ever added
+
+    def saved_temp_postcode
+      implemented_in_subclass
+    end
+
+    def existing_address
+      implemented_in_subclass
+    end
+
+    def address_type
+      implemented_in_subclass
+    end
+
+    def implemented_in_subclass
+      raise NotImplementedError, "This #{self.class} cannot respond to:"
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OperatorAddressManualForm < ManualAddressForm
+    include CanNavigateFlexibly
+
+    private
+
+    def saved_temp_postcode
+      @enrollment.interim.operator_postcode
+    end
+
+    def existing_address
+      @enrollment.operator_address
+    end
+
+    def address_type
+      Address.address_types[:operator]
+    end
+  end
+end

--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -7,12 +7,21 @@ module WasteExemptionsEngine
     self.table_name = "addresses"
 
     enum address_type: { unknown: 0, operator: 1 }
+    enum mode: { unknown_mode: 0, lookup: 1, manual: 2 }
 
     def self.create_from_address_finder_data(data)
       data = data.except("address").except("state_date")
       data["uprn"] = data["uprn"].to_s
       data["x"] = data["x"].to_f
       data["y"] = data["y"].to_f
+      data["mode"] = Address.modes[:lookup]
+
+      Address.create(data)
+    end
+
+    def self.create_from_manual_entry_data(data, address_type)
+      data["address_type"] = address_type
+      data["mode"] = Address.modes[:manual]
 
       Address.create(data)
     end

--- a/app/services/waste_exemptions_engine/address_finder_service.rb
+++ b/app/services/waste_exemptions_engine/address_finder_service.rb
@@ -32,7 +32,7 @@ module WasteExemptionsEngine
     private
 
     def handle_error(error)
-      Airbrake.notify(e, url: @url) if defined?(Airbrake)
+      Airbrake.notify(error, url: @url) if defined?(Airbrake)
       Rails.logger.error "Address Finder error: #{error}"
     end
   end

--- a/app/views/waste_exemptions_engine/operator_address_manual_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_address_manual_forms/new.html.erb
@@ -1,0 +1,23 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_operator_address_manual_forms_path(@operator_address_manual_form.token)) %>
+
+<div class="text">
+  <%= form_for(@operator_address_manual_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @operator_address_manual_form) %>
+
+    <% if @operator_address_manual_form.address_finder_error %>
+    <div class="error-summary" role="alert">
+      <h2 class="heading-medium error-summary-heading"><%= t(".address_finder_error_heading") %></h2>
+      <p><%= t(".address_finder_error_text") %></p>
+    </div>
+    <% end %>
+
+    <h1 class="heading-large"><%= t(".heading.#{@operator_address_manual_form.business_type}") %></h1>
+
+    <%= render("waste_exemptions_engine/shared/manual_address", form: @operator_address_manual_form, f: f) %>
+
+    <%= f.hidden_field :token, value: @operator_address_manual_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/waste_exemptions_engine/shared/_manual_address.html.erb
+++ b/app/views/waste_exemptions_engine/shared/_manual_address.html.erb
@@ -1,0 +1,70 @@
+<div class="form-group">
+  <label class="form-label"><%= t(".preset_postcode_label") %></label>
+  <span class="postcode"><%= form.postcode %></span>
+  <%= link_to(t(".postcode_change_link"), back_operator_address_manual_forms_path(form.token)) %>
+</div>
+
+<% if form.errors[:premises].any? %>
+<div class="form-group form-group-error">
+<% else %>
+<div class="form-group">
+<% end %>
+  <fieldset id="premises">
+    <% if form.errors[:premises].any? %>
+    <span class="error-message"><%= form.errors[:premises].join(", ") %></span>
+    <% end %>
+
+    <%= f.label :premises, class: "form-label" do %>
+      <%= t(".premises_label") %>
+      <span class='form-hint'><%= t(".premises_hint") %></span>
+    <% end %>
+    <%= f.text_field :premises, value: form.premises, class: "form-control" %>
+  </fieldset>
+</div>
+
+<% if form.errors[:street_address].any? %>
+<div class="form-group form-group-error">
+<% else %>
+<div class="form-group">
+<% end %>
+  <fieldset id="street_address">
+    <% if form.errors[:street_address].any? %>
+    <span class="error-message"><%= form.errors[:street_address].join(", ") %></span>
+    <% end %>
+
+    <%= f.label :street_address, t(".street_address_label"), class: "form-label" %>
+    <%= f.text_field :street_address, value: form.street_address, class: "form-control" %>
+  </fieldset>
+</div>
+
+<% if form.errors[:locality].any? %>
+<div class="form-group form-group-error">
+<% else %>
+<div class="form-group">
+<% end %>
+  <fieldset id="locality">
+    <% if form.errors[:locality].any? %>
+    <span class="error-message"><%= form.errors[:locality].join(", ") %></span>
+    <% end %>
+
+    <%= f.label :locality, t(".locality_label"), class: "form-label" %>
+    <%= f.text_field :locality, value: form.locality, class: "form-control" %>
+  </fieldset>
+</div>
+
+<% if form.errors[:city].any? %>
+<div class="form-group form-group-error">
+<% else %>
+<div class="form-group">
+<% end %>
+  <fieldset id="city">
+    <% if form.errors[:city].any? %>
+    <span class="error-message"><%= form.errors[:city].join(", ") %></span>
+    <% end %>
+
+    <%= f.label :city, t(".city_label"), class: "form-label" %>
+    <%= f.text_field :city, value: form.city, class: "form-control" %>
+  </fieldset>
+</div>
+
+<%= f.hidden_field :postcode, value: form.postcode %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,9 +6,24 @@ en:
         back_link: Back
       errors:
         heading: A problem to fix
+      manual_address:
+        premises_label: Building name or number
+        premises_hint: For example, a business premises name or house number
+        street_address_label: Address line 1
+        locality_label: Address line 2 (optional)
+        city_label: Town or city
+        postcode_label: Postcode (optional)
+        preset_postcode_label: Postcode
+        postcode_change_link: "Change postcode"
       os_terms_footer:
         text: © Crown copyright and database rights 2018 Ordnance Survey 100024198. Use of this addressing data is subject to the
         link_text: address data terms and conditions (opens new tab)
+      select_address:
+        address_label: Address
+        address_blank_option:
+          zero: No addresses found
+          one: 1 address found
+          other: "%{count} addresses found"
 
   # Custom error pages
   invalid_id_title: Invalid ID

--- a/config/locales/forms/operator_address_manual_forms/en.yml
+++ b/config/locales/forms/operator_address_manual_forms/en.yml
@@ -1,0 +1,37 @@
+en:
+  waste_exemptions_engine:
+    operator_address_manual_forms:
+      new:
+        title: Operator address
+        heading:
+          localAuthority: What's the address of the local authority or public body?
+          limitedCompany: What's the company address?
+          limitedLiabilityPartnership: What's the address of the limited liability partnership?
+          partnership: What's the address of the partnership?
+          soleTrader: What's the address of the business?
+          charity: What's the address of the charity or trust?
+        address_finder_error_heading: Our address finder is not working
+        address_finder_error_text: Please enter the address below.
+        error_heading: Something is wrong
+        next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/operator_address_manual_form:
+          attributes:
+            premises:
+              blank: "Enter the building name or number"
+              too_long: "The building name or number must be no longer than 200 characters"
+            street_address:
+              blank: "Enter an address line 1"
+              too_long: "The address line 1 must be no longer than 160 characters"
+            locality:
+              too_long: "The address line 2 must be no longer than 70 characters"
+            city:
+              blank: "Enter a town or city"
+              too_long: "The town or city must be no longer than 30 characters"
+            postcode:
+              too_long: "The postcode must be no longer than 8 characters"
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,16 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :operator_address_manual_forms,
+            only: [:new, :create],
+            path: "operator-address-manual",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "operator_address_manual_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   resources :contact_name_forms,
             only: [:new, :create],
             path: "contact-name",

--- a/db/migrate/20181221144235_add_mode_to_addresses.rb
+++ b/db/migrate/20181221144235_add_mode_to_addresses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddModeToAddresses < ActiveRecord::Migration
+  def change
+    add_column :addresses, :mode, :integer, default: 0
+  end
+end


### PR DESCRIPTION
With the operator postcode and address lookup pages sorted, the next step was to bring in the manual address entry page. Like the previous changes this brings in the base classes and additional migrations to support this work, so when we come to add these address pages for other areas the change will be much smaller.

We've also had to make some alterations based on the fact that we are working with a PostgresSql backed model, the most impacted being mass attribute assignment. Rails has built in protections to prevent you from mass assignining attributes based on params the user has entered, so we have had to incorporate this within the changes made.