### PR TITLE
Implement configuration in the engine

### DIFF
--- a/app/mailers/waste_exemptions_engine/confirmation_mailer.rb
+++ b/app/mailers/waste_exemptions_engine/confirmation_mailer.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
 
       mail(
         to: recipient_email_address,
-        from: "#{Rails.configuration.service_name} <#{Rails.configuration.email_service_email}>",
+        from: "#{WasteExemptionsEngine.service_name} <#{WasteExemptionsEngine.email_service_email}>",
         subject: I18n.t(".waste_exemptions_engine.confirmation_mailer.send_confirmation_email.subject",
                         reference: @registration.reference)
       )

--- a/app/models/concerns/waste_exemptions_engine/can_change_exemption_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_exemption_status.rb
@@ -25,7 +25,7 @@ module WasteExemptionsEngine
       # Transition effects
       def activate_exemption
         self.registered_on = Date.today
-        self.expires_on = Date.today + (Rails.configuration.years_before_expiry.years - 1.day)
+        self.expires_on = Date.today + (WasteExemptionsEngine.years_before_expiry.years - 1.day)
         save!
       end
     end

--- a/app/presenters/waste_exemptions_engine/certificate_presenter.rb
+++ b/app/presenters/waste_exemptions_engine/certificate_presenter.rb
@@ -34,7 +34,7 @@ module WasteExemptionsEngine
 
     def expires_after_pluralized
       ActionController::Base.helpers.pluralize(
-        Rails.configuration.years_before_expiry,
+        WasteExemptionsEngine.years_before_expiry,
         I18n.t("#{LOCALES_KEY}.changes.year")
       )
     end

--- a/app/services/waste_exemptions_engine/address_finder_service.rb
+++ b/app/services/waste_exemptions_engine/address_finder_service.rb
@@ -7,7 +7,7 @@ module WasteExemptionsEngine
     def initialize(postcode)
       # Strip out non-alphanumeric characters
       @postcode = postcode.gsub(/[^a-z0-9]/i, "")
-      @url = Rails.configuration.addressbase_url +
+      @url = WasteExemptionsEngine.addressbase_url +
              "/address-service/v1/addresses/postcode?postcode=#{@postcode}&client-id=0&key=client1"
     end
 

--- a/app/services/waste_exemptions_engine/companies_house_service.rb
+++ b/app/services/waste_exemptions_engine/companies_house_service.rb
@@ -6,8 +6,8 @@ module WasteExemptionsEngine
   class CompaniesHouseService
     def initialize(company_no)
       @company_no = company_no
-      @url = "#{Rails.configuration.companies_house_host}#{@company_no}"
-      @api_key = Rails.configuration.companies_house_api_key
+      @url = "#{WasteExemptionsEngine.companies_house_host}#{@company_no}"
+      @api_key = WasteExemptionsEngine.companies_house_api_key
     end
 
     def status

--- a/app/views/pages/version.html.erb
+++ b/app/views/pages/version.html.erb
@@ -1,12 +1,12 @@
 <% content_for :title, "Version" %>
 
 <div class="text">
-  <h1 class="heading-large"><%= Rails.configuration.application_name %></h1>
+  <h1 class="heading-large"><%= WasteExemptionsEngine.application_name %></h1>
   <p>
     <label><%= t(".commit") %></label>
     <strong>
       <%= link_to(current_git_commit,
-                  "#{Rails.configuration.git_repository_url}\/commit\/#{current_git_commit}",
+                  "#{WasteExemptionsEngine.git_repository_url}\/commit\/#{current_git_commit}",
                   target: "_blank",
                   class: "btn-link") %>
     </strong>

--- a/app/views/waste_exemptions_engine/confirmation_mailer/send_confirmation_email.html.erb
+++ b/app/views/waste_exemptions_engine/confirmation_mailer/send_confirmation_email.html.erb
@@ -12,7 +12,7 @@
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
   <!-- Use title if it's in the page YAML frontmatter -->
-  <title><%= Rails.configuration.service_name %></title>
+  <title><%= WasteExemptionsEngine.service_name %></title>
 </head>
 
 <body style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; color: #0b0c0c">

--- a/config/initializers/wickedpdf.rb
+++ b/config/initializers/wickedpdf.rb
@@ -2,7 +2,7 @@
 
 require "wicked_pdf"
 
-if ENV["USE_XVFB_FOR_WICKEDPDF"] == "true"
+if WasteExemptionsEngine.use_xvfb_for_wickedpdf == "true"
   WickedPdf.config = {
     exe_path: WasteExemptionsEngine::Engine.root.join("script", "wkhtmltopdf.sh").to_s
   }

--- a/lib/waste_exemptions_engine.rb
+++ b/lib/waste_exemptions_engine.rb
@@ -3,4 +3,34 @@
 require "waste_exemptions_engine/engine"
 
 module WasteExemptionsEngine
+
+  # Configuration pattern based on
+  # https://guides.rubyonrails.org/engines.html#configuring-an-engine
+
+  # General config
+  mattr_accessor :service_name do
+    "Waste Exemptions Service"
+  end
+  mattr_accessor :application_name
+  mattr_accessor :git_repository_url
+  mattr_accessor :years_before_expiry do
+    3
+  end
+
+  # Companies house API config
+  mattr_accessor :companies_house_host do
+    "https://api.companieshouse.gov.uk/company/"
+  end
+  mattr_accessor :companies_house_api_key
+
+  # Addressbase config
+  mattr_accessor :addressbase_url
+
+  # Email config
+  mattr_accessor :email_service_email
+
+  # PDF config
+  mattr_accessor :use_xvfb_for_wickedpdf do
+    "true"
+  end
 end


### PR DESCRIPTION
Prior to this change configuration was essentially reading env vars directly, or assuming that the host application had set something in its application.rb and made it available via `Rails.configuration`.

As we started to look at adding our missing tests, we realised that we'd have to adopt this same pattern in our dummy app if we wanted this to work.

Ideally we want never to have to touch the code generated for the dummy app, hence we went looking for an alternative.

https://guides.rubyonrails.org/engines.html#configuring-an-engine details how to go about providing configuration for an engine, and this not only solved the test problem but also felt like a better approach.

Hence these changes implement the mechanism to allow a host application to pass in config values, and updates the code in the engine to use them rather than `Rails.configuration`.