### PR TITLE
Add scope for searching registrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
   # needs to be in place before we run the migrations.
   - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
   - RAILS_ENV=test bundle exec rake db:create --trace
+  - RAILS_ENV=test bundle exec rake db:migrate --trace
 
 after_script:
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,7 @@ source "https://rubygems.org"
 # development dependencies will be added by default to the :development group.
 gemspec
 
-# Declare any dependencies that are still in development here instead of in
-# your gemspec. These might include edge Rails or gems from your path or
-# Git. Remember to move these dependencies to your gemspec before releasing
-# your gem to rubygems.org.
-
-# To use a debugger
-# gem 'byebug', group: [:development, :test]
+group :test do
+  gem "database_cleaner"
+  gem "vcr", "~> 4.0"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ DEPENDENCIES
   rspec-rails (~> 3.8.0)
   simplecov
   timecop
-  vcr
+  vcr (~> 4.0)
   waste_exemptions_engine!
   webmock
 

--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -10,5 +10,8 @@ module WasteExemptionsEngine
     enum address_type: { unknown: 0, operator: 1, contact: 2, site: 3 }
     enum mode: { unknown_mode: 0, lookup: 1, manual: 2, auto: 3 }
 
+    scope :search_term, lambda { |term|
+      where("UPPER(postcode) LIKE ?", "%#{term&.upcase}%")
+    }
   end
 end

--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -13,5 +13,7 @@ module WasteExemptionsEngine
     scope :search_term, lambda { |term|
       where("UPPER(postcode) LIKE ?", "%#{term&.upcase}%")
     }
+
+    scope :site, -> { where(address_type: 3) }
   end
 end

--- a/app/models/waste_exemptions_engine/person.rb
+++ b/app/models/waste_exemptions_engine/person.rb
@@ -9,5 +9,8 @@ module WasteExemptionsEngine
 
     enum person_type: { partner: 0 }
 
+    scope :search_term, lambda { |term|
+      where("UPPER(CONCAT(first_name, ' ', last_name)) LIKE ?", "%#{term&.upcase}%")
+    }
   end
 end

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -13,7 +13,8 @@ module WasteExemptionsEngine
 
     scope :search_term, lambda { |term|
       where(
-        "UPPER(applicant_email) = ? OR UPPER(reference) = ?",
+        "UPPER(applicant_email) = ? OR UPPER(contact_email) = ? OR UPPER(reference) = ?",
+        term&.upcase,
         term&.upcase,
         term&.upcase
       )

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -14,13 +14,15 @@ module WasteExemptionsEngine
     scope :search_term, lambda { |term|
       where(
         "UPPER(applicant_email) = ?\
+         OR UPPER(CONCAT(applicant_first_name, ' ', applicant_last_name)) LIKE ?\
          OR UPPER(contact_email) = ?\
          OR UPPER(operator_name) = ?\
          OR UPPER(reference) = ?",
-        term&.upcase,
-        term&.upcase,
-        term&.upcase,
-        term&.upcase
+        term&.upcase, # applicant_email
+        "%#{term&.upcase}%", # applicant names
+        term&.upcase, # contact_email
+        term&.upcase, # operator_name
+        term&.upcase # reference
       )
     }
 

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -17,13 +17,13 @@ module WasteExemptionsEngine
          OR UPPER(CONCAT(applicant_first_name, ' ', applicant_last_name)) LIKE ?\
          OR UPPER(contact_email) = ?\
          OR UPPER(CONCAT(contact_first_name, ' ', contact_last_name)) LIKE ?\
-         OR UPPER(operator_name) = ?\
+         OR UPPER(operator_name) LIKE ?\
          OR UPPER(reference) = ?",
         term&.upcase, # applicant_email
         "%#{term&.upcase}%", # applicant names
         term&.upcase, # contact_email
         "%#{term&.upcase}%", # contact names
-        term&.upcase, # operator_name
+        "%#{term&.upcase}%", # operator_name
         term&.upcase # reference
       )
     }

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -12,7 +12,7 @@ module WasteExemptionsEngine
     has_many :exemptions, through: :registration_exemptions
 
     scope :search_term, lambda { |term|
-      where("reference = ?", term)
+      where("reference = ?", term&.upcase)
     }
 
     private

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -28,6 +28,10 @@ module WasteExemptionsEngine
       )
     }
 
