### PR TITLE
Improve exemptions dates in PDF certificate

### DIFF
--- a/app/views/waste_exemptions_engine/pdfs/certificate.html.erb
+++ b/app/views/waste_exemptions_engine/pdfs/certificate.html.erb
@@ -165,10 +165,14 @@
               </tr>
             </thead>
             <tbody>
+              <tr>
+                <td><%=t ".exemption.expires_label" %></td>
+                <td>&nbsp;</td>
+              </tr>
               <% @presenter.registration_exemptions.each do |registration_exemption| %>
                 <% exemption = registration_exemption.exemption %>
                 <tr>
-                  <td class="table-column-text"><%=t ".exemption.expires", expires_on: registration_exemption.expires_on.in_time_zone("London").to_date %></td>
+                  <td class="table-column-text"><%= registration_exemption.expires_on.to_formatted_s(:day_month_year) %></td>
                   <td><%= "#{exemption.code} - #{exemption.summary}" %></td>
                 </tr>
               <% end %>

--- a/config/locales/pdfs/certificate.en.yml
+++ b/config/locales/pdfs/certificate.en.yml
@@ -33,8 +33,8 @@ en:
           location_description: Location description
           address: Site address
         exemption:
-          heading: Exemption Details
-          expires: Expires on %{expires_on}
+          heading: Exemption details
+          expires_label: Expires on
         changes:
           heading: "Making changes to your registration"
           paragraph1: "Your registration will last %{expires_after_pluralized} and will need to be re-registered after this period. If any of your details change, you must notify us within 28 days of the change."


### PR DESCRIPTION
Prior to this change the expires on date for each exemption was displayed in the formatt YYYY-MM-DD. To be consistent with other dates in the certificate we wanted to change this to be 'January 22 2019'.

The longer format would have forced each exemption to cover 2 lines, so we also tweeked the formatting of the exemption details section and how the date is shown in each row.