### PR TITLE
Fix copy for org. name and validtion header

### DIFF
--- a/config/locales/forms/applicant_email_forms/en.yml
+++ b/config/locales/forms/applicant_email_forms/en.yml
@@ -4,7 +4,7 @@ en:
       new:
         title: Your email address
         heading: What is your contact email address?
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         contact_email_label: Email address
         confirmed_email_label: Confirm email address
         next_button: Continue

--- a/config/locales/forms/applicant_name_forms/en.yml
+++ b/config/locales/forms/applicant_name_forms/en.yml
@@ -7,7 +7,7 @@ en:
         description: Please enter your name, even if you’re an agent, employee or other third-party
         first_name_label: First name
         last_name_label: Last name
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/applicant_phone_forms/en.yml
+++ b/config/locales/forms/applicant_phone_forms/en.yml
@@ -6,7 +6,7 @@ en:
         heading: What is your telephone number?
         phone_number_label: Telephone number
         phone_number_hint: This can be a landline or mobile
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/business_type_forms/en.yml
+++ b/config/locales/forms/business_type_forms/en.yml
@@ -13,7 +13,7 @@ en:
           local_authority: Local authority or public body
           charity: Charity or trust
         help: Not sure? Call our helpline on 03708 506 506.
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/check_your_answers_forms/en.yml
+++ b/config/locales/forms/check_your_answers_forms/en.yml
@@ -4,7 +4,7 @@ en:
       new:
         title: Check your details
         heading: Check your answers before completing your registration
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         error_description_1: "We're missing some of the information we need to complete your registration:"
         error_description_2: "Please go back and make sure all the required questions have been answered."
         description: We will send a copy of this summary in a confirmation email

--- a/config/locales/forms/contact_address_lookup_forms/en.yml
+++ b/config/locales/forms/contact_address_lookup_forms/en.yml
@@ -7,7 +7,7 @@ en:
         postcode_label: Postcode
         postcode_change_link: "Change postcode"
         manual_address_link: "I cannot find the address in the list"
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/contact_address_manual_forms/en.yml
+++ b/config/locales/forms/contact_address_manual_forms/en.yml
@@ -8,7 +8,7 @@ en:
         postcode_change_link: "Change postcode"
         address_finder_error_heading: Our address finder is not working
         address_finder_error_text: Please enter the address below.
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/contact_email_forms/en.yml
+++ b/config/locales/forms/contact_email_forms/en.yml
@@ -4,7 +4,7 @@ en:
       new:
         title: Contact email address
         heading: What is the contact's email address?
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         contact_email_label: Email address
         confirmed_email_label: Confirm email address
         next_button: Continue

--- a/config/locales/forms/contact_name_forms/en.yml
+++ b/config/locales/forms/contact_name_forms/en.yml
@@ -7,7 +7,7 @@ en:
         description: We will contact this person if we need to discuss the waste operation
         first_name_label: First name
         last_name_label: Last name
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/contact_phone_forms/en.yml
+++ b/config/locales/forms/contact_phone_forms/en.yml
@@ -6,7 +6,7 @@ en:
         heading: What is the contact's telephone number?
         phone_number_label: Telephone number
         phone_number_hint: This can be a landline or mobile
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/contact_position_forms/en.yml
+++ b/config/locales/forms/contact_position_forms/en.yml
@@ -6,7 +6,7 @@ en:
         heading: What is their position?
         position_label: Position (optional)
         position_hint: For example, Manager
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/declaration_forms/en.yml
+++ b/config/locales/forms/declaration_forms/en.yml
@@ -10,7 +10,7 @@ en:
         declaration_text: I understand and agree with the declaration above
         privacy_link_text: "Privacy: how we use your personal information (opens new tab)"
         alt_text: Important message
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/is_a_farm_forms/en.yml
+++ b/config/locales/forms/is_a_farm_forms/en.yml
@@ -7,7 +7,7 @@ en:
         options:
           "yes": "Yes"
           "no": "No"
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/on_a_farm_forms/en.yml
+++ b/config/locales/forms/on_a_farm_forms/en.yml
@@ -7,7 +7,7 @@ en:
         options:
           "yes": "Yes"
           "no": "No"
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/operator_address_lookup_forms/en.yml
+++ b/config/locales/forms/operator_address_lookup_forms/en.yml
@@ -13,7 +13,7 @@ en:
         postcode_label: Postcode
         postcode_change_link: "Change postcode"
         manual_address_link: "I cannot find the address in the list"
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/operator_address_manual_forms/en.yml
+++ b/config/locales/forms/operator_address_manual_forms/en.yml
@@ -14,7 +14,7 @@ en:
         postcode_change_link: "Change postcode"
         address_finder_error_heading: Our address finder is not working
         address_finder_error_text: Please enter the address below.
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/operator_name_forms/en.yml
+++ b/config/locales/forms/operator_name_forms/en.yml
@@ -5,22 +5,19 @@ en:
         title: Operator name
         heading:
           localAuthority: What's the name of the local authority or public body?
-          limitedCompany: What's the name of the company?
-          limitedLiabilityPartnership: What's the name of the limited liability partnership?
-          overseas: What's the name of the business or organisation?
+          limitedCompany: What's the registered name of the company?
+          limitedLiabilityPartnership: What's the registered name of the limited liability partnership?
           partnership: What's the name of the partnership?
           soleTrader: Who’s carrying out the waste operation?
           charity: What's the name of the charity or trust?
         description: This is the name of the operator responsible for the waste operation
         operator_name_label:
           localAuthority: Local authority or public body name
-          limitedCompany: Company trading name
-          limitedLiabilityPartnership: Partnership trading name
-          overseas: Trading name
-          partnership: Partnership trading name
+          limitedCompany: Registered company name
+          partnership: Partnership name
           soleTrader: Full name
           charity: Charity or trust name
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/registration_complete_forms/en.yml
+++ b/config/locales/forms/registration_complete_forms/en.yml
@@ -20,7 +20,7 @@ en:
         call_helpline_text: Call our helpline on 03708 506 506 if you have any questions about your registration.
         survey_link_text: What do you think of this service?
         survey_link_hint: (takes 30 seconds)
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Finished
   activemodel:
     errors:

--- a/config/locales/forms/registration_number_forms/en.yml
+++ b/config/locales/forms/registration_number_forms/en.yml
@@ -15,7 +15,7 @@ en:
         explanation:
           limitedCompany: We'll look this number up in the Companies House register to make sure it belongs to an active company.
           limitedLiabilityPartnership: We'll look this number up in the Companies House register to make sure it belongs to an active limited liability partnership.
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/site_address_lookup_forms/en.yml
+++ b/config/locales/forms/site_address_lookup_forms/en.yml
@@ -7,7 +7,7 @@ en:
         postcode_label: Postcode
         postcode_change_link: "Change postcode"
         manual_address_link: "I cannot find the address in the list"
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:

--- a/config/locales/forms/site_address_manual_forms/en.yml
+++ b/config/locales/forms/site_address_manual_forms/en.yml
@@ -8,7 +8,7 @@ en:
         postcode_change_link: "Change postcode"
         address_finder_error_heading: Our address finder is not working
         address_finder_error_text: Please enter the address below.
-        error_heading: Something is wrong
+        error_heading: A problem to fix
         next_button: Continue
   activemodel:
     errors:


### PR DESCRIPTION
This change does 2 things

- it corrects the copy for the operator name to ensure we are asking for the registered or official name and never a trading name
- it makes the heading when a validation error(s) occur consistent across all pages.