### PR TITLE
Add contact address lookup page

### DIFF
--- a/app/controllers/waste_exemptions_engine/contact_address_lookup_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_address_lookup_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ContactAddressLookupFormsController < AddressLookupFormsController
+    def new
+      super(ContactAddressLookupForm, "contact_address_lookup_form")
+    end
+
+    def create
+      super(ContactAddressLookupForm, "contact_address_lookup_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/contact_address_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_address_form.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module ContactAddressForm
+
+    private
+
+    def existing_postcode
+      @enrollment.interim.contact_postcode
+    end
+
+    def existing_address
+      @enrollment.contact_address
+    end
+
+    def address_type
+      Address.address_types[:contact]
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/contact_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_address_lookup_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ContactAddressLookupForm < AddressLookupForm
+    include ContactAddressForm
+
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -47,6 +47,7 @@ module WasteExemptionsEngine
         state :contact_phone_form
         state :contact_email_form
         state :contact_postcode_form
+        state :contact_address_lookup_form
 
         # Farm questions
         state :is_a_farm_form
@@ -132,8 +133,11 @@ module WasteExemptionsEngine
           transitions from: :contact_email_form,
                       to: :contact_postcode_form
 
-          # Farm questions
           transitions from: :contact_postcode_form,
+                      to: :contact_address_lookup_form
+
+          # Farm questions
+          transitions from: :contact_address_lookup_form,
                       to: :is_a_farm_form
 
           transitions from: :is_a_farm_form,
@@ -211,9 +215,12 @@ module WasteExemptionsEngine
           transitions from: :contact_postcode_form,
                       to: :contact_email_form
 
+          transitions from: :contact_address_lookup_form,
+                      to: :contact_postcode_form
+
           # Farm questions
           transitions from: :is_a_farm_form,
-                      to: :contact_postcode_form
+                      to: :contact_address_lookup_form
 
           transitions from: :on_a_farm_form,
                       to: :is_a_farm_form

--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -6,7 +6,7 @@ module WasteExemptionsEngine
 
     self.table_name = "addresses"
 
-    enum address_type: { unknown: 0, operator: 1 }
+    enum address_type: { unknown: 0, operator: 1, contact: 2 }
     enum mode: { unknown_mode: 0, lookup: 1, manual: 2 }
 
     def self.create_from_address_finder_data(data, address_type)

--- a/app/models/waste_exemptions_engine/enrollment.rb
+++ b/app/models/waste_exemptions_engine/enrollment.rb
@@ -30,9 +30,19 @@ module WasteExemptionsEngine
     end
 
     def operator_address
+      find_address_by_type(Address.address_types[:operator])
+    end
+
+    def contact_address
+      find_address_by_type(Address.address_types[:contact])
+    end
+
+    private
+
+    def find_address_by_type(address_type)
       return nil unless addresses.present?
 
-      addresses.where(address_type: Address.address_types[:operator]).first
+      addresses.where(address_type: address_type).first
     end
   end
 end

--- a/app/views/waste_exemptions_engine/contact_address_lookup_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_address_lookup_forms/new.html.erb
@@ -1,0 +1,28 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_contact_address_lookup_forms_path(@contact_address_lookup_form.token)) %>
+
+<div class="text">
+  <%= form_for(@contact_address_lookup_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @contact_address_lookup_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <div class="form-group">
+      <label class="form-label"><%= t(".postcode_label") %></label>
+      <span class="postcode"><%= @contact_address_lookup_form.postcode %></span>
+      <%= link_to(t(".postcode_change_link"), back_contact_address_lookup_forms_path(@contact_address_lookup_form.token)) %>
+    </div>
+
+    <%= render("waste_exemptions_engine/shared/select_address", form: @contact_address_lookup_form, f: f) %>
+
+    <div class="form-group">
+      <%= link_to(t(".manual_address_link"), skip_to_manual_address_contact_address_lookup_forms_path(@contact_address_lookup_form.token)) %>
+    </div>
+
+    <%= f.hidden_field :token, value: @contact_address_lookup_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+
+  <%= render("waste_exemptions_engine/shared/os_terms_footer") %>
+</div>

--- a/config/locales/forms/contact_address_lookup_forms/en.yml
+++ b/config/locales/forms/contact_address_lookup_forms/en.yml
@@ -1,0 +1,21 @@
+en:
+  waste_exemptions_engine:
+    contact_address_lookup_forms:
+      new:
+        title: Contact address selection
+        heading: What is the contact's address?
+        postcode_label: Postcode
+        postcode_change_link: "Change postcode"
+        manual_address_link: "I cannot find the address in the list"
+        error_heading: Something is wrong
+        next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/contact_address_lookup_forms:
+          attributes:
+            addresses:
+              blank: "You must select an address"
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/locales/forms/contact_postcode_forms/en.yml
+++ b/config/locales/forms/contact_postcode_forms/en.yml
@@ -3,7 +3,7 @@ en:
     contact_postcode_forms:
       new:
         title: Contact address postcode
-        heading: What is the contact's address?
+        heading: What is the postcode for the contact's address?
         postcode_label: Please enter a UK postcode
         postcode_hint: For example, BS1 5AH
         error_heading: A problem to fix

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,6 +212,21 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :contact_address_lookup_forms,
+            only: [:new, :create],
+            path: "contact-address-lookup",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "contact_address_lookup_forms#go_back",
+              as: "back",
+              on: :collection
+
+              get "skip_to_manual_address/:token",
+              to: "contact_address_lookup_forms#skip_to_manual_address",
+              as: "skip_to_manual_address",
+              on: :collection
+            end
+
   resources :is_a_farm_forms,
             only: [:new, :create],
             path: "is-a-farm",


### PR DESCRIPTION
Using the pattern set out for the operator postcode page, this adds the page to handle selecting the contact address.