### PR TITLE
Fix site validation in check answers page

### DIFF
--- a/app/forms/waste_exemptions_engine/check_your_answers_form.rb
+++ b/app/forms/waste_exemptions_engine/check_your_answers_form.rb
@@ -83,9 +83,20 @@ module WasteExemptionsEngine
 
     validates :is_a_farm, inclusion: { in: [true, false] }
     validates :on_a_farm, inclusion: { in: [true, false] }
-    validates :grid_reference, "waste_exemptions_engine/grid_reference": true
-    validates :site_description, "waste_exemptions_engine/site_description": true
     validates :exemptions, "waste_exemptions_engine/exemptions": true
 
+    validates :grid_reference, "waste_exemptions_engine/grid_reference": true, if: :uses_site_location?
+    validates :site_description, "waste_exemptions_engine/site_description": true, if: :uses_site_location?
+    validates :site_address, "waste_exemptions_engine/address": true, unless: :uses_site_location?
+
+    private
+
+    def uses_site_location?
+      # This should never happen, but if there is no site address we default
+      # to validating the site grid reference and description
+      return true unless @transient_registration&.site_address
+
+      @transient_registration.site_address.auto?
+    end
   end
 end

--- a/app/presenters/waste_exemptions_engine/certificate_presenter.rb
+++ b/app/presenters/waste_exemptions_engine/certificate_presenter.rb
@@ -40,7 +40,7 @@ module WasteExemptionsEngine
     end
 
     def site_is_grid_reference?
-      site_address.grid_reference.present?
+      site_address.auto?
     end
 
     def list_people


### PR DESCRIPTION
Because of the way we had the validation configured previously it was only letting us enter a site location using grid reference and description.

This change adds a conditional to the validation i.e. if the site was set using a grid reference use one set of validation, else use the other.