### PR TITLE
Add registration complete page

### DIFF
--- a/app/controllers/waste_exemptions_engine/registration_complete_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/registration_complete_forms_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RegistrationCompleteFormsController < FormsController
+    def new
+      return unless super(RegistrationCompleteForm, "registration_complete_form")
+    end
+
+    # Overwrite create and go_back as you shouldn't be able to submit or go back
+    def create; end
+
+    def go_back; end
+  end
+end

--- a/app/forms/waste_exemptions_engine/registration_complete_form.rb
+++ b/app/forms/waste_exemptions_engine/registration_complete_form.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RegistrationCompleteForm < BaseForm
+
+    attr_accessor :reference, :exemptions_plural, :contact_email
+
+    def initialize(enrollment)
+      super
+      self.reference = @enrollment.reference
+      self.exemptions_plural = @enrollment.exemptions.length > 1 ? "many" : "one"
+      self.contact_email = @enrollment.contact_email
+    end
+
+    # Override BaseForm method as users shouldn't be able to submit this form
+    def submit; end
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_exemption_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_exemption_status.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module CanChangeExemptionStatus
+    extend ActiveSupport::Concern
+
+    included do
+      include AASM
+
+      aasm column: :state do
+        state :pending, initial: true
+        state :active
+        state :ceased
+        state :expired
+        state :revoked
+
+        event :activate do
+          transitions from: :pending,
+                      to: :active,
+                      after: :activate_exemption
+        end
+
+      end
+
+      # Transition effects
+      def activate_exemption
+        self.registered_on = Date.today
+        self.expires_on = Date.today + (Rails.configuration.years_before_expiry.years - 1.day)
+        save!
+      end
+    end
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_workflow_status.rb
@@ -61,8 +61,11 @@ module WasteExemptionsEngine
         state :site_address_manual_form
 
         state :exemptions_form
+
+        # End pages
         state :check_your_answers_form
         state :declaration_form
+        state :registration_complete_form
 
         # Transitions
         event :next do
@@ -198,6 +201,10 @@ module WasteExemptionsEngine
 
           transitions from: :check_your_answers_form,
                       to: :declaration_form
+
+          transitions from: :declaration_form,
+                      to: :registration_complete_form,
+                      after: :activate_exemptions
         end
 
         event :back do
@@ -402,6 +409,12 @@ module WasteExemptionsEngine
 
     def skip_to_manual_address?
       interim.address_finder_error
+    end
+
+    def activate_exemptions
+      Enrollment.transaction do
+        enrollment_exemptions.each(&:activate)
+      end
     end
   end
 end

--- a/app/models/waste_exemptions_engine/enrollment.rb
+++ b/app/models/waste_exemptions_engine/enrollment.rb
@@ -9,7 +9,7 @@ module WasteExemptionsEngine
     # We want to create the interim record at the same time as the enrollment
     # is initialized. With activerecord objects overriding the initializer is
     # seen as an anti-pattern, so instead we rely on its callbacks.
-    after_create :create_interim
+    after_create :create_interim, :apply_reference
 
     # HasSecureToken provides an easy way to generate unique random tokens for
     # any model in ruby on rails. We use it to uniquely identify an enrollment
@@ -49,6 +49,11 @@ module WasteExemptionsEngine
       return nil unless addresses.present?
 
       addresses.where(address_type: address_type).first
+    end
+
+    def apply_reference
+      self.reference = format("WEX%06d", id)
+      save!
     end
   end
 end

--- a/app/models/waste_exemptions_engine/enrollment_exemption.rb
+++ b/app/models/waste_exemptions_engine/enrollment_exemption.rb
@@ -2,6 +2,7 @@
 
 module WasteExemptionsEngine
   class EnrollmentExemption < ActiveRecord::Base
+    include CanChangeExemptionStatus
 
     self.table_name = "enrollment_exemptions"
 

