### PR TITLE
Add site postcode page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ git:
 
 before_install:
   - export TZ=UTC
+  - gem install -v 1.17.2 bundler --no-rdoc --no-ri
 
 before_script:
   # Setup to support the CodeClimate test coverage submission

--- a/app/controllers/waste_exemptions_engine/site_grid_reference_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/site_grid_reference_forms_controller.rb
@@ -9,5 +9,12 @@ module WasteExemptionsEngine
     def create
       super(SiteGridReferenceForm, "site_grid_reference_form")
     end
+
+    def skip_to_address
+      find_or_initialize_enrollment(params[:token])
+
+      @enrollment.skip_to_address! if form_matches_state?
+      redirect_to_correct_form
+    end
   end
 end

--- a/app/controllers/waste_exemptions_engine/site_postcode_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/site_postcode_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class SitePostcodeFormsController < PostcodeFormsController
+    def new
+      super(SitePostcodeForm, "site_postcode_form")
+    end
+
+    def create
+      super(SitePostcodeForm, "site_postcode_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/site_postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/site_postcode_form.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class SitePostcodeForm < PostcodeForm
+    include CanNavigateFlexibly
+
+    private
+
+    def existing_postcode
+      @enrollment.interim.site_postcode
+    end
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -56,6 +56,7 @@ module WasteExemptionsEngine
 
         # Site questions
         state :site_grid_reference_form
+        state :site_postcode_form
 
         state :exemptions_form
         state :check_your_answers_form
@@ -166,6 +167,10 @@ module WasteExemptionsEngine
                       to: :site_grid_reference_form
 
           transitions from: :site_grid_reference_form,
+                      to: :site_postcode_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :site_grid_reference_form,
                       to: :exemptions_form
 
           transitions from: :exemptions_form,
@@ -264,6 +269,9 @@ module WasteExemptionsEngine
           transitions from: :site_grid_reference_form,
                       to: :on_a_farm_form
 
+          transitions from: :site_postcode_form,
+                      to: :site_grid_reference_form
+
           # Exemptions questions
           transitions from: :exemptions_form,
                       to: :site_grid_reference_form
@@ -284,6 +292,11 @@ module WasteExemptionsEngine
 
           transitions from: :contact_address_lookup_form,
                       to: :contact_address_manual_form
+        end
+
+        event :skip_to_address do
+          transitions from: :site_grid_reference_form,
+                      to: :site_postcode_form
         end
       end
     end

--- a/app/views/waste_exemptions_engine/site_grid_reference_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/site_grid_reference_forms/new.html.erb
@@ -79,7 +79,7 @@
     </div>
 
     <div class="form-group">
-      <%= link_to(t(".use_address_link"), skip_to_manual_address_operator_address_lookup_forms_path(@site_grid_reference_form.token)) %>
+      <%= link_to(t(".use_address_link"), skip_to_address_site_grid_reference_forms_path(@site_grid_reference_form.token)) %>
     </div>
 
     <%= f.hidden_field :token, value: @site_grid_reference_form.token %>

--- a/app/views/waste_exemptions_engine/site_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/site_postcode_forms/new.html.erb
@@ -1,0 +1,45 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_site_postcode_forms_path(@site_postcode_form.token)) %>
+
+<div class="text">
+  <%= form_for(@site_postcode_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @site_postcode_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <% if @site_postcode_form.errors[:postcode].any? %>
+    <div class="form-group form-group-error">
+    <% else %>
+    <div class="form-group">
+    <% end %>
+      <fieldset id="postcode">
+        <legend class="visuallyhidden">
+          <%= t(".heading") %>
+        </legend>
+
+        <% if @site_postcode_form.errors[:postcode].any? %>
+        <span class="error-message"><%= @site_postcode_form.errors[:postcode].join(", ") %></span>
+        <% end %>
+
+        <%= f.label :postcode, class: "form-label" do %>
+          <%= t(".postcode_label") %>
+          <span class='form-hint'><%= t(".postcode_hint") %></span>
+        <% end %>
+        <%= f.text_field :postcode, value: @site_postcode_form.postcode, class: "form-control" %>
+
+      </fieldset>
+    </div>
+
+    <%= f.hidden_field :token, value: @site_postcode_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+
+    <% if @site_postcode_form.errors.added?(:postcode, :no_results) %>
+    <div class="form-group">
+      <%= link_to(t(".manual_address_link"), skip_to_manual_address_contact_postcode_forms_path(@site_postcode_form.token)) %>
+    </div>
+    <% end %>
+  <% end %>
+
+  <%= render("waste_exemptions_engine/shared/os_terms_footer") %>
+</div>

--- a/config/locales/forms/site_postcode_forms/en.yml
+++ b/config/locales/forms/site_postcode_forms/en.yml
@@ -1,0 +1,23 @@
+en:
+  waste_exemptions_engine:
+    site_postcode_forms:
+      new:
+        title: Site address postcode
+        heading: What is the postcode for the address of the waste operation?
+        postcode_label: Please enter a UK postcode
+        postcode_hint: For example, BS1 5AH
+        error_heading: A problem to fix
+        next_button: Find address
+        manual_address_link: "Enter address manually"
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/site_postcode_form:
+          attributes:
+            postcode:
+              blank: "Enter a postcode"
+              wrong_format: "Enter a valid UK postcode"
+              no_results: "We cannot find any addresses for that postcode. Check the postcode or enter the address manually."
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -265,6 +265,26 @@ WasteExemptionsEngine::Engine.routes.draw do
               to: "site_grid_reference_forms#go_back",
               as: "back",
               on: :collection
+
+              get "skip_to_address/:token",
+              to: "site_grid_reference_forms#skip_to_address",
+              as: "skip_to_address",
+              on: :collection
+            end
+
+  resources :site_postcode_forms,
+            only: [:new, :create],
+            path: "site-postcode",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "site_postcode_forms#go_back",
+              as: "back",
+              on: :collection
+
+              get "skip_to_manual_address/:token",
+              to: "site_postcode_forms#skip_to_manual_address",
+              as: "skip_to_manual_address",
+              on: :collection
             end
 
   resources :exemptions_forms,

--- a/db/migrate/20190103103408_add_site_postcode_to_interims.rb
+++ b/db/migrate/20190103103408_add_site_postcode_to_interims.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSitePostcodeToInterims < ActiveRecord::Migration
+  def change
+    add_column :interims, :site_postcode, :string
+  end
+end


### PR DESCRIPTION
This is following our pattern for postcode search pages in the app, with one slight tweak.

Moving from the site grid reference to the site postcode is an optional step, and not as a result of an error. Also it does not infer we want to enter the address manually.

Hence we have added a `skip_to_address` method to the controller, and event in the workflow to better reflect this.