### PR TITLE
Add contact manual address page

### DIFF
--- a/app/controllers/waste_exemptions_engine/contact_address_manual_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_address_manual_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ContactAddressManualFormsController < FormsController
+    def new
+      super(ContactAddressManualForm, "contact_address_manual_form")
+    end
+
+    def create
+      super(ContactAddressManualForm, "contact_address_manual_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/contact_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_address_manual_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ContactAddressManualForm < AddressManualForm
+    include ContactAddressForm
+
+  end
+end

--- a/app/views/waste_exemptions_engine/contact_address_manual_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_address_manual_forms/new.html.erb
@@ -1,0 +1,29 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_contact_address_manual_forms_path(@contact_address_manual_form.token)) %>
+
+<div class="text">
+  <%= form_for(@contact_address_manual_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @contact_address_manual_form) %>
+
+    <% if @contact_address_manual_form.address_finder_error %>
+    <div class="error-summary" role="alert">
+      <h2 class="heading-medium error-summary-heading"><%= t(".address_finder_error_heading") %></h2>
+      <p><%= t(".address_finder_error_text") %></p>
+    </div>
+    <% end %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <div class="form-group">
+      <label class="form-label"><%= t(".postcode_label") %></label>
+      <span class="postcode"><%= @contact_address_manual_form.postcode %></span>
+      <%= link_to(t(".postcode_change_link"), back_contact_address_manual_forms_path(@contact_address_manual_form.token)) %>
+    </div>
+
+    <%= render("waste_exemptions_engine/shared/manual_address", form: @contact_address_manual_form, f: f) %>
+
+    <%= f.hidden_field :token, value: @contact_address_manual_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/waste_exemptions_engine/operator_address_manual_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_address_manual_forms/new.html.erb
@@ -13,6 +13,12 @@
 
     <h1 class="heading-large"><%= t(".heading.#{@operator_address_manual_form.business_type}") %></h1>
 
+    <div class="form-group">
+      <label class="form-label"><%= t(".postcode_label") %></label>
+      <span class="postcode"><%= @operator_address_manual_form.postcode %></span>
+      <%= link_to(t(".postcode_change_link"), back_operator_address_manual_forms_path(@operator_address_manual_form.token)) %>
+    </div>
+
     <%= render("waste_exemptions_engine/shared/manual_address", form: @operator_address_manual_form, f: f) %>
 
     <%= f.hidden_field :token, value: @operator_address_manual_form.token %>

--- a/app/views/waste_exemptions_engine/shared/_manual_address.html.erb
+++ b/app/views/waste_exemptions_engine/shared/_manual_address.html.erb
@@ -1,9 +1,3 @@
-<div class="form-group">
-  <label class="form-label"><%= t(".preset_postcode_label") %></label>
-  <span class="postcode"><%= form.postcode %></span>
-  <%= link_to(t(".postcode_change_link"), back_operator_address_manual_forms_path(form.token)) %>
-</div>
-
 <% if form.errors[:premises].any? %>
 <div class="form-group form-group-error">
 <% else %>

--- a/config/locales/forms/contact_address_manual_forms/en.yml
+++ b/config/locales/forms/contact_address_manual_forms/en.yml
@@ -1,15 +1,9 @@
 en:
   waste_exemptions_engine:
-    operator_address_manual_forms:
+    contact_address_manual_forms:
       new:
-        title: Operator address
-        heading:
-          localAuthority: What's the address of the local authority or public body?
-          limitedCompany: What's the company address?
-          limitedLiabilityPartnership: What's the address of the limited liability partnership?
-          partnership: What's the address of the partnership?
-          soleTrader: What's the address of the business?
-          charity: What's the address of the charity or trust?
+        title: Contact address
+        heading: What is the contact's address?
         postcode_label: Postcode
         postcode_change_link: "Change postcode"
         address_finder_error_heading: Our address finder is not working
@@ -19,7 +13,7 @@ en:
   activemodel:
     errors:
       models:
-        waste_exemptions_engine/operator_address_manual_form:
+        waste_exemptions_engine/contact_address_manual_form:
           attributes:
             premises:
               blank: "Enter the building name or number"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -227,6 +227,16 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :contact_address_manual_forms,
+            only: [:new, :create],
+            path: "contact-address-manual",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "contact_address_manual_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   resources :is_a_farm_forms,
             only: [:new, :create],
             path: "is-a-farm",


### PR DESCRIPTION
This adds the manual address entry page for the WEX contact copying the pattern for manual operator address.

It also resolves an issue found with having multiple manual address entries in the shared manual address view partial. The shared partial included the link to change the postcode, which needs to be dynamic depending on the address we are working with. However prior to this change we had it set to the operator postcode lookup page.

Following the pattern set in the address lookup views, we simply moved this section out of the shared manual address partial and into the contact and operator views.