### PR TITLE
Add site address lookup page

### DIFF
--- a/app/controllers/waste_exemptions_engine/site_address_lookup_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/site_address_lookup_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class SiteAddressLookupFormsController < AddressLookupFormsController
+    def new
+      super(SiteAddressLookupForm, "site_address_lookup_form")
+    end
+
+    def create
+      super(SiteAddressLookupForm, "site_address_lookup_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/site_address_form.rb
+++ b/app/forms/waste_exemptions_engine/site_address_form.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module SiteAddressForm
+
+    private
+
+    def existing_postcode
+      @enrollment.interim.site_postcode
+    end
+
+    def existing_address
+      @enrollment.site_address
+    end
+
+    def address_type
+      Address.address_types[:site]
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/site_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/site_address_lookup_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class SiteAddressLookupForm < AddressLookupForm
+    include SiteAddressForm
+
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -57,6 +57,7 @@ module WasteExemptionsEngine
         # Site questions
         state :site_grid_reference_form
         state :site_postcode_form
+        state :site_address_lookup_form
 
         state :exemptions_form
         state :check_your_answers_form
@@ -173,6 +174,23 @@ module WasteExemptionsEngine
           transitions from: :site_grid_reference_form,
                       to: :exemptions_form
 
+          # transitions from: :site_postcode_form,
+          #             to: :site_address_manual_form,
+          #             if: :skip_to_manual_address?
+
+          transitions from: :site_postcode_form,
+                      to: :site_address_lookup_form
+
+          # transitions from: :site_address_lookup_form,
+          #             to: :site_address_manual_form,
+          #             if: :skip_to_manual_address?
+
+          transitions from: :site_address_lookup_form,
+                      to: :exemptions_form
+
+          # transitions from: :site_address_manual_form,
+          #             to: :exemptions_form
+
           transitions from: :exemptions_form,
                       to: :check_your_answers_form
         end
@@ -272,7 +290,21 @@ module WasteExemptionsEngine
           transitions from: :site_postcode_form,
                       to: :site_grid_reference_form
 
+          transitions from: :site_address_lookup_form,
+                      to: :site_postcode_form
+
+          transitions from: :site_address_manual_form,
+                      to: :site_postcode_form
+
           # Exemptions questions
+          # transitions from: :exemptions_form,
+          #             to: :site_address_manual_form,
+          #             if: :site_address_was_manually_entered?
+
+          transitions from: :exemptions_form,
+                      to: :site_address_lookup_form,
+                      if: :site_address_was_entered?
+
           transitions from: :exemptions_form,
                       to: :site_grid_reference_form
 
@@ -292,6 +324,12 @@ module WasteExemptionsEngine
 
           transitions from: :contact_address_lookup_form,
                       to: :contact_address_manual_form
+
+          transitions from: :site_postcode_form,
+                      to: :site_address_manual_form
+
+          transitions from: :site_address_lookup_form,
+                      to: :site_address_manual_form
         end
 
         event :skip_to_address do
@@ -317,6 +355,18 @@ module WasteExemptionsEngine
       return unless contact_address
 
       contact_address.manual?
+    end
+
+    # def site_address_was_manually_entered?
+    #   return unless site_address
+    #
+    #   site_address.manual?
+    # end
+
+    def site_address_was_entered?
+      return unless site_address
+
+      site_address.lookup?
     end
 
     def should_contact_the_agency?

--- a/app/views/waste_exemptions_engine/site_address_lookup_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/site_address_lookup_forms/new.html.erb
@@ -1,0 +1,28 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_site_address_lookup_forms_path(@site_address_lookup_form.token)) %>
+
+<div class="text">
+  <%= form_for(@site_address_lookup_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @site_address_lookup_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <div class="form-group">
+      <label class="form-label"><%= t(".postcode_label") %></label>
+      <span class="postcode"><%= @site_address_lookup_form.postcode %></span>
+      <%= link_to(t(".postcode_change_link"), back_site_address_lookup_forms_path(@site_address_lookup_form.token)) %>
+    </div>
+
+    <%= render("waste_exemptions_engine/shared/select_address", form: @site_address_lookup_form, f: f) %>
+
+    <div class="form-group">
+      <%= link_to(t(".manual_address_link"), skip_to_manual_address_site_address_lookup_forms_path(@site_address_lookup_form.token)) %>
+    </div>
+
+    <%= f.hidden_field :token, value: @site_address_lookup_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+
+  <%= render("waste_exemptions_engine/shared/os_terms_footer") %>
+</div>

--- a/config/locales/forms/site_address_lookup_forms/en.yml
+++ b/config/locales/forms/site_address_lookup_forms/en.yml
@@ -1,0 +1,21 @@
+en:
+  waste_exemptions_engine:
+    site_address_lookup_forms:
+      new:
+        title: Site address selection
+        heading: What is the address of the waste operation?
+        postcode_label: Postcode
+        postcode_change_link: "Change postcode"
+        manual_address_link: "I cannot find the address in the list"
+        error_heading: Something is wrong
+        next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/site_address_lookup_forms:
+          attributes:
+            addresses:
+              blank: "You must select an address"
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -287,6 +287,21 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :site_address_lookup_forms,
+            only: [:new, :create],
+            path: "site-address-lookup",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "site_address_lookup_forms#go_back",
+              as: "back",
+              on: :collection
+
+              get "skip_to_manual_address/:token",
+              to: "site_address_lookup_forms#skip_to_manual_address",
+              as: "skip_to_manual_address",
+              on: :collection
+            end
+
   resources :exemptions_forms,
             only: [:new, :create],
             path: "exemptions",


### PR DESCRIPTION
This adds the page to select the site address based on results of a postcode lookup. It's essentially a duplicate of what we have already done for the operator and contact address.

To that end, we have also been a bit cheeky and added the code in `CanChangeWorkflowStatus` (though commented it out) to handle manual address entry, as it was easier to work out the transitions based on where we want to get to, rather than via an interim step.

They will be uncommented in a subsquent commit.