### PR TITLE
Refactor postcode form objects

### DIFF
--- a/app/forms/waste_exemptions_engine/contact_postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_postcode_form.rb
@@ -4,28 +4,10 @@ module WasteExemptionsEngine
   class ContactPostcodeForm < PostcodeForm
     include CanNavigateFlexibly
 
-    attr_accessor :business_type, :contact_postcode
+    private
 
-    def initialize(enrollment)
-      super
-
-      self.contact_postcode = @enrollment.interim.contact_postcode
+    def existing_postcode
+      @enrollment.interim.contact_postcode
     end
-
-    def submit(params)
-      # Assign the params for validation and pass them to the BaseForm method
-      # for updating
-      self.contact_postcode = params[:contact_postcode]
-      format_postcode(contact_postcode)
-      attributes = {}
-
-      # While we won't proceed if the postcode isn't valid, we should always
-      # save it in case it's needed for manual entry
-      @enrollment.interim.update_attributes(contact_postcode: contact_postcode)
-
-      super(attributes, params[:token])
-    end
-
-    validates :contact_postcode, "waste_exemptions_engine/postcode": true
   end
 end

--- a/app/forms/waste_exemptions_engine/operator_postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_postcode_form.rb
@@ -4,30 +4,19 @@ module WasteExemptionsEngine
   class OperatorPostcodeForm < PostcodeForm
     include CanNavigateFlexibly
 
-    attr_accessor :business_type, :operator_postcode
+    attr_accessor :business_type
 
     def initialize(enrollment)
       super
 
-      self.operator_postcode = @enrollment.interim.operator_postcode
       # We only use this for the correct microcopy
       self.business_type = @enrollment.business_type
     end
 
-    def submit(params)
-      # Assign the params for validation and pass them to the BaseForm method
-      # for updating
-      self.operator_postcode = params[:operator_postcode]
-      format_postcode(operator_postcode)
-      attributes = {}
+    private
 
-      # While we won't proceed if the postcode isn't valid, we should always
-      # save it in case it's needed for manual entry
-      @enrollment.interim.update_attributes(operator_postcode: operator_postcode)
-
-      super(attributes, params[:token])
+    def existing_postcode
+      @enrollment.interim.operator_postcode
     end
-
-    validates :operator_postcode, "waste_exemptions_engine/postcode": true
   end
 end

--- a/app/forms/waste_exemptions_engine/postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/postcode_form.rb
@@ -2,13 +2,57 @@
 
 module WasteExemptionsEngine
   class PostcodeForm < BaseForm
+
+    attr_accessor :postcode
+
+    def initialize(enrollment)
+      super
+
+      self.postcode = existing_postcode
+    end
+
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method
+      # for updating
+      self.postcode = params[:postcode]
+      format_postcode
+
+      # While we won't proceed if the postcode isn't valid, we should always
+      # save it in case it's needed for manual entry
+      interim_field = determine_interim_postcode_field_name
+      @enrollment.interim.update_attributes(interim_field => postcode)
+
+      # We pass through an empty hash for the attributes, as there is nothing to
+      # update on the enrollment itself
+      super({}, params[:token])
+    end
+
+    validates :postcode, "waste_exemptions_engine/postcode": true
+
     private
 
-    def format_postcode(postcode)
+    def format_postcode
       return unless postcode.present?
 
       postcode.upcase!
       postcode.strip!
+    end
+
+    # We use this to work out what the field name will be in the interim model.
+    # It relies on the convention of naming the field object_postcde e.g.
+    # contact_postcode, and that the form object will also correspond to this
+    # e.g. ContactPostcodeForm
+    # By doing this we can remove duplication in the postcode form objects
+    # which previously only needed a different submit method in order to specify
+    # the name of the field to update.
+    def determine_interim_postcode_field_name
+      name = self.class.name.demodulize
+      name.sub!("Form", "")
+      name.underscore.to_sym
+    end
+
+    def existing_postcode
+      raise NotImplementedError, "This #{self.class} cannot respond to:"
     end
   end
 end

--- a/app/views/waste_exemptions_engine/contact_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_postcode_forms/new.html.erb
@@ -6,25 +6,25 @@
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
-    <% if @contact_postcode_form.errors[:contact_postcode].any? %>
+    <% if @contact_postcode_form.errors[:postcode].any? %>
     <div class="form-group form-group-error">
     <% else %>
     <div class="form-group">
     <% end %>
-      <fieldset id="contact_postcode">
+      <fieldset id="postcode">
         <legend class="visuallyhidden">
           <%= t(".heading") %>
         </legend>
 
-        <% if @contact_postcode_form.errors[:contact_postcode].any? %>
-        <span class="error-message"><%= @contact_postcode_form.errors[:contact_postcode].join(", ") %></span>
+        <% if @contact_postcode_form.errors[:postcode].any? %>
+        <span class="error-message"><%= @contact_postcode_form.errors[:postcode].join(", ") %></span>
         <% end %>
 
