### PR TITLE
Remove notice icon from declaration page

### DIFF
--- a/app/views/waste_exemptions_engine/declaration_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/declaration_forms/new.html.erb
@@ -6,12 +6,7 @@
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
-    <div class="icon heading-with-border">
-      <div class="icon-important inline">
-        <%= image_tag "icon-important-2x.png", alt: t('.alt_text') %>
-      </div>
-      <span class="heading-small inline"><%= t '.notice' %></span>
-    </div>
+    <p class="heading-small inline"><%= t '.notice' %></p>
 
     <ul class="list list-bullet">
       <li><%= t(".list_item_1") %></li>


### PR DESCRIPTION
We were having trouble aligning the icon to some text in the declaration page, when it was highlighted that we don't use any icons in the Waste carriers renewals declaration page.

Therefore to keep the services consistent this change removes the image (and therefore the problem) from the declaration page.