+    scope :search_term_on_people, lambda { |term|
+      joins(:people).merge(Person.search_term(term))
+    }
+
     private
 
     def find_address_by_type(address_type)

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -12,7 +12,11 @@ module WasteExemptionsEngine
     has_many :exemptions, through: :registration_exemptions
 
     scope :search_term, lambda { |term|
-      where("reference = ?", term&.upcase)
+      where(
+        "UPPER(applicant_email) = ? OR UPPER(reference) = ?",
+        term&.upcase,
+        term&.upcase
+      )
     }
 
     private

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -15,7 +15,9 @@ module WasteExemptionsEngine
       where(
         "UPPER(applicant_email) = ?\
          OR UPPER(contact_email) = ?\
+         OR UPPER(operator_name) = ?\
          OR UPPER(reference) = ?",
+        term&.upcase,
         term&.upcase,
         term&.upcase,
         term&.upcase

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -11,6 +11,10 @@ module WasteExemptionsEngine
     has_many :registration_exemptions
     has_many :exemptions, through: :registration_exemptions
 
+    scope :search_term, lambda { |term|
+      where("reference = ?", term)
+    }
+
     private
 
     def find_address_by_type(address_type)

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
 
     scope :search_term, lambda { |term|
       where(id: search_term_on_registration(term).ids +
-                search_term_on_addresses(term).ids +
+                search_term_on_site_addresses(term).ids +
                 search_term_on_people(term).ids)
     }
 
@@ -36,8 +36,8 @@ module WasteExemptionsEngine
       )
     }
 
