### PR TITLE
Add site manual address entry page

### DIFF
--- a/app/controllers/waste_exemptions_engine/site_address_manual_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/site_address_manual_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class SiteAddressManualFormsController < FormsController
+    def new
+      super(SiteAddressManualForm, "site_address_manual_form")
+    end
+
+    def create
+      super(SiteAddressManualForm, "site_address_manual_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/site_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/site_address_manual_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class SiteAddressManualForm < AddressManualForm
+    include SiteAddressForm
+
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -58,6 +58,7 @@ module WasteExemptionsEngine
         state :site_grid_reference_form
         state :site_postcode_form
         state :site_address_lookup_form
+        state :site_address_manual_form
 
         state :exemptions_form
         state :check_your_answers_form
@@ -174,22 +175,22 @@ module WasteExemptionsEngine
           transitions from: :site_grid_reference_form,
                       to: :exemptions_form
 
-          # transitions from: :site_postcode_form,
-          #             to: :site_address_manual_form,
-          #             if: :skip_to_manual_address?
+          transitions from: :site_postcode_form,
+                      to: :site_address_manual_form,
+                      if: :skip_to_manual_address?
 
           transitions from: :site_postcode_form,
                       to: :site_address_lookup_form
 
-          # transitions from: :site_address_lookup_form,
-          #             to: :site_address_manual_form,
-          #             if: :skip_to_manual_address?
+          transitions from: :site_address_lookup_form,
+                      to: :site_address_manual_form,
+                      if: :skip_to_manual_address?
 
           transitions from: :site_address_lookup_form,
                       to: :exemptions_form
 
-          # transitions from: :site_address_manual_form,
-          #             to: :exemptions_form
+          transitions from: :site_address_manual_form,
+                      to: :exemptions_form
 
           transitions from: :exemptions_form,
                       to: :check_your_answers_form
@@ -297,9 +298,9 @@ module WasteExemptionsEngine
                       to: :site_postcode_form
 
           # Exemptions questions
-          # transitions from: :exemptions_form,
-          #             to: :site_address_manual_form,
-          #             if: :site_address_was_manually_entered?
+          transitions from: :exemptions_form,
+                      to: :site_address_manual_form,
+                      if: :site_address_was_manually_entered?
 
           transitions from: :exemptions_form,
                       to: :site_address_lookup_form,
@@ -357,11 +358,11 @@ module WasteExemptionsEngine
       contact_address.manual?
     end
 
-    # def site_address_was_manually_entered?
-    #   return unless site_address
-    #
-    #   site_address.manual?
-    # end
+    def site_address_was_manually_entered?
+      return unless site_address
+
+      site_address.manual?
+    end
 
     def site_address_was_entered?
       return unless site_address

--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -21,6 +21,8 @@ module WasteExemptionsEngine
     end
 
     def self.create_from_manual_entry_data(data, address_type)
+      data = update_xy_from_postcode(data) if address_type == Address.address_types[:site]
+
       create_address(data, address_type, Address.modes[:manual])
     end
 
@@ -35,6 +37,18 @@ module WasteExemptionsEngine
       data["mode"] = mode
 
       Address.create(data)
+    end
+
+    private_class_method def self.update_xy_from_postcode(data)
+      return nil unless data
+
+      results = AddressFinderService.new(data[:postcode]).search_by_postcode
+      if results&.length&.positive?
+        data["x"] = results.first["x"].to_f
+        data["y"] = results.first["y"].to_f
+      end
+
+      data
     end
 
     private_class_method def self.update_xy_from_grid_reference(data)

--- a/app/views/waste_exemptions_engine/site_address_manual_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/site_address_manual_forms/new.html.erb
@@ -1,0 +1,29 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_site_address_manual_forms_path(@site_address_manual_form.token)) %>
+
+<div class="text">
+  <%= form_for(@site_address_manual_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @site_address_manual_form) %>
+
+    <% if @site_address_manual_form.address_finder_error %>
+    <div class="error-summary" role="alert">
+      <h2 class="heading-medium error-summary-heading"><%= t(".address_finder_error_heading") %></h2>
+      <p><%= t(".address_finder_error_text") %></p>
+    </div>
+    <% end %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <div class="form-group">
+      <label class="form-label"><%= t(".postcode_label") %></label>
+      <span class="postcode"><%= @site_address_manual_form.postcode %></span>
+      <%= link_to(t(".postcode_change_link"), back_site_address_manual_forms_path(@site_address_manual_form.token)) %>
+    </div>
+
+    <%= render("waste_exemptions_engine/shared/manual_address", form: @site_address_manual_form, f: f) %>
+
+    <%= f.hidden_field :token, value: @site_address_manual_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/forms/site_address_manual_forms/en.yml
+++ b/config/locales/forms/site_address_manual_forms/en.yml
@@ -1,0 +1,33 @@
+en:
+  waste_exemptions_engine:
+    site_address_manual_forms:
+      new:
+        title: Site address
+        heading: What is the address of the waste operation?
+        postcode_label: Postcode
+        postcode_change_link: "Change postcode"
+        address_finder_error_heading: Our address finder is not working
+        address_finder_error_text: Please enter the address below.
+        error_heading: Something is wrong
+        next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/site_address_manual_form:
+          attributes:
+            premises:
+              blank: "Enter the building name or number"
+              too_long: "The building name or number must be no longer than 200 characters"
+            street_address:
+              blank: "Enter an address line 1"
+              too_long: "The address line 1 must be no longer than 160 characters"
+            locality:
+              too_long: "The address line 2 must be no longer than 70 characters"
+            city:
+              blank: "Enter a town or city"
+              too_long: "The town or city must be no longer than 30 characters"
+            postcode:
+              too_long: "The postcode must be no longer than 8 characters"
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -302,6 +302,16 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :site_address_manual_forms,
+            only: [:new, :create],
+            path: "site-address-manual",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "site_address_manual_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   resources :exemptions_forms,
             only: [:new, :create],
             path: "exemptions",


### PR DESCRIPTION
Follows the pattern set for manual address entry, and copies what we have done for the operator and contact.

In addition it includes a new feature specific to the site address, where we use the OS Places postcode lookup to determine the x & y (easting and northing) for a manually entered an address.

Bringing in the current design for address entry (originated in FRAE) makes it less likely that a user can get an unknown postcode in. With this additional change we can move a step closer to 100% of addresses having an X & Y, and therefore our ability to determine the EA Admin area they belong to.