### PR TITLE
Add check your answers page

### DIFF
--- a/app/controllers/waste_exemptions_engine/check_your_answers_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/check_your_answers_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class CheckYourAnswersFormsController < FormsController
+    def new
+      super(CheckYourAnswersForm, "check_your_answers_form")
+    end
+
+    def create
+      super(CheckYourAnswersForm, "check_your_answers_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/check_your_answers_form.rb
+++ b/app/forms/waste_exemptions_engine/check_your_answers_form.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class CheckYourAnswersForm < BaseForm
+    include CanNavigateFlexibly
+
+    attr_accessor :location
+    attr_accessor :applicant_first_name, :applicant_last_name, :applicant_phone, :applicant_email
+    attr_accessor :business_type, :company_no, :operator_name, :operator_address
+    attr_accessor :contact_first_name, :contact_last_name, :contact_position, :contact_phone, :contact_email
+    attr_accessor :contact_address
+    attr_accessor :is_a_farm, :on_a_farm, :site_address, :grid_reference, :site_description, :exemptions
+
+    # We know this is a long method, but its just assigning attributes. Breaking
+    # it up for the sake of rubocop would add little benefit, hence the
+    # exceptions
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
+    def initialize(enrollment)
+      super
+
+      self.location = @enrollment.location
+
+      self.applicant_first_name = @enrollment.applicant_first_name
+      self.applicant_last_name = @enrollment.applicant_last_name
+      self.applicant_phone = @enrollment.applicant_phone
+      self.applicant_email = @enrollment.applicant_email
+
+      self.business_type = @enrollment.business_type
+
+      self.company_no = @enrollment.company_no
+      self.operator_name = @enrollment.operator_name
+      self.operator_address = @enrollment.operator_address
+
+      self.contact_first_name = @enrollment.contact_first_name
+      self.contact_last_name = @enrollment.contact_last_name
+      self.contact_position = @enrollment.contact_position
+      self.contact_phone = @enrollment.contact_phone
+      self.contact_email = @enrollment.contact_email
+      self.contact_address = @enrollment.contact_address
+
+      self.is_a_farm = @enrollment.is_a_farm
+      self.on_a_farm = @enrollment.on_a_farm
+
+      self.site_address = @enrollment.site_address
+      self.grid_reference = site_address&.grid_reference
+      self.site_description = site_address&.description
+
+      self.exemptions = @enrollment.exemptions
+
+      valid?
+    end
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
+
+    def submit(params)
+      super({}, params[:token])
+    end
+
+    def applicant_name
+      "#{applicant_first_name} #{applicant_last_name}"
+    end
+
+    def contact_name
+      "#{contact_first_name} #{contact_last_name}"
+    end
+
+    validates :location, "waste_exemptions_engine/location": true
+    validates :applicant_first_name, :applicant_last_name, "waste_exemptions_engine/person_name": true
+    validates :applicant_phone, "waste_exemptions_engine/phone_number": true
+    validates :applicant_email, "waste_exemptions_engine/email": true
+
+    validates :business_type, "waste_exemptions_engine/business_type": true
+    validates :company_no, "waste_exemptions_engine/company_no": true
+    validates :operator_name, "waste_exemptions_engine/operator_name": true
+    validates :operator_address, "waste_exemptions_engine/address": true
+
+    validates :contact_first_name, :contact_last_name, "waste_exemptions_engine/person_name": true
+    validates :contact_position, "waste_exemptions_engine/position": true
+    validates :contact_phone, "waste_exemptions_engine/phone_number": true
+    validates :contact_email, "waste_exemptions_engine/email": true
+    validates :contact_address, "waste_exemptions_engine/address": true
+
+    validates :is_a_farm, :on_a_farm, "waste_exemptions_engine/yes_no": true
+    validates :grid_reference, "waste_exemptions_engine/grid_reference": true
+    validates :site_description, "waste_exemptions_engine/site_description": true
+    validates :exemptions, "waste_exemptions_engine/exemptions": true
+
+  end
+end

--- a/app/helpers/waste_exemptions_engine/application_helper.rb
+++ b/app/helpers/waste_exemptions_engine/application_helper.rb
@@ -29,6 +29,18 @@ module WasteExemptionsEngine
       end
     end
 
+    def displayable_address(address)
+      return [] unless address.present?
+
+      # Get all the possible address lines, then remove the blank ones
+      [address.organisation,
+       address.premises,
+       address.street_address,
+       address.locality,
+       address.city,
+       address.postcode].reject(&:blank?)
+    end
+
     private
 
     def title_text

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -57,8 +57,8 @@ module WasteExemptionsEngine
         # Site questions
         state :site_grid_reference_form
 
-        # Exemptions questions
         state :exemptions_form
+        state :check_your_answers_form
 
         # Transitions
         event :next do
@@ -165,9 +165,11 @@ module WasteExemptionsEngine
           transitions from: :on_a_farm_form,
                       to: :site_grid_reference_form
 
-          # Exemptions questions
           transitions from: :site_grid_reference_form,
                       to: :exemptions_form
+
+          transitions from: :exemptions_form,
+                      to: :check_your_answers_form
         end
 
         event :back do
@@ -265,6 +267,9 @@ module WasteExemptionsEngine
           # Exemptions questions
           transitions from: :exemptions_form,
                       to: :site_grid_reference_form
+
+          transitions from: :check_your_answers_form,
+                      to: :exemptions_form
         end
 
         event :skip_to_manual_address do

--- a/app/validators/waste_exemptions_engine/address_validator.rb
+++ b/app/validators/waste_exemptions_engine/address_validator.rb
@@ -5,7 +5,7 @@ module WasteExemptionsEngine
     def validate_each(record, attribute, value)
       return false unless value_is_present?(record, attribute, value)
 
-      valid_uk_address?(record, attribute, value)
+      false
     end
 
     private
@@ -14,14 +14,6 @@ module WasteExemptionsEngine
       return true if value.present?
 
       record.errors[attribute] << error_message(record, attribute, "blank")
-      false
-    end
-
-    def valid_uk_address?(record, attribute, value)
-      return true if value.address_mode == "address-results"
-      return true if value.address_mode == "manual-uk"
-
-      record.errors[attribute] << error_message(record, attribute, "should_be_uk")
       false
     end
 

--- a/app/views/waste_exemptions_engine/check_your_answers_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/check_your_answers_forms/new.html.erb
@@ -1,0 +1,115 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_check_your_answers_forms_path(@check_your_answers_form.token)) %>
+
+<div class="text">
+  <% if @check_your_answers_form.errors.any? %>
+
+    <div class="error-summary" role="alert">
+      <h2 class="heading-medium error-summary-heading"><%= t(".error_heading") %></h2>
+
+      <p><%= t(".error_description_1") %></p>
+
+      <ul class="list list-bullet">
+      <% @check_your_answers_form.errors.each do |_field, message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+
+      <p><%= t(".error_description_2") %></p>
+    </div>
+
+  <% else %>
+
+    <%= form_for(@check_your_answers_form) do |f| %>
+      <%= render("waste_exemptions_engine/shared/errors", object: @check_your_answers_form) %>
+
+      <h1 class="heading-large"><%= t(".heading") %></h1>
+
+      <p><%= t(".description") %></p>
+
+      <hr>
+      <h2 class="heading-medium"><%= t(".location.subheading") %></h2>
+      <p><%= t(".location.location_html") %></p>
+
+      <hr>
+      <h2 class="heading-medium"><%= t(".applicant.subheading") %></h2>
+      <ul class="list list-bullet">
+        <li><%= t(".applicant.name_html", value: @check_your_answers_form.applicant_name) %></li>
+        <li><%= t(".applicant.phone_html", value: @check_your_answers_form.applicant_phone) %></li>
+        <li><%= t(".applicant.email_html", value: @check_your_answers_form.applicant_email) %></li>
+      </ul>
+
+      <hr>
+      <h2 class="heading-medium"><%= t(".operator.subheading") %></h2>
+      <ul class="list list-bullet">
+        <li><%= t(".operator.business_type.#{@check_your_answers_form.business_type}_html") %></li>
+        <li><%= t(".operator.name.#{@check_your_answers_form.business_type}_html", value: @check_your_answers_form.operator_name) %></li>
+        <% if @check_your_answers_form.company_no.present? %>
+        <li><%= t(".operator.company_no_html") %></li>
+        <% end %>
+      </ul>
+
+      <hr>
+      <h2 class="heading-medium"><%= t(".operator.subheading_address") %></h2>
+      <ul class="list">
+        <% displayable_address(@check_your_answers_form.operator_address).each do |line| %>
+          <li><%= line %></li>
+        <% end %>
+      </ul>
+
+      <hr>
+      <h2 class="heading-medium"><%= t(".contact.subheading") %></h2>
+      <ul class="list list-bullet">
+        <li><%= t(".contact.name_html", value: @check_your_answers_form.contact_name) %></li>
+        <% if @check_your_answers_form.contact_position.present? %>
+        <li><%= t(".contact.position_html", value: @check_your_answers_form.contact_position) %></li>
+        <% end %>
+        <li><%= t(".contact.phone_html", value: @check_your_answers_form.contact_phone) %></li>
+        <li><%= t(".contact.email_html", value: @check_your_answers_form.contact_email) %></li>
+      </ul>
+
+      <hr>
+      <h2 class="heading-medium"><%= t(".contact.subheading_address") %></h2>
+      <ul class="list">
+        <% displayable_address(@check_your_answers_form.contact_address).each do |line| %>
+          <li><%= line %></li>
+        <% end %>
+      </ul>
+
+      <hr>
+      <h2 class="heading-medium"><%= t(".farming.subheading") %></h2>
+      <ul class="list list-bullet">
+        <li><%= t(".farming.is_a_farm.#{@check_your_answers_form.is_a_farm}_html") %></li>
+        <li><%= t(".farming.on_a_farm.#{@check_your_answers_form.on_a_farm}_html") %></li>
+      </ul>
+
+      <hr>
+      <h2 class="heading-medium"><%= t(".site.subheading.#{@check_your_answers_form.site_address&.mode}") %></h2>
+      <% if @check_your_answers_form.site_address&.auto? %>
+      <ul class="list list-bullet">
+        <li><%= t(".site.grid_reference_html", value: @check_your_answers_form.grid_reference) %></li>
+        <li><%= @check_your_answers_form.site_description %></li>
+      </ul>
+      <% else %>
+      <ul class="list">
+        <% displayable_address(@check_your_answers_form.site_address).each do |line| %>
+          <li><%= line %></li>
+        <% end %>
+      </ul>
+      <% end %>
+
+      <hr>
+      <h2 class="heading-medium"><%= t(".exemptions.subheading") %></h2>
+      <ul class="list list-bullet">
+        <% @check_your_answers_form.exemptions.each do |exemption| %>
+        <li><span class="strong"><%= exemption.code %></span> - <%= exemption.summary %></li>
+        <% end %>
+      </ul>
+
+      <%= f.hidden_field :token, value: @check_your_answers_form.token %>
+      <div class="form-group">
+        <%= f.submit t(".next_button"), class: "button" %>
+      </div>
+    <% end %>
+
+  <% end %>
+</div>