-    scope :search_term_on_addresses, lambda { |term|
-      joins(:addresses).merge(Address.search_term(term))
+    scope :search_term_on_site_addresses, lambda { |term|
+      joins(:addresses).merge(Address.search_term(term).site)
     }
 
     scope :search_term_on_people, lambda { |term|

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -13,7 +13,9 @@ module WasteExemptionsEngine
 
     scope :search_term, lambda { |term|
       where(
-        "UPPER(applicant_email) = ? OR UPPER(contact_email) = ? OR UPPER(reference) = ?",
+        "UPPER(applicant_email) = ?\
+         OR UPPER(contact_email) = ?\
+         OR UPPER(reference) = ?",
         term&.upcase,
         term&.upcase,
         term&.upcase

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -28,6 +28,10 @@ module WasteExemptionsEngine
       )
     }
 
+    scope :search_term_on_addresses, lambda { |term|
+      joins(:addresses).merge(Address.search_term(term))
+    }
+
     scope :search_term_on_people, lambda { |term|
       joins(:people).merge(Person.search_term(term))
     }

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -16,11 +16,13 @@ module WasteExemptionsEngine
         "UPPER(applicant_email) = ?\
          OR UPPER(CONCAT(applicant_first_name, ' ', applicant_last_name)) LIKE ?\
          OR UPPER(contact_email) = ?\
+         OR UPPER(CONCAT(contact_first_name, ' ', contact_last_name)) LIKE ?\
          OR UPPER(operator_name) = ?\
          OR UPPER(reference) = ?",
         term&.upcase, # applicant_email
         "%#{term&.upcase}%", # applicant names
         term&.upcase, # contact_email
+        "%#{term&.upcase}%", # contact names
         term&.upcase, # operator_name
         term&.upcase # reference
       )

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,0 +1,4 @@
+test:
+  adapter: postgresql
+  database: travis_ci_test
+  username: postgres

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,0 +1,192 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20190121092357) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "addresses", force: :cascade do |t|
+    t.integer  "address_type",        default: 0
+    t.integer  "mode",                default: 0
+    t.string   "uprn"
+    t.string   "organisation"
+    t.string   "premises"
+    t.string   "street_address"
+    t.string   "locality"
+    t.string   "city"
+    t.string   "postcode"
+    t.float    "x"
+    t.float    "y"
+    t.string   "coordinate_system"
+    t.string   "blpu_state_code"
+    t.string   "postal_address_code"
+    t.string   "logical_status_code"
+    t.string   "source_data_type"
+    t.string   "country_iso"
+    t.string   "grid_reference"
+    t.text     "description"
+    t.integer  "registration_id"
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+  end
+
+  add_index "addresses", ["registration_id"], name: "index_addresses_on_registration_id", using: :btree
+
+  create_table "exemptions", force: :cascade do |t|
+    t.integer "category"
+    t.string  "code"
+    t.string  "url"
+    t.string  "summary"
+    t.text    "description"
+    t.text    "guidance"
+  end
+
+  create_table "people", force: :cascade do |t|
+    t.string   "first_name"
+    t.string   "last_name"
+    t.integer  "person_type"
+    t.integer  "registration_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "people", ["registration_id"], name: "index_people_on_registration_id", using: :btree
+
+  create_table "registration_exemptions", force: :cascade do |t|
+    t.string   "state"
+    t.date     "registered_on"
+    t.date     "expires_on"
+    t.integer  "registration_id"
+    t.integer  "exemption_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "registration_exemptions", ["exemption_id"], name: "index_registration_exemptions_on_exemption_id", using: :btree
+  add_index "registration_exemptions", ["registration_id"], name: "index_registration_exemptions_on_registration_id", using: :btree
+
+  create_table "registrations", force: :cascade do |t|
+    t.string   "reference"
+    t.string   "location"
+    t.string   "applicant_first_name"
+    t.string   "applicant_last_name"
+    t.string   "applicant_phone"
+    t.string   "applicant_email"
+    t.string   "business_type"
+    t.string   "operator_name"
+    t.string   "company_no"
+    t.string   "contact_first_name"
+    t.string   "contact_last_name"
+    t.string   "contact_position"
+    t.string   "contact_phone"
+    t.string   "contact_email"
+    t.boolean  "is_a_farm"
+    t.boolean  "on_a_farm"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+    t.date     "submitted_at"
+  end
+
+  add_index "registrations", ["reference"], name: "index_registrations_on_reference", unique: true, using: :btree
+
+  create_table "transient_addresses", force: :cascade do |t|
+    t.integer  "address_type",              default: 0
+    t.integer  "mode",                      default: 0
+    t.string   "uprn"
+    t.string   "organisation"
+    t.string   "premises"
+    t.string   "street_address"
+    t.string   "locality"
+    t.string   "city"
+    t.string   "postcode"
+    t.float    "x"
+    t.float    "y"
+    t.string   "coordinate_system"
+    t.string   "blpu_state_code"
+    t.string   "postal_address_code"
+    t.string   "logical_status_code"
+    t.string   "source_data_type"
+    t.string   "country_iso"
+    t.string   "grid_reference"
+    t.text     "description"
+    t.integer  "transient_registration_id"
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+  end
+
+  add_index "transient_addresses", ["transient_registration_id"], name: "index_transient_addresses_on_transient_registration_id", using: :btree
+
+  create_table "transient_people", force: :cascade do |t|
+    t.string   "first_name"
+    t.string   "last_name"
+    t.integer  "person_type"
+    t.integer  "transient_registration_id"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "transient_people", ["transient_registration_id"], name: "index_transient_people_on_transient_registration_id", using: :btree
+
+  create_table "transient_registration_exemptions", force: :cascade do |t|
+    t.string   "state"
+    t.date     "registered_on"
+    t.date     "expires_on"
+    t.integer  "transient_registration_id"
+    t.integer  "exemption_id"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "transient_registration_exemptions", ["exemption_id"], name: "index_transient_registration_exemptions_on_exemption_id", using: :btree
+  add_index "transient_registration_exemptions", ["transient_registration_id"], name: "index_trans_reg_exemptions_on_transient_registration_id", using: :btree
+
+  create_table "transient_registrations", force: :cascade do |t|
+    t.string   "token"
+    t.string   "reference"
+    t.string   "workflow_state"
+    t.string   "start_option"
+    t.string   "location"
+    t.string   "applicant_first_name"
+    t.string   "applicant_last_name"
+    t.string   "applicant_phone"
+    t.string   "applicant_email"
+    t.string   "business_type"
+    t.string   "operator_name"
+    t.string   "company_no"
+    t.string   "contact_first_name"
+    t.string   "contact_last_name"
+    t.string   "contact_position"
+    t.string   "contact_phone"
+    t.string   "contact_email"
+    t.boolean  "is_a_farm"
+    t.boolean  "on_a_farm"
+    t.boolean  "declaration"
+    t.string   "temp_operator_postcode"
+    t.string   "temp_contact_postcode"
+    t.string   "temp_site_postcode"
+    t.string   "temp_grid_reference"
+    t.text     "temp_site_description"
+    t.boolean  "address_finder_error",   default: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+  end
+
+  add_index "transient_registrations", ["reference"], name: "index_transient_registrations_on_reference", unique: true, using: :btree
+  add_index "transient_registrations", ["token"], name: "index_transient_registrations_on_token", unique: true, using: :btree
+
+  add_foreign_key "addresses", "registrations"
+  add_foreign_key "people", "registrations"
+  add_foreign_key "transient_addresses", "transient_registrations"
+  add_foreign_key "transient_people", "transient_registrations"
+end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -5,5 +5,19 @@ FactoryBot.define do
     sequence :postcode do |n|
       "BS#{n}AA"
     end
