### PR TITLE
Add contact postcode lookup page

### DIFF
--- a/app/controllers/waste_exemptions_engine/contact_postcode_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_postcode_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ContactPostcodeFormsController < PostcodeFormsController
+    def new
+      super(ContactPostcodeForm, "contact_postcode_form")
+    end
+
+    def create
+      super(ContactPostcodeForm, "contact_postcode_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/contact_postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_postcode_form.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ContactPostcodeForm < PostcodeForm
+    include CanNavigateFlexibly
+
+    attr_accessor :business_type, :contact_postcode
+
+    def initialize(enrollment)
+      super
+
+      self.contact_postcode = @enrollment.interim.contact_postcode
+    end
+
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method
+      # for updating
+      self.contact_postcode = params[:contact_postcode]
+      format_postcode(contact_postcode)
+      attributes = {}
+
+      # While we won't proceed if the postcode isn't valid, we should always
+      # save it in case it's needed for manual entry
+      @enrollment.interim.update_attributes(contact_postcode: contact_postcode)
+
+      super(attributes, params[:token])
+    end
+
+    validates :contact_postcode, "waste_exemptions_engine/postcode": true
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -46,6 +46,7 @@ module WasteExemptionsEngine
         state :contact_position_form
         state :contact_phone_form
         state :contact_email_form
+        state :contact_postcode_form
 
         # Farm questions
         state :is_a_farm_form
@@ -128,8 +129,11 @@ module WasteExemptionsEngine
           transitions from: :contact_phone_form,
                       to: :contact_email_form
 
-          # Farm questions
           transitions from: :contact_email_form,
+                      to: :contact_postcode_form
+
+          # Farm questions
+          transitions from: :contact_postcode_form,
                       to: :is_a_farm_form
 
           transitions from: :is_a_farm_form,
@@ -204,9 +208,12 @@ module WasteExemptionsEngine
           transitions from: :contact_email_form,
                       to: :contact_phone_form
 
+          transitions from: :contact_postcode_form,
+                      to: :contact_email_form
+
           # Farm questions
           transitions from: :is_a_farm_form,
-                      to: :contact_email_form
+                      to: :contact_postcode_form
 
           transitions from: :on_a_farm_form,
                       to: :is_a_farm_form

--- a/app/views/waste_exemptions_engine/contact_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_postcode_forms/new.html.erb
@@ -1,0 +1,45 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_contact_postcode_forms_path(@contact_postcode_form.token)) %>
+
+<div class="text">
+  <%= form_for(@contact_postcode_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @contact_postcode_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <% if @contact_postcode_form.errors[:contact_postcode].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="contact_postcode">
+        <legend class="visuallyhidden">
+          <%= t(".heading") %>
+        </legend>
+
+        <% if @contact_postcode_form.errors[:contact_postcode].any? %>
+        <span class="error-message"><%= @contact_postcode_form.errors[:contact_postcode].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :contact_postcode, class: "form-label" do %>
+          <%= t(".contact_postcode_label") %>
+          <span class='form-hint'><%= t(".contact_postcode_hint") %></span>
+        <% end %>
+        <%= f.text_field :contact_postcode, value: @contact_postcode_form.contact_postcode, class: "form-control" %>
+
+      </fieldset>
+    </div>
+
+    <%= f.hidden_field :token, value: @contact_postcode_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+
+    <% if @contact_postcode_form.errors.added?(:contact_postcode, :no_results) %>
+    <div class="form-group">
+      <%= link_to(t(".manual_address_link"), skip_to_manual_address_contact_postcode_forms_path(@contact_postcode_form.token)) %>
+    </div>
+    <% end %>
+  <% end %>
+
+  <%= render("waste_exemptions_engine/shared/os_terms_footer") %>
+</div>

--- a/config/locales/forms/contact_postcode_forms/en.yml
+++ b/config/locales/forms/contact_postcode_forms/en.yml
@@ -1,0 +1,23 @@
+en:
+  waste_exemptions_engine:
+    contact_postcode_forms:
+      new:
+        title: Contact address postcode
+        heading: What is the contact's address?
+        contact_postcode_label: Please enter a UK postcode
+        contact_postcode_hint: For example, BS1 5AH
+        error_heading: A problem to fix
+        next_button: Find address
+        manual_address_link: "Enter address manually"
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/contact_postcode_form:
+          attributes:
+            contact_postcode:
+              blank: "Enter a postcode"
+              wrong_format: "Enter a valid UK postcode"
+              no_results: "We cannot find any addresses for that postcode. Check the postcode or enter the address manually."
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -197,6 +197,21 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :contact_postcode_forms,
+            only: [:new, :create],
+            path: "contact-postcode",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "contact_postcode_forms#go_back",
+              as: "back",
+              on: :collection
+
+              get "skip_to_manual_address/:token",
+              to: "contact_postcode_forms#skip_to_manual_address",
+              as: "skip_to_manual_address",
+              on: :collection
+            end
+
   resources :is_a_farm_forms,
             only: [:new, :create],
             path: "is-a-farm",

--- a/db/migrate/20181227104112_add_contact_postcode_to_interims.rb
+++ b/db/migrate/20181227104112_add_contact_postcode_to_interims.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddContactPostcodeToInterims < ActiveRecord::Migration
+  def change
+    add_column :interims, :contact_postcode, :string
+  end
+end


### PR DESCRIPTION
Using the pattern we copied from Waste Carriers for looking up the operator address using a postcode, we've used it again the contact address.

The one difference here is that content does not change based on business type, so we have been able to delete those elements from the code for the contact postcode page.