--- a/config/locales/forms/check_your_answers_forms/en.yml
+++ b/config/locales/forms/check_your_answers_forms/en.yml
@@ -1,0 +1,131 @@
+en:
+  waste_exemptions_engine:
+    check_your_answers_forms:
+      new:
+        title: Check your details
+        heading: Check your answers before completing your registration
+        error_heading: Something is wrong
+        error_description_1: "We're missing some of the information we need to complete your registration:"
+        error_description_2: "Please go back and make sure all the required questions have been answered."
+        description: We will send a copy of this summary in a confirmation email
+        location:
+          subheading: "You told us"
+          location_html: "the waste operation will take place in <span class=\"strong\">England</span>"
+        applicant:
+          subheading: Your details
+          name_html: "your name is <span class=\"strong\">%{value}</span>"
+          phone_html: "your phone number is <span class=\"strong\">%{value}</span>"
+          email_html: "your email is <span class=\"strong\">%{value}</span>"
+        operator:
+          subheading: Operator details
+          business_type:
+            limitedCompany_html: "the operator is a <span class=\"strong\">limited company</span>"
+            limitedLiabilityPartnership_html: "the operator is a <span class=\"strong\">limited liability partnership</span>"
+            localAuthority_html: "the operator is a <span class=\"strong\">local authority or public body</span>"
+            partnership_html: "the operator is a <span class=\"strong\">partnership</span>"
+            soleTrader_html: "the operator is a <span class=\"strong\">individual or sole trader</span>"
+            charity_html: "the operator is a <span class=\"strong\">charity or trust</span>"
+          name:
+            limitedCompany_html: "the company name is <span class=\"strong\">%{value}</span>"
+            limitedLiabilityPartnership_html: "the partnership name is <span class=\"strong\">%{value}</span>"
+            localAuthority_html: "the local authority or public body name is <span class=\"strong\">%{value}</span>"
+            partnership_html: "the partnership name is <span class=\"strong\">%{value}</span>"
+            soleTrader_html: "the operator's name is <span class=\"strong\">%{value}</span>"
+            charity_html: "the charity or trust name is <span class=\"strong\">%{value}</span>"
+          company_no_html: "the Companies House number is <span class=\"strong\">%{value}</span>"
+          subheading_address: Operator address
+        contact:
+          subheading: Contact deatils
+          name_html: "the contact's name is <span class=\"strong\">%{value}</span>"
+          position_html: "the contact's position is <span class=\"strong\">%{value}</span>"
+          phone_html: "the contact's phone number is <span class=\"strong\">%{value}</span>"
+          email_html: "the contact's email is <span class=\"strong\">%{value}</span>"
+          subheading_address: Contact address
+        farming:
+          subheading: Farming information
+          is_a_farm:
+            true_html: "the operater <span class=\"strong\">is</span> a farmer"
+            false_html: "the operater <span class=\"strong\">is not</span> a farmer"
+          on_a_farm:
+            true_html: "the operation <span class=\"strong\">will</span> take place on a farm"
+            false_html: "the operation <span class=\"strong\">will not</span> take place on a farm"
+        site:
+          subheading:
+            lookup: Site address
+            manual: Site address
+            auto: Site location
+          grid_reference_html: "the site is located at grid reference <span class=\"strong\">%{value}</span>"
+        exemptions:
+          subheading: Selected exemptions
+        next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/check_your_answers_form:
+          attributes:
+            location:
+              inclusion: "You need to tell us if you are registering a waste operation based in England"
+            applicant_first_name:
+              blank: "You need to enter your first name"
+              invalid: "Your first name must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+              too_long: "Your first name must have no more than 70 characters"
+            applicant_last_name:
+              blank: "You need to enter your last name"
+              invalid: "Your last name must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+              too_long: "Your last name must have no more than 70 characters"
+            applicant_phone:
+              blank: "You need to enter your telephone number"
+              invalid_format: "Your phone number is not a valid number"
+              too_long: "Your phone number should have no more than than 15 characters"
+            applicant_email:
+              blank: "You need to enter your email address"
+              invalid_format: "Your email is not a valid email address"
+            business_type:
+              inclusion: "You need to tell us what type of organisation the operator is"
+            company_no:
+              invalid_format: "The operator company number is not valid - it should have 8 digits, or 2 letters followed by 6 digits. If your number has only 7 digits, enter it with a zero at the start."
+              inactive: "The operator company must be registered as an active company"
+              not_found: "Companies House couldn't find a company with this number"
+              error: "There was an error with Companies House"
+              blank: "You need to tell us the operator's company registration number"
+            operator_name:
+              blank: "You need to tell us the waste operator's name"
+              too_long: "Enter a shorter waste operator name with no more than 255 characters"
+            operator_address:
+              blank: "You need to tell us the waste operator's address"
+            contact_first_name:
+              blank: "You need to enter the contact's first name"
+              invalid: "The contact's first name must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+              too_long: "The contact's first name must have no more than 70 characters"
+            contact_last_name:
+              blank: "You need to enter the contact's last name"
+              invalid: "The contact's last name must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+              too_long: "The contact's last name must have no more than 70 characters"
+            contact_position:
+              invalid: "The contact's position must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+              too_long: "The contact's position must have no more than 70 characters"
+            contact_phone:
+              blank: "You need to enter the contact's telephone number"
+              invalid_format: "The contact's phone number is not a valid number"
+              too_long: "The contact's phone number should have no more than than 15 characters"
+            contact_email:
+              blank: "You need to enter the contact's email address"
+              invalid_format: "The contact's email is not a valid email address"
+            contact_address:
+              blank: "You need to tell us the contact's address"
+            is_a_farm:
+              inclusion: "You must tell us if the operator is a farmer"
+            on_a_farm:
+              inclusion: "You must tell us if the operation is on a farm"
+            grid_reference:
+              blank: "You need to tell us the site grid reference"
+              wrong_format: The site grid reference should have 2 letters and 10 digits
+              invalid: The site grid reference is not a valid coordinate
+            site_description:
+              blank: You need to provide a site description
+              too_long: The site description must be no longer than 500 characters
+            exemptions:
+              inclusion: "You must select at least one exemption"
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -277,6 +277,16 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :check_your_answers_forms,
+            only: [:new, :create],
+            path: "check-your-answers",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "check_your_answers_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   # See http://patrickperey.com/railscast-053-handling-exceptions/
   get "(errors)/:id", to: "errors#show", as: "error"
 


### PR DESCRIPTION
The design and method for displaying previously entered answers is lifted straight from Waste Carriers. However as the content is different it has been heavily edited to match the Waste Exemptions journey.

There has been one slight tweak to the design as well. When it comes to referencing the locale content, rather than generic subheadings and fields from different sections aligned together, it has been broken down into sections.

This should hopefully make aligning the content and layout a little easier when changes are made in the future.