+
+    address_type { 0 }
+
+    trait :operator do
+      address_type { 1 }
+    end
+
+    trait :contact do
+      address_type { 2 }
+    end
+
+    trait :site do
+      address_type { 3 }
+    end
   end
 end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :address, class: WasteExemptionsEngine::Address do
+    sequence :postcode do |n|
+      "BS#{n}AA"
+    end
+  end
+end

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :person, class: WasteExemptionsEngine::Person do
+    sequence :first_name do |n|
+      "Firstperson#{n}"
+    end
+
+    sequence :last_name do |n|
+      "Lastperson#{n}"
+    end
+  end
+end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -18,6 +18,14 @@ FactoryBot.define do
       "contact#{n}@example.com"
     end
 
+    sequence :contact_first_name do |n|
+      "Firstcontact#{n}"
+    end
+
+    sequence :contact_last_name do |n|
+      "Lastcontact#{n}"
+    end
+
     sequence :operator_name do |n|
       "Operator #{n}"
     end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -6,6 +6,14 @@ FactoryBot.define do
       "applicant#{n}@example.com"
     end
 
+    sequence :applicant_first_name do |n|
+      "Firstapp#{n}"
+    end
+
+    sequence :applicant_last_name do |n|
+      "Lastapp#{n}"
+    end
+
     sequence :contact_email do |n|
       "contact#{n}@example.com"
     end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
       "contact#{n}@example.com"
     end
 
+    sequence :operator_name do |n|
+      "Operator #{n}"
+    end
+
     sequence :reference do |n|
       "WEX#{n}"
     end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -34,7 +34,11 @@ FactoryBot.define do
       "WEX#{n}"
     end
 
-    addresses { [build(:address), build(:address), build(:address)] }
+    addresses do
+      [build(:address, :operator),
+       build(:address, :contact),
+       build(:address, :site)]
+    end
 
     people { [build(:person), build(:person)] }
   end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -2,6 +2,10 @@
 
 FactoryBot.define do
   factory :registration, class: WasteExemptionsEngine::Registration do
+    sequence :applicant_email do |n|
+      "applicant#{n}@example.com"
+    end
+
     sequence :reference do |n|
       "WEX#{n}"
     end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
       "applicant#{n}@example.com"
     end
 
+    sequence :contact_email do |n|
+      "contact#{n}@example.com"
+    end
+
     sequence :reference do |n|
       "WEX#{n}"
     end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -33,5 +33,7 @@ FactoryBot.define do
     sequence :reference do |n|
       "WEX#{n}"
     end
+
+    people { [build(:person), build(:person)] }
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -34,6 +34,8 @@ FactoryBot.define do
       "WEX#{n}"
     end
 
+    addresses { [build(:address), build(:address), build(:address)] }
+
     people { [build(:person), build(:person)] }
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :registration, class: WasteExemptionsEngine::Registration do
+    sequence :reference do |n|
+      "WEX#{n}"
+    end
+  end
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe WasteExemptionsEngine::Address, type: :model do
-  let(:matching_address) { create(:address) }
-  let(:non_matching_address) { create(:address) }
+  let(:matching_address) { create(:address, :site) }
+  let(:non_matching_address) { create(:address, :contact) }
 
   describe "#search_term" do
     let(:term) { nil }
@@ -13,13 +13,25 @@ RSpec.describe WasteExemptionsEngine::Address, type: :model do
     context "when the search term is a postcode" do
       let(:term) { matching_address.postcode }
 
-      it "returns renewals with a matching postcode" do
+      it "returns addresses with a matching postcode" do
         expect(scope).to include(matching_address)
       end
 
       it "does not return others" do
         expect(scope).not_to include(non_matching_address)
       end
+    end
+  end
+
+  describe "#site" do
+    let(:scope) { WasteExemptionsEngine::Address.site }
+
+    it "returns site addresses" do
+      expect(scope).to include(matching_address)
+    end
+
+    it "does not return others" do
+      expect(scope).not_to include(non_matching_address)
     end
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WasteExemptionsEngine::Address, type: :model do
+  let(:matching_address) { create(:address) }
+  let(:non_matching_address) { create(:address) }
+
+  describe "#search_term" do
+    let(:term) { nil }
+    let(:scope) { WasteExemptionsEngine::Address.search_term(term) }
+
+    context "when the search term is a postcode" do
+      let(:term) { matching_address.postcode }
+
+      it "returns renewals with a matching postcode" do
+        expect(scope).to include(matching_address)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_address)
+      end
+    end
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe WasteExemptionsEngine::Person, type: :model do
     context "when the search term is a first_name" do
       let(:term) { matching_person.first_name }
 
