### PR TITLE
Change site description columns to be text

### DIFF
--- a/db/migrate/20181231093833_change_description_to_be_text_in_addresses.rb
+++ b/db/migrate/20181231093833_change_description_to_be_text_in_addresses.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ChangeDescriptionToBeTextInAddresses < ActiveRecord::Migration
+  def change
+    reversible do |change|
+      change.up { change_column :addresses, :description, :text }
+      change.down { change_column :addresses, :description, :string }
+    end
+  end
+end

--- a/db/migrate/20181231093858_change_site_description_to_be_text_in_interims.rb
+++ b/db/migrate/20181231093858_change_site_description_to_be_text_in_interims.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ChangeSiteDescriptionToBeTextInInterims < ActiveRecord::Migration
+  def change
+    reversible do |change|
+      change.up { change_column :interims, :site_description, :text }
+      change.down { change_column :interims, :site_description, :string }
+    end
+  end
+end


### PR DESCRIPTION
The next change we were about to work on was selecting the exemptions. One of the things we need prior to that is to import and store the exemptions to choose, and as we began work we were reminded there is a 'text' type in PostgreSql (we need to hold a description for the exemptions).

We then had a "doh!" moment when we realised that this would be a better way to hold the site description, as its more expressive of the type of information be held (multiple lines of text rather than a single text value) and gives us more flexitibility in the future.