### PR TITLE
Add site grid reference page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       aasm (~> 4.12)
       has_secure_token
       high_voltage (~> 3.1)
+      os_map_ref (~> 0.5)
       pg (~> 0.18.4)
       phonelib
       rails (= 4.2.11)
@@ -118,6 +119,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
+    os_map_ref (0.5.0)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)

--- a/app/controllers/waste_exemptions_engine/site_grid_reference_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/site_grid_reference_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class SiteGridReferenceFormsController < FormsController
+    def new
+      super(SiteGridReferenceForm, "site_grid_reference_form")
+    end
+
+    def create
+      super(SiteGridReferenceForm, "site_grid_reference_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/site_grid_reference_form.rb
+++ b/app/forms/waste_exemptions_engine/site_grid_reference_form.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class SiteGridReferenceForm < BaseForm
+    include CanNavigateFlexibly
+
+    attr_accessor :grid_reference, :description
+
+    def initialize(enrollment)
+      super
+      self.grid_reference = @enrollment.interim.grid_reference
+      self.description = @enrollment.interim.site_description
+    end
+
+    def submit(params)
+      assign_params(params)
+
+      @enrollment.interim.update_attributes(
+        grid_reference: grid_reference,
+        site_description: description
+      )
+
+      new_address = create_address
+      attributes = {
+        addresses: add_or_replace_address(
+          new_address,
+          @enrollment.addresses
+        )
+      }
+
+      super(attributes, params[:token])
+    end
+
+    validates :grid_reference, "waste_exemptions_engine/grid_reference": true
+    validates :description, "waste_exemptions_engine/site_description": true
+
+    private
+
+    def assign_params(params)
+      # Strip out whitespace from start and end
+      params.each { |_key, value| value.strip! }
+
+      self.grid_reference = params[:grid_reference]&.upcase
+      self.description = params[:description]
+    end
+
+    def existing_address
+      @enrollment.site_address
+    end
+
+    def create_address
+      return nil if grid_reference.blank?
+
+      Address.create_from_grid_reference_data(
+        { "grid_reference": grid_reference, "description": description },
+        Address.address_types[:site]
+      )
+    end
+
+    def add_or_replace_address(address, existing_addresses)
+      return existing_addresses unless address
+
+      # Update the enrollment's nested addresses, replacing any existing address
+      # of the same type
+      updated_addresses = existing_addresses
+      matched_address = updated_addresses.find(existing_address.id) if existing_address
+
+      if matched_address
+        updated_addresses.delete(matched_address)
+        matched_address.delete
+      end
+
+      updated_addresses << address
+
+      updated_addresses
+    end
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -54,6 +54,9 @@ module WasteExemptionsEngine
         state :is_a_farm_form
         state :on_a_farm_form
 
+        # Site questions
+        state :site_grid_reference_form
+
         # Transitions
         event :next do
           # Start
@@ -154,6 +157,10 @@ module WasteExemptionsEngine
           # Farm questions
           transitions from: :is_a_farm_form,
                       to: :on_a_farm_form
+
+          # Site questions
+          transitions from: :on_a_farm_form,
+                      to: :site_grid_reference_form
         end
 
         event :back do
@@ -243,6 +250,10 @@ module WasteExemptionsEngine
 
           transitions from: :on_a_farm_form,
                       to: :is_a_farm_form
+
+          # Site questions
+          transitions from: :site_grid_reference_form,
+                      to: :on_a_farm_form
         end
 
         event :skip_to_manual_address do

--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -1,31 +1,55 @@
 # frozen_string_literal: true
 
+require "os_map_ref"
+
 module WasteExemptionsEngine
   class Address < ActiveRecord::Base
     belongs_to :enrollment
 
     self.table_name = "addresses"
 
-    enum address_type: { unknown: 0, operator: 1, contact: 2 }
-    enum mode: { unknown_mode: 0, lookup: 1, manual: 2 }
+    enum address_type: { unknown: 0, operator: 1, contact: 2, site: 3 }
+    enum mode: { unknown_mode: 0, lookup: 1, manual: 2, auto: 3 }
 
     def self.create_from_address_finder_data(data, address_type)
-      data["address_type"] = address_type
-      data["mode"] = Address.modes[:lookup]
-
       data = data.except("address").except("state_date")
       data["uprn"] = data["uprn"].to_s
       data["x"] = data["x"].to_f
       data["y"] = data["y"].to_f
 
-      Address.create(data)
+      create_address(data, address_type, Address.modes[:lookup])
     end
 
     def self.create_from_manual_entry_data(data, address_type)
+      create_address(data, address_type, Address.modes[:manual])
+    end
+
+    def self.create_from_grid_reference_data(data, address_type)
+      data = update_xy_from_grid_reference(data)
+
+      create_address(data, address_type, Address.modes[:auto])
+    end
+
+    private_class_method def self.create_address(data, address_type, mode)
       data["address_type"] = address_type
-      data["mode"] = Address.modes[:manual]
+      data["mode"] = mode
 
       Address.create(data)
+    end
+
+    private_class_method def self.update_xy_from_grid_reference(data)
+      return nil unless data
+
+      begin
+        location = OsMapRef::Location.for(data[:grid_reference])
+        data["x"] = location.easting.to_f
+        data["y"] = location.northing.to_f
+      rescue OsMapRef::Error
+        data["x"] = nil
+        data["y"] = nil
+      end
+
+      data
     end
   end
 end

--- a/app/models/waste_exemptions_engine/enrollment.rb
+++ b/app/models/waste_exemptions_engine/enrollment.rb
@@ -37,6 +37,10 @@ module WasteExemptionsEngine
       find_address_by_type(Address.address_types[:contact])
     end
 
+    def site_address
+      find_address_by_type(Address.address_types[:site])
+    end
+
     private
 
     def find_address_by_type(address_type)

--- a/app/validators/waste_exemptions_engine/grid_reference_validator.rb
+++ b/app/validators/waste_exemptions_engine/grid_reference_validator.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "os_map_ref"
+
+module WasteExemptionsEngine
+  class GridReferenceValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      return false unless value_is_present?(record, attribute, value)
+      return false unless value_has_valid_format?(record, attribute, value)
+
+      value_is_valid_coordinate?(record, attribute, value)
+    end
+
+    private
+
+    def value_is_present?(record, attribute, value)
+      return true if value.present?
+
+      record.errors[attribute] << error_message(record, attribute, "blank")
+      false
+    end
+
+    # Note that OsMapRef will work with less stringent coordinates than are
+    # specified for this service - so we need to add an additional check
+    def value_has_valid_format?(record, attribute, value)
+      return true if value.match?(/\A#{grid_reference_pattern}\z/)
+
+      record.errors[attribute] << error_message(record, attribute, "wrong_format")
+      false
+    end
+
+    def value_is_valid_coordinate?(record, attribute, value)
+      OsMapRef::Location.for(value).easting
+      true
+    rescue OsMapRef::Error
+      record.errors[attribute] << error_message(record, attribute, "invalid")
+      false
+    end
+
+    def grid_reference_pattern
+      [two_letters, optional_space, five_digits, optional_space, five_digits].join
+    end
+
+    def two_letters
+      "[A-Za-z]{2}"
+    end
+
+    def five_digits
+      '\d{5}'
+    end
+
+    def optional_space
+      '\s*'
+    end
+
+    def error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/app/validators/waste_exemptions_engine/site_description_validator.rb
+++ b/app/validators/waste_exemptions_engine/site_description_validator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class SiteDescriptionValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      return false unless value_is_present?(record, attribute, value)
+
+      value_is_not_too_long?(record, attribute, value)
+    end
+
+    private
+
+    def value_is_present?(record, attribute, value)
+      return true if value.present?
+
+      record.errors[attribute] << error_message(record, attribute, "blank")
+      false
+    end
+
+    def value_is_not_too_long?(record, attribute, value)
+      return true if value.length <= 500
+
+      record.errors[attribute] << error_message(record, attribute, "too_long")
+      false
+    end
+
+    def error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/app/views/waste_exemptions_engine/site_grid_reference_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/site_grid_reference_forms/new.html.erb
@@ -1,0 +1,90 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_site_grid_reference_forms_path(@site_grid_reference_form.token)) %>
+
+<div class="text">
+  <%= form_for(@site_grid_reference_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @site_grid_reference_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <% if @site_grid_reference_form.errors[:grid_reference].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="grid_reference">
+        <% if @site_grid_reference_form.errors[:grid_reference].any? %>
+        <span class="error-message"><%= @site_grid_reference_form.errors[:grid_reference].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :grid_reference, class: "form-label" do %>
+          <%= t(".grid_reference_label") %>
+          <span class='form-hint'><%= t(".grid_reference_hint") %></span>
+        <% end %>
+        <%= f.text_field :grid_reference, value: @site_grid_reference_form.grid_reference, class: "form-control" %>
+      </fieldset>
+    </div>
+
+    <div class="form-group">
+      <details>
+        <summary>
+          <span class="summary"><%= t(".grid_reference_help_link") %></span>
+        </summary>
+        <div class="panel panel-border-narrow">
+          <p><%=
+            t(
+              ".grid_reference_help_hint",
+              link: link_to(
+                t(".grid_reference_help_tool_link"),
+                "http://gridreferencefinder.com/",
+                rel: "external",
+                target: "_blank"
+                )
+            ).html_safe
+            %>
+          </p>
+          <ul class="list list-number">
+            <li><%= t(".grid_reference_help_step_1") %></li>
+            <li><%= t(".grid_reference_help_step_2") %></li>
+            <li><%= t(".grid_reference_help_step_3") %></li>
+          </ul>
+        </div>
+      </details>
+    </div>
+
+    <% if @site_grid_reference_form.errors[:description].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="description">
+        <% if @site_grid_reference_form.errors[:description].any? %>
+        <span class="error-message"><%= @site_grid_reference_form.errors[:description].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :description, class: "form-label" do %>
+          <%= t(".description_label") %>
+          <span class='form-hint'>
+            <%= t(".description_hint") %>
+            <ul class="list list-bullet">
+              <li><%= t(".description_hint_bullet_1") %></li>
+              <li><%= t(".description_hint_bullet_2") %></li>
+              <li><%= t(".description_hint_bullet_3") %></li>
+              <li><%= t(".description_hint_bullet_4") %></li>
+            </ul>
+          </span>
+        <% end %>
+        <%= f.text_area :description, value: @site_grid_reference_form.description, class: "form-control", rows: 4 %>
+      </fieldset>
+      <p><%= t(".description_limit") %></p>
+    </div>
+
+    <div class="form-group">
+      <%= link_to(t(".use_address_link"), skip_to_manual_address_operator_address_lookup_forms_path(@site_grid_reference_form.token)) %>
+    </div>
+
+    <%= f.hidden_field :token, value: @site_grid_reference_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/forms/site_grid_reference_forms/en.yml
+++ b/config/locales/forms/site_grid_reference_forms/en.yml
@@ -1,0 +1,39 @@
+en:
+  waste_exemptions_engine:
+    site_grid_reference_forms:
+      new:
+        title: Site grid reference
+        heading: Where will this waste operation take place?
+        grid_reference_label: National Grid reference
+        grid_reference_hint: Enter 2 letters and 10 digits. For example, ST 58132 72695.
+        grid_reference_help_link: Help finding a grid reference
+        grid_reference_help_hint: Use the free %{link}
+        grid_reference_help_tool_link: UK Grid Reference Finder (opens new window).
+        grid_reference_help_step_1: Search for the location or postcode on the left of the page.
+        grid_reference_help_step_2: Right-click to display the grid reference.
+        grid_reference_help_step_3: Select the grid reference then copy and paste back on this page.
+        description_label: Site details
+        description_hint: "Useful information includes:"
+        description_hint_bullet_1: nearby landmarks
+        description_hint_bullet_2: description of the site
+        description_hint_bullet_3: man-made features, for example roads, walls or buildings
+        description_hint_bullet_4: natural features, for example rivers, trees or hedges
+        description_limit: "500 character limit"
+        error_heading: A problem to fix
+        next_button: Continue
+        use_address_link: Use an address instead
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/site_grid_reference_form:
+          attributes:
+            grid_reference:
+              blank: Enter a grid reference
+              wrong_format: The grid reference should have 2 letters and 10 digits
+              invalid: The grid reference is not a valid coordinate
+            description:
+              blank: Enter a site description
+              too_long: The site description must be no longer than 500 characters
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -257,6 +257,16 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :site_grid_reference_forms,
+            only: [:new, :create],
+            path: "site-grid-reference",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "site_grid_reference_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   # See http://patrickperey.com/railscast-053-handling-exceptions/
   get "(errors)/:id", to: "errors#show", as: "error"
 

--- a/db/migrate/20181228105322_add_grid_reference_to_addresses.rb
+++ b/db/migrate/20181228105322_add_grid_reference_to_addresses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGridReferenceToAddresses < ActiveRecord::Migration
+  def change
+    add_column :addresses, :grid_reference, :string
+  end
+end

--- a/db/migrate/20181228105748_add_grid_reference_to_interims.rb
+++ b/db/migrate/20181228105748_add_grid_reference_to_interims.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGridReferenceToInterims < ActiveRecord::Migration
+  def change
+    add_column :interims, :grid_reference, :string
+  end
+end

--- a/db/migrate/20181228113158_add_description_to_addresses.rb
+++ b/db/migrate/20181228113158_add_description_to_addresses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDescriptionToAddresses < ActiveRecord::Migration
+  def change
+    add_column :addresses, :description, :string
+  end
+end

--- a/db/migrate/20181228113251_add_site_description_to_interims.rb
+++ b/db/migrate/20181228113251_add_site_description_to_interims.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSiteDescriptionToInterims < ActiveRecord::Migration
+  def change
+    add_column :interims, :site_description, :string
+  end
+end

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -27,6 +27,9 @@ Gem::Specification.new do |s|
   # Use rest-client for external requests, eg. to Companies House
   s.add_dependency "rest-client", "~> 2.0"
 
+  # Used to convert national grid references to easting and northing coordinates
+  s.add_dependency "os_map_ref", "~> 0.5"
+
   s.add_dependency "pg", "~> 0.18.4"
 
   # Validations


### PR DESCRIPTION
This adds the site grid reference page to waste exemptions. This does not have an equivalent in Waste Carriers so we have taken the technical design from the waste exemptions model, but the UI design and content from Flood Risk Activity Exemptions (FRAE), which came after WEX and iterated it's site grid reference page.

This also brings in the [os_map_ref](https://github.com/DEFRA/os-map-ref) gem. Similar functionality was built into WEX, but then moved to this gem for FRAE. We use it to convert a National Grid Reference to an x & y (easting & northing) so we can then query the area lookup WFS service to determine the EA area. It also helps us validate that a grid reference is valid.