### PR TITLE
Add declaration page

### DIFF
--- a/app/controllers/waste_exemptions_engine/declaration_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/declaration_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class DeclarationFormsController < FormsController
+    def new
+      super(DeclarationForm, "declaration_form")
+    end
+
+    def create
+      super(DeclarationForm, "declaration_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/check_your_answers_form.rb
+++ b/app/forms/waste_exemptions_engine/check_your_answers_form.rb
@@ -81,7 +81,8 @@ module WasteExemptionsEngine
     validates :contact_email, "waste_exemptions_engine/email": true
     validates :contact_address, "waste_exemptions_engine/address": true
 
-    validates :is_a_farm, :on_a_farm, "waste_exemptions_engine/yes_no": true
+    validates :is_a_farm, inclusion: { in: [true, false] }
+    validates :on_a_farm, inclusion: { in: [true, false] }
     validates :grid_reference, "waste_exemptions_engine/grid_reference": true
     validates :site_description, "waste_exemptions_engine/site_description": true
     validates :exemptions, "waste_exemptions_engine/exemptions": true

--- a/app/forms/waste_exemptions_engine/declaration_form.rb
+++ b/app/forms/waste_exemptions_engine/declaration_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class DeclarationForm < BaseForm
+    include CanNavigateFlexibly
+
+    attr_accessor :declaration
+
+    def initialize(enrollment)
+      super
+      self.declaration = @enrollment.declaration
+    end
+
+    def submit(params)
+      self.declaration = params[:declaration].to_i
+
+      attributes = { declaration: declaration }
+
+      super(attributes, params[:token])
+    end
+
+    validates :declaration, inclusion: { in: [1] }
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
+# We believe in the case of the different states and transitions for the
+# exemption journey, its better to see them all in one place. However this
+# does mean the module length breaks rubocops rules hence the exception.
+# rubocop:disable Metrics/ModuleLength
 module WasteExemptionsEngine
-  # We believe in the case of the different states and transitions for the
-  # exemption journey, its better to see them all in one place. However this
-  # does mean the module length breaks rubocops rules hence the exception.
-  # rubocop:disable Metrics/ModuleLength
   module CanChangeWorkflowStatus
     extend ActiveSupport::Concern
 
@@ -62,6 +62,7 @@ module WasteExemptionsEngine
 
         state :exemptions_form
         state :check_your_answers_form
+        state :declaration_form
 
         # Transitions
         event :next do
@@ -194,6 +195,9 @@ module WasteExemptionsEngine
 
           transitions from: :exemptions_form,
                       to: :check_your_answers_form
+
+          transitions from: :check_your_answers_form,
+                      to: :declaration_form
         end
 
         event :back do
@@ -309,8 +313,12 @@ module WasteExemptionsEngine
           transitions from: :exemptions_form,
                       to: :site_grid_reference_form
 
+          # End pages
           transitions from: :check_your_answers_form,
                       to: :exemptions_form
+
+          transitions from: :declaration_form,
+                      to: :check_your_answers_form
         end
 
         event :skip_to_manual_address do
@@ -396,5 +404,5 @@ module WasteExemptionsEngine
       interim.address_finder_error
     end
   end
-  # rubocop:enable Metrics/ModuleLength
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/views/waste_exemptions_engine/declaration_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/declaration_forms/new.html.erb
@@ -1,0 +1,37 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_declaration_forms_path(@declaration_form.token)) %>
+
+<div class="text">
+  <%= form_for(@declaration_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @declaration_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <div class="icon heading-with-border">
+      <div class="icon-important inline">
+        <%= image_tag "icon-important-2x.png", alt: t('.alt_text') %>
+      </div>
+      <span class="heading-small inline"><%= t '.notice' %></span>
+    </div>
+
+    <ul class="list list-bullet">
+      <li><%= t(".list_item_1") %></li>
+      <li><%= t(".list_item_2") %></li>
+    </ul>
+
+    <div class="form-group">
+      <fieldset id="declaration">
+        <div class="multiple-choice">
+          <%= f.check_box :declaration %>
+          <%= f.label :declaration, t(".declaration_text") %>
+        </div>
+      </fieldset>
+    </div>
+
+    <p><%= link_to t(".privacy_link_text"), page_path("privacy"),  target: "_blank" %></p>
+
+    <%= f.hidden_field :token, value: @declaration_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/forms/declaration_forms/en.yml
+++ b/config/locales/forms/declaration_forms/en.yml
@@ -1,0 +1,24 @@
+en:
+  waste_exemptions_engine:
+    declaration_forms:
+      new:
+        title: Declaration
+        heading: Declaration
+        notice: You can be prosecuted and fined if you provide false or misleading information
+        list_item_1: By registering, you confirm that the information you have provided is true
+        list_item_2: The business or organisation carrying out the waste operation has authorised me to provide this information
+        declaration_text: I understand and agree with the declaration above
+        privacy_link_text: "Privacy: how we use your personal information (opens new tab)"
+        alt_text: Important message
+        error_heading: Something is wrong
+        next_button: Continue
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/declaration_form:
+          attributes:
+            declaration:
+              inclusion: "You cannot register if you do not understand and agree with the declaration"
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -332,6 +332,16 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :declaration_forms,
+            only: [:new, :create],
+            path: "declaration",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+              to: "declaration_forms#go_back",
+              as: "back",
+              on: :collection
+            end
+
   # See http://patrickperey.com/railscast-053-handling-exceptions/
   get "(errors)/:id", to: "errors#show", as: "error"
 

--- a/db/migrate/20190104133305_add_declaration_to_enrollments.rb
+++ b/db/migrate/20190104133305_add_declaration_to_enrollments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeclarationToEnrollments < ActiveRecord::Migration
+  def change
+    add_column :enrollments, :declaration, :boolean
+  end
+end


### PR DESCRIPTION
Using the WCR declaration as a model, we implement it here but update the content to match WEX's declaration page.

We also fix an issue found with the check details page, caused by the fact that `is_a_farm` and `on_a_farm` are stored as boolean's, though when we validate them in their own forms the params are passed as strings (hence the confusion around what validation to use).