-        <%= f.label :contact_postcode, class: "form-label" do %>
-          <%= t(".contact_postcode_label") %>
-          <span class='form-hint'><%= t(".contact_postcode_hint") %></span>
+        <%= f.label :postcode, class: "form-label" do %>
+          <%= t(".postcode_label") %>
+          <span class='form-hint'><%= t(".postcode_hint") %></span>
         <% end %>
-        <%= f.text_field :contact_postcode, value: @contact_postcode_form.contact_postcode, class: "form-control" %>
+        <%= f.text_field :postcode, value: @contact_postcode_form.postcode, class: "form-control" %>
 
       </fieldset>
     </div>
@@ -34,7 +34,7 @@
       <%= f.submit t(".next_button"), class: "button" %>
     </div>
 
-    <% if @contact_postcode_form.errors.added?(:contact_postcode, :no_results) %>
+    <% if @contact_postcode_form.errors.added?(:postcode, :no_results) %>
     <div class="form-group">
       <%= link_to(t(".manual_address_link"), skip_to_manual_address_contact_postcode_forms_path(@contact_postcode_form.token)) %>
     </div>

--- a/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
@@ -6,25 +6,25 @@
 
     <h1 class="heading-large"><%= t(".heading.#{@operator_postcode_form.business_type}") %></h1>
 
-    <% if @operator_postcode_form.errors[:operator_postcode].any? %>
+    <% if @operator_postcode_form.errors[:postcode].any? %>
     <div class="form-group form-group-error">
     <% else %>
     <div class="form-group">
     <% end %>
-      <fieldset id="operator_postcode">
+      <fieldset id="postcode">
         <legend class="visuallyhidden">
           <%= t(".heading.#{@operator_postcode_form.business_type}") %>
         </legend>
 
-        <% if @operator_postcode_form.errors[:operator_postcode].any? %>
-        <span class="error-message"><%= @operator_postcode_form.errors[:operator_postcode].join(", ") %></span>
+        <% if @operator_postcode_form.errors[:postcode].any? %>
+        <span class="error-message"><%= @operator_postcode_form.errors[:postcode].join(", ") %></span>
         <% end %>
 
-        <%= f.label :operator_postcode, class: "form-label" do %>
-          <%= t(".operator_postcode_label") %>
-          <span class='form-hint'><%= t(".operator_postcode_hint") %></span>
+        <%= f.label :postcode, class: "form-label" do %>
+          <%= t(".postcode_label") %>
+          <span class='form-hint'><%= t(".postcode_hint") %></span>
         <% end %>
-        <%= f.text_field :operator_postcode, value: @operator_postcode_form.operator_postcode, class: "form-control" %>
+        <%= f.text_field :postcode, value: @operator_postcode_form.postcode, class: "form-control" %>
 
       </fieldset>
     </div>
@@ -34,7 +34,7 @@
       <%= f.submit t(".next_button"), class: "button" %>
     </div>
 
-    <% if @operator_postcode_form.errors.added?(:operator_postcode, :no_results) %>
+    <% if @operator_postcode_form.errors.added?(:postcode, :no_results) %>
     <div class="form-group">
       <%= link_to(t(".manual_address_link"), skip_to_manual_address_operator_postcode_forms_path(@operator_postcode_form.token)) %>
     </div>

--- a/config/locales/forms/contact_postcode_forms/en.yml
+++ b/config/locales/forms/contact_postcode_forms/en.yml
@@ -4,8 +4,8 @@ en:
       new:
         title: Contact address postcode
         heading: What is the contact's address?
-        contact_postcode_label: Please enter a UK postcode
-        contact_postcode_hint: For example, BS1 5AH
+        postcode_label: Please enter a UK postcode
+        postcode_hint: For example, BS1 5AH
         error_heading: A problem to fix
         next_button: Find address
         manual_address_link: "Enter address manually"
@@ -14,7 +14,7 @@ en:
       models:
         waste_exemptions_engine/contact_postcode_form:
           attributes:
-            contact_postcode:
+            postcode:
               blank: "Enter a postcode"
               wrong_format: "Enter a valid UK postcode"
               no_results: "We cannot find any addresses for that postcode. Check the postcode or enter the address manually."

--- a/config/locales/forms/operator_postcode_forms/en.yml
+++ b/config/locales/forms/operator_postcode_forms/en.yml
@@ -10,8 +10,8 @@ en:
           partnership: What's the address of the partnership?
           soleTrader: What's the address of the business?
           charity: What's the address of the charity or trust?
-        operator_postcode_label: Please enter a UK postcode
-        operator_postcode_hint: For example, BS1 5AH
+        postcode_label: Please enter a UK postcode
+        postcode_hint: For example, BS1 5AH
         error_heading: A problem to fix
         next_button: Find address
         manual_address_link: "Enter address manually"
@@ -20,7 +20,7 @@ en:
       models:
         waste_exemptions_engine/operator_postcode_form:
           attributes:
-            operator_postcode:
+            postcode:
               blank: "Enter a postcode"
               wrong_format: "Enter a valid UK postcode"
               no_results: "We cannot find any addresses for that postcode. Check the postcode or enter the address manually."


### PR DESCRIPTION
Having implemented another postcode page for the contact, we identified there was some duplication we could remove by pushing logic into the base PostcodeForm that both the contact and operator form objects inherited.