-      it "returns renewals with a matching applicant name" do
+      it "returns people with a matching name" do
         expect(scope).to include(matching_person)
       end
 
@@ -25,7 +25,7 @@ RSpec.describe WasteExemptionsEngine::Person, type: :model do
     context "when the search term is a last_name" do
       let(:term) { matching_person.last_name }
 
-      it "returns renewals with a matching applicant name" do
+      it "returns people with a matching name" do
         expect(scope).to include(matching_person)
       end
 
@@ -34,10 +34,10 @@ RSpec.describe WasteExemptionsEngine::Person, type: :model do
       end
     end
 
-    context "when the search term is an applicant's full name" do
+    context "when the search term is a full name" do
       let(:term) { "#{matching_person.first_name} #{matching_person.last_name}" }
 
-      it "returns renewals with a matching applicant name" do
+      it "returns people with a matching name" do
         expect(scope).to include(matching_person)
       end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WasteExemptionsEngine::Person, type: :model do
+  let(:matching_person) { create(:person) }
+  let(:non_matching_person) { create(:person) }
+
+  describe "#search_term" do
+    let(:term) { nil }
+    let(:scope) { WasteExemptionsEngine::Person.search_term(term) }
+
+    context "when the search term is a first_name" do
+      let(:term) { matching_person.first_name }
+
+      it "returns renewals with a matching applicant name" do
+        expect(scope).to include(matching_person)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_person)
+      end
+    end
+
+    context "when the search term is a last_name" do
+      let(:term) { matching_person.last_name }
+
+      it "returns renewals with a matching applicant name" do
+        expect(scope).to include(matching_person)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_person)
+      end
+    end
+
+    context "when the search term is an applicant's full name" do
+      let(:term) { "#{matching_person.first_name} #{matching_person.last_name}" }
+
+      it "returns renewals with a matching applicant name" do
+        expect(scope).to include(matching_person)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_person)
+      end
+    end
+  end
+end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WasteExemptionsEngine::Registration, type: :model do
+  describe "scope" do
+    it_should_behave_like "Registration scopes"
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,7 @@ require "factory_bot_rails"
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir["./spec/support/**/*.rb"].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -65,14 +65,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  # Clean the database before running tests
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean
   end
 end

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -68,42 +68,6 @@ RSpec.shared_examples "Registration scopes" do
       end
     end
 
-    context "when the search term is an applicant_first_name" do
-      let(:term) { matching_registration.applicant_first_name }
-
-      it "returns renewals with a matching applicant name" do
-        expect(scope).to include(matching_registration)
-      end
-
-      it "does not return others" do
-        expect(scope).not_to include(non_matching_registration)
-      end
-    end
-
-    context "when the search term is an applicant_last_name" do
-      let(:term) { matching_registration.applicant_last_name }
-
-      it "returns renewals with a matching applicant name" do
-        expect(scope).to include(matching_registration)
-      end
-
-      it "does not return others" do
-        expect(scope).not_to include(non_matching_registration)
-      end
-    end
-
-    context "when the search term is an applicant's full name" do
-      let(:term) { "#{matching_registration.applicant_first_name} #{matching_registration.applicant_last_name}" }
-
-      it "returns renewals with a matching applicant name" do
-        expect(scope).to include(matching_registration)
-      end
-
-      it "does not return others" do
-        expect(scope).not_to include(non_matching_registration)
-      end
-    end
-
     context "when the search term is an contact_email" do
       let(:term) { matching_registration.contact_email }
 

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -116,6 +116,42 @@ RSpec.shared_examples "Registration scopes" do
       end
     end
 
+    context "when the search term is an contact_first_name" do
+      let(:term) { matching_registration.contact_first_name }
+
+      it "returns renewals with a matching contact name" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+
+    context "when the search term is an contact_last_name" do
+      let(:term) { matching_registration.contact_last_name }
+
+      it "returns renewals with a matching contact name" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+
+    context "when the search term is an contact's full name" do
+      let(:term) { "#{matching_registration.contact_first_name} #{matching_registration.contact_last_name}" }
+
+      it "returns renewals with a matching contact name" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+
     context "when the search term is an operator_name" do
       let(:term) { matching_registration.operator_name }
 

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -162,6 +162,14 @@ RSpec.shared_examples "Registration scopes" do
       it "does not return others" do
         expect(scope).not_to include(non_matching_registration)
       end