--- a/app/views/waste_exemptions_engine/registration_complete_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/registration_complete_forms/new.html.erb
@@ -1,0 +1,42 @@
+<div class="column-two-thirds">
+<% if @registration_complete_form.errors.any? %>
+
+  <h1 class="heading-large"><%= t(".error_heading") %></h1>
+
+  <% @registration_complete_form.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+  <% end %>
+
+<% else %>
+
+  <%= form_for(@registration_complete_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @registration_complete_form) %>
+
+    <div class="govuk-box-highlight">
+      <h1 class="heading-xlarge"><%= t(".heading") %></h1>
+      <p class="font-large"><%= t(".highlight_text") %><br><span class="strong"><%= @registration_complete_form.reference %></span></p>
+    </div>
+
+    <p><%= t(".confirmation_email_text", email: @registration_complete_form.contact_email) %></p>
+
+    <h2 class="heading-medium"><%= t(".what_happens_next.subheading") %></h2>
+
+    <ul class="list list-bullet">
+      <li><%= t(".what_happens_next.bullet_1") %></li>
+      <li><%= t(".what_happens_next.bullet_2_#{@registration_complete_form.exemptions_plural}") %></li>
+    </ul>
+
+    <h2 class="heading-medium"><%= t(".registration_checks.subheading") %></h2>
+    <p><%= t(".registration_checks.note") %></p>
+
+    <div class="panel panel-border-wide">
+      <p><%= t(".call_helpline_text") %></p>
+    </div>
+
+    <p><%= link_to(t(".survey_link_text"), t("layouts.application.feedback_url")) %> <%= t(".survey_link_hint") %></p>
+
+    <%= f.hidden_field :token, value: @registration_complete_form.token %>
+  <% end %>
+
+<% end %>
+</div>

--- a/config/locales/forms/registration_complete_forms/en.yml
+++ b/config/locales/forms/registration_complete_forms/en.yml
@@ -1,0 +1,32 @@
+en:
+  waste_exemptions_engine:
+    registration_complete_forms:
+      new:
+        title: Registration complete
+        heading: Registration complete
+        highlight_text: "Your registration number is"
+        confirmation_email_text: "We have sent a confirmation email to %{email}."
+        what_happens_next:
+          subheading: What happens next
+          bullet_1: |
+            your organisation’s details will be processed and appear on the public register within 5 days
+          bullet_2_one: we’ll send a renewal reminder when this waste exemption is due to expire
+          bullet_2_many: we’ll send a renewal reminder when these waste exemptions are due to expire
+        registration_checks:
+          subheading: Registration checks
+          note: |
+            Waste exemption registrations are subject to checks. Deliberately providing false details, or not complying with exemption rules, can lead to de-registration and prosecution.
+        paragraph_6: If any of your details change you must update your registration within 28 days.
+        call_helpline_text: Call our helpline on 03708 506 506 if you have any questions about your registration.
+        survey_link_text: What do you think of this service?
+        survey_link_hint: (takes 30 seconds)
+        error_heading: Something is wrong
+        next_button: Finished
+  activemodel:
+    errors:
+      models:
+        waste_carriers_engine/registration_complete_form:
+          attributes:
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -342,6 +342,11 @@ WasteExemptionsEngine::Engine.routes.draw do
               on: :collection
             end
 
+  resources :registration_complete_forms,
+            only: [:new, :create],
+            path: "registration-complete",
+            path_names: { new: "/:token" }
+
   # See http://patrickperey.com/railscast-053-handling-exceptions/
   get "(errors)/:id", to: "errors#show", as: "error"
 

--- a/db/migrate/20190104151459_add_reference_to_enrollments.rb
+++ b/db/migrate/20190104151459_add_reference_to_enrollments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReferenceToEnrollments < ActiveRecord::Migration
+  def change
+    add_column :enrollments, :reference, :string
+  end
+end

--- a/db/migrate/20190104153628_add_date_fields_to_enrollment_exemptions.rb
+++ b/db/migrate/20190104153628_add_date_fields_to_enrollment_exemptions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDateFieldsToEnrollmentExemptions < ActiveRecord::Migration
+  def change
+    add_column :enrollment_exemptions, :registered_on, :date
+    add_column :enrollment_exemptions, :expires_on, :date
+  end
+end

--- a/db/migrate/20190104154234_add_status_to_enrollment_exemptions.rb
+++ b/db/migrate/20190104154234_add_status_to_enrollment_exemptions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStatusToEnrollmentExemptions < ActiveRecord::Migration
+  def change
+    add_column :enrollment_exemptions, :state, :string
+  end
+end


### PR DESCRIPTION
Taking the logic of Waste Carriers we have updated the content to match the waste exemptions registration complete page.

Part of the changes require us for the first time to mark state of the exemption (active, ceased, revoked, expired etc) plus the dates it was registered and will expire. We also need to handle generating the reference number for the enrollment.

As with Waste Carriers, wherever we have to record and transition state in an entity we use a state machine. Hence the introduction of `can_change_exemption_status` in this change.