+
+      context "when the search term is a partial operator_name" do
+        let(:term) { matching_registration.operator_name[0, 5] }
+
+        it "returns renewals with a matching operator name" do
+          expect(scope).to include(matching_registration)
+        end
+      end
     end
 
     context "when the search term is a reference" do

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -52,6 +52,26 @@ RSpec.shared_examples "Registration scopes" do
       end
     end
 
+    context "when the search term is an operator_name" do
+      let(:term) { matching_registration.operator_name }
+
+      it "returns renewals with a matching operator name" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+
+      context "when the search term is in the wrong case" do
+        let(:term) { matching_registration.operator_name.upcase }
+
+        it "still returns matching results" do
+          expect(scope).to include(matching_registration)
+        end
+      end
+    end
+
     context "when the search term is a reference" do
       let(:term) { matching_registration.reference }
 

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -145,10 +145,21 @@ RSpec.shared_examples "Registration scopes" do
     end
 
     context "when the search term is a related address's postcode" do
-      let(:term) { matching_registration.addresses.first.postcode }
+      let(:address) { matching_registration.addresses.last }
+      let(:term) { address.postcode }
 
-      it "returns renewals with a matching address" do
-        expect(scope).to include(matching_registration)
+      context "when the address is a site address" do
+        it "is included in the scope" do
+          expect(scope).to include(matching_registration)
+        end
+      end
+
+      context "when the address is not a site address" do
+        let(:address) { matching_registration.addresses.first }
+
+        it "is not included in the scope" do
+          expect(scope).to_not include(matching_registration)
+        end
       end
 
       it "does not return others" do

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples "Registration scopes" do
     context "when the search term is an applicant_email" do
       let(:term) { matching_registration.applicant_email }
 
-      it "returns renewals with a matching reference" do
+      it "returns registrations with a matching reference" do
         expect(scope).to include(matching_registration)
       end
 
@@ -31,7 +31,7 @@ RSpec.shared_examples "Registration scopes" do
     context "when the search term is an applicant_first_name" do
       let(:term) { matching_registration.applicant_first_name }
 
-      it "returns renewals with a matching applicant name" do
+      it "returns registrations with a matching applicant name" do
         expect(scope).to include(matching_registration)
       end
 
@@ -43,7 +43,7 @@ RSpec.shared_examples "Registration scopes" do
     context "when the search term is an applicant_last_name" do
       let(:term) { matching_registration.applicant_last_name }
 
-      it "returns renewals with a matching applicant name" do
+      it "returns registrations with a matching applicant name" do
         expect(scope).to include(matching_registration)
       end
 
@@ -55,7 +55,7 @@ RSpec.shared_examples "Registration scopes" do
     context "when the search term is an applicant's full name" do
       let(:term) { "#{matching_registration.applicant_first_name} #{matching_registration.applicant_last_name}" }
 
-      it "returns renewals with a matching applicant name" do
+      it "returns registrations with a matching applicant name" do
         expect(scope).to include(matching_registration)
       end
 
@@ -67,7 +67,7 @@ RSpec.shared_examples "Registration scopes" do
     context "when the search term is an contact_email" do
       let(:term) { matching_registration.contact_email }
 
-      it "returns renewals with a matching reference" do
+      it "returns registrations with a matching reference" do
         expect(scope).to include(matching_registration)
       end
 
@@ -79,7 +79,7 @@ RSpec.shared_examples "Registration scopes" do
     context "when the search term is an contact_first_name" do
       let(:term) { matching_registration.contact_first_name }
 
-      it "returns renewals with a matching contact name" do
+      it "returns registrations with a matching contact name" do
         expect(scope).to include(matching_registration)
       end
 
@@ -91,7 +91,7 @@ RSpec.shared_examples "Registration scopes" do
     context "when the search term is an contact_last_name" do
       let(:term) { matching_registration.contact_last_name }
 
-      it "returns renewals with a matching contact name" do
+      it "returns registrations with a matching contact name" do
         expect(scope).to include(matching_registration)
       end
 
@@ -103,7 +103,7 @@ RSpec.shared_examples "Registration scopes" do
     context "when the search term is an contact's full name" do
       let(:term) { "#{matching_registration.contact_first_name} #{matching_registration.contact_last_name}" }
 
-      it "returns renewals with a matching contact name" do
+      it "returns registrations with a matching contact name" do
         expect(scope).to include(matching_registration)
       end
 
@@ -115,7 +115,7 @@ RSpec.shared_examples "Registration scopes" do
     context "when the search term is an operator_name" do
       let(:term) { matching_registration.operator_name }
 
-      it "returns renewals with a matching operator name" do
+      it "returns registrations with a matching operator name" do
         expect(scope).to include(matching_registration)
       end
 
@@ -126,7 +126,7 @@ RSpec.shared_examples "Registration scopes" do
       context "when the search term is a partial operator_name" do
         let(:term) { matching_registration.operator_name[0, 5] }
 
-        it "returns renewals with a matching operator name" do
+        it "returns registrations with a matching operator name" do
           expect(scope).to include(matching_registration)
         end
       end
@@ -135,7 +135,7 @@ RSpec.shared_examples "Registration scopes" do
     context "when the search term is a reference" do
       let(:term) { matching_registration.reference }
 
-      it "returns renewals with a matching reference" do
+      it "returns registrations with a matching reference" do
         expect(scope).to include(matching_registration)
       end
 
@@ -173,7 +173,7 @@ RSpec.shared_examples "Registration scopes" do
         "#{person.first_name} #{person.last_name}"
       end
 
-      it "returns renewals with a matching person" do
+      it "returns registrations with a matching person" do
         expect(scope).to include(matching_registration)
       end
 

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -32,6 +32,26 @@ RSpec.shared_examples "Registration scopes" do
       end
     end
 
+    context "when the search term is an contact_email" do
+      let(:term) { matching_registration.contact_email }
+
+      it "returns renewals with a matching reference" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+
+      context "when the search term is in the wrong case" do
+        let(:term) { matching_registration.contact_email.upcase }
+
+        it "still returns matching results" do
+          expect(scope).to include(matching_registration)
+        end
+      end
+    end
+
     context "when the search term is a reference" do
       let(:term) { matching_registration.reference }
 

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -143,11 +143,6 @@ RSpec.shared_examples "Registration scopes" do
         expect(scope).not_to include(non_matching_registration)
       end
     end
-  end
-
-  describe "#search_term_on_addresses" do
-    let(:term) { nil }
-    let(:scope) { WasteExemptionsEngine::Registration.search_term_on_addresses(term) }
 
     context "when the search term is a related address's postcode" do
       let(:term) { matching_registration.addresses.first.postcode }
@@ -160,11 +155,6 @@ RSpec.shared_examples "Registration scopes" do
         expect(scope).not_to include(non_matching_registration)
       end
     end
-  end
-
-  describe "#search_term_on_people" do
-    let(:term) { nil }
-    let(:scope) { WasteExemptionsEngine::Registration.search_term_on_people(term) }
 
     context "when the search term is a related person's name" do
       let(:term) do

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -12,6 +12,26 @@ RSpec.shared_examples "Registration scopes" do
       expect(scope.length).to eq(0)
     end
 
+    context "when the search term is an applicant_email" do
+      let(:term) { matching_registration.applicant_email }
+
+      it "returns renewals with a matching reference" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+
+      context "when the search term is in the wrong case" do
+        let(:term) { matching_registration.applicant_email.upcase }
+
+        it "still returns matching results" do
+          expect(scope).to include(matching_registration)
+        end
+      end
+    end
+
     context "when the search term is a reference" do
       let(:term) { matching_registration.reference }
 

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -42,14 +42,6 @@ RSpec.shared_examples "Registration scopes" do
       it "does not return others" do
         expect(scope).not_to include(non_matching_registration)
       end
-
-      context "when the search term is in the wrong case" do
-        let(:term) { matching_registration.contact_email.upcase }
-
-        it "still returns matching results" do
-          expect(scope).to include(matching_registration)
-        end
-      end
     end
 
     context "when the search term is an operator_name" do
@@ -62,14 +54,6 @@ RSpec.shared_examples "Registration scopes" do
       it "does not return others" do
         expect(scope).not_to include(non_matching_registration)
       end
-
-      context "when the search term is in the wrong case" do
-        let(:term) { matching_registration.operator_name.upcase }
-
-        it "still returns matching results" do
-          expect(scope).to include(matching_registration)
-        end
-      end
     end
 
     context "when the search term is a reference" do
@@ -81,14 +65,6 @@ RSpec.shared_examples "Registration scopes" do
 
       it "does not return others" do
         expect(scope).not_to include(non_matching_registration)
-      end
-
-      context "when the search term is in the wrong case" do
-        let(:term) { matching_registration.reference.downcase }
-
-        it "still returns matching results" do
-          expect(scope).to include(matching_registration)
-        end
       end
     end
   end

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -32,6 +32,78 @@ RSpec.shared_examples "Registration scopes" do
       end
     end
 
+    context "when the search term is an applicant_first_name" do
+      let(:term) { matching_registration.applicant_first_name }
+
+      it "returns renewals with a matching applicant name" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+
+    context "when the search term is an applicant_last_name" do
+      let(:term) { matching_registration.applicant_last_name }
+
+      it "returns renewals with a matching applicant name" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+
+    context "when the search term is an applicant's full name" do
+      let(:term) { "#{matching_registration.applicant_first_name} #{matching_registration.applicant_last_name}" }
+
+      it "returns renewals with a matching applicant name" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+
+    context "when the search term is an applicant_first_name" do
+      let(:term) { matching_registration.applicant_first_name }
+
+      it "returns renewals with a matching applicant name" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+
+    context "when the search term is an applicant_last_name" do
+      let(:term) { matching_registration.applicant_last_name }
+
+      it "returns renewals with a matching applicant name" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+
+    context "when the search term is an applicant's full name" do
+      let(:term) { "#{matching_registration.applicant_first_name} #{matching_registration.applicant_last_name}" }
+
+      it "returns renewals with a matching applicant name" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+
     context "when the search term is an contact_email" do
       let(:term) { matching_registration.contact_email }
 

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "Registration scopes" do
+  let(:matching_registration) { create(:registration) }
+  let(:non_matching_registration) { create(:registration) }
+
+  describe "#search_term" do
+    let(:term) { nil }
+    let(:scope) { WasteExemptionsEngine::Registration.search_term(term) }
+
+    it "returns nothing when no search term is given" do
+      expect(scope.length).to eq(0)
+    end
+
+    context "when the search term is a reference" do
+      let(:term) { matching_registration.reference }
+
+      it "returns renewals with a matching reference" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -22,6 +22,14 @@ RSpec.shared_examples "Registration scopes" do
       it "does not return others" do
         expect(scope).not_to include(non_matching_registration)
       end
+
+      context "when the search term is in the wrong case" do
+        let(:term) { matching_registration.reference.downcase }
+
+        it "still returns matching results" do
+          expect(scope).to include(matching_registration)
+        end
+      end
     end
   end
 end

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -144,4 +144,24 @@ RSpec.shared_examples "Registration scopes" do
       end
     end
   end
+
+  describe "#search_term_on_people" do
+    let(:term) { nil }
+    let(:scope) { WasteExemptionsEngine::Registration.search_term_on_people(term) }
+
+    context "when the search term is a related person's name" do
+      let(:term) do
+        person = matching_registration.people.first
+        "#{person.first_name} #{person.last_name}"
+      end
+
+      it "returns renewals with a matching person" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -8,10 +8,6 @@ RSpec.shared_examples "Registration scopes" do
     let(:term) { nil }
     let(:scope) { WasteExemptionsEngine::Registration.search_term(term) }
 
-    it "returns nothing when no search term is given" do
-      expect(scope.length).to eq(0)
-    end
-
     context "when the search term is an applicant_email" do
       let(:term) { matching_registration.applicant_email }
 

--- a/spec/support/shared_examples/registration_scopes.rb
+++ b/spec/support/shared_examples/registration_scopes.rb
@@ -145,6 +145,23 @@ RSpec.shared_examples "Registration scopes" do
     end
   end
 
+  describe "#search_term_on_addresses" do
+    let(:term) { nil }
+    let(:scope) { WasteExemptionsEngine::Registration.search_term_on_addresses(term) }
+
+    context "when the search term is a related address's postcode" do
+      let(:term) { matching_registration.addresses.first.postcode }
+
+      it "returns renewals with a matching address" do
+        expect(scope).to include(matching_registration)
+      end
+
+      it "does not return others" do
+        expect(scope).not_to include(non_matching_registration)
+      end
+    end
+  end
+
   describe "#search_term_on_people" do
     let(:term) { nil }
     let(:scope) { WasteExemptionsEngine::Registration.search_term_on_people(term) }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-59

This PR adds a scope to registrations which will allow us to filter by a specific search term.

The search checks the following fields:

- site postcode
- registration reference number
- business or partner name
- applicant name
- applicant email
- contact name
- contact email