### PR TITLE
Convert to block style configuration

### DIFF
--- a/app/mailers/waste_exemptions_engine/confirmation_mailer.rb
+++ b/app/mailers/waste_exemptions_engine/confirmation_mailer.rb
@@ -11,9 +11,11 @@ module WasteExemptionsEngine
       certificate = generate_pdf_certificate
       attachments["#{registration.reference}.pdf"] = certificate if certificate
 
+      config = WasteExemptionsEngine.configuration
+
       mail(
         to: recipient_email_address,
-        from: "#{WasteExemptionsEngine.service_name} <#{WasteExemptionsEngine.email_service_email}>",
+        from: "#{config.service_name} <#{config.email_service_email}>",
         subject: I18n.t(".waste_exemptions_engine.confirmation_mailer.send_confirmation_email.subject",
                         reference: @registration.reference)
       )

--- a/app/models/concerns/waste_exemptions_engine/can_change_exemption_status.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_change_exemption_status.rb
@@ -25,7 +25,7 @@ module WasteExemptionsEngine
       # Transition effects
       def activate_exemption
         self.registered_on = Date.today
-        self.expires_on = Date.today + (WasteExemptionsEngine.years_before_expiry.years - 1.day)
+        self.expires_on = Date.today + (WasteExemptionsEngine.configuration.years_before_expiry.years - 1.day)
         save!
       end
     end

--- a/app/presenters/waste_exemptions_engine/certificate_presenter.rb
+++ b/app/presenters/waste_exemptions_engine/certificate_presenter.rb
@@ -34,7 +34,7 @@ module WasteExemptionsEngine
 
     def expires_after_pluralized
       ActionController::Base.helpers.pluralize(
-        WasteExemptionsEngine.years_before_expiry,
+        WasteExemptionsEngine.configuration.years_before_expiry,
         I18n.t("#{LOCALES_KEY}.changes.year")
       )
     end

--- a/app/services/waste_exemptions_engine/address_finder_service.rb
+++ b/app/services/waste_exemptions_engine/address_finder_service.rb
@@ -7,7 +7,7 @@ module WasteExemptionsEngine
     def initialize(postcode)
       # Strip out non-alphanumeric characters
       @postcode = postcode.gsub(/[^a-z0-9]/i, "")
-      @url = WasteExemptionsEngine.addressbase_url +
+      @url = WasteExemptionsEngine.configuration.addressbase_url +
              "/address-service/v1/addresses/postcode?postcode=#{@postcode}&client-id=0&key=client1"
     end
 

--- a/app/services/waste_exemptions_engine/companies_house_service.rb
+++ b/app/services/waste_exemptions_engine/companies_house_service.rb
@@ -6,8 +6,8 @@ module WasteExemptionsEngine
   class CompaniesHouseService
     def initialize(company_no)
       @company_no = company_no
-      @url = "#{WasteExemptionsEngine.companies_house_host}#{@company_no}"
-      @api_key = WasteExemptionsEngine.companies_house_api_key
+      @url = "#{WasteExemptionsEngine.configuration.companies_house_host}#{@company_no}"
+      @api_key = WasteExemptionsEngine.configuration.companies_house_api_key
     end
 
     def status

--- a/app/views/pages/version.html.erb
+++ b/app/views/pages/version.html.erb
@@ -1,12 +1,12 @@
 <% content_for :title, "Version" %>
 
 <div class="text">
-  <h1 class="heading-large"><%= WasteExemptionsEngine.application_name %></h1>
+  <h1 class="heading-large"><%= WasteExemptionsEngine.configuration.application_name %></h1>
   <p>
     <label><%= t(".commit") %></label>
     <strong>
       <%= link_to(current_git_commit,
-                  "#{WasteExemptionsEngine.git_repository_url}\/commit\/#{current_git_commit}",
+                  "#{WasteExemptionsEngine.configuration_repository_url}\/commit\/#{current_git_commit}",
                   target: "_blank",
                   class: "btn-link") %>
     </strong>

--- a/app/views/waste_exemptions_engine/confirmation_mailer/send_confirmation_email.html.erb
+++ b/app/views/waste_exemptions_engine/confirmation_mailer/send_confirmation_email.html.erb
@@ -12,7 +12,7 @@
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
   <!-- Use title if it's in the page YAML frontmatter -->
-  <title><%= WasteExemptionsEngine.service_name %></title>
+  <title><%= WasteExemptionsEngine.configuration.service_name %></title>
 </head>
 
 <body style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; color: #0b0c0c">

--- a/config/initializers/wickedpdf.rb
+++ b/config/initializers/wickedpdf.rb
@@ -2,7 +2,7 @@
 
 require "wicked_pdf"
 
-if WasteExemptionsEngine.use_xvfb_for_wickedpdf == "true"
+if WasteExemptionsEngine.configuration.use_xvfb_for_wickedpdf == "true"
   WickedPdf.config = {
     exe_path: WasteExemptionsEngine::Engine.root.join("script", "wkhtmltopdf.sh").to_s
   }

--- a/lib/waste_exemptions_engine.rb
+++ b/lib/waste_exemptions_engine.rb
@@ -4,33 +4,38 @@ require "waste_exemptions_engine/engine"
 
 module WasteExemptionsEngine
 
-  # Configuration pattern based on
-  # https://guides.rubyonrails.org/engines.html#configuring-an-engine
+  # Enable the ability to configure the gem from its host app, rather than
+  # reading directly from env vars. Derived from
+  # https://robots.thoughtbot.com/mygem-configure-block
+  class << self
+    attr_writer :configuration
 
-  # General config
-  mattr_accessor :service_name do
-    "Waste Exemptions Service"
-  end
-  mattr_accessor :application_name
-  mattr_accessor :git_repository_url
-  mattr_accessor :years_before_expiry do
-    3
+    def configuration
+      @configuration ||= Configuration.new
+    end
   end
 
-  # Companies house API config
-  mattr_accessor :companies_house_host do
-    "https://api.companieshouse.gov.uk/company/"
+  def self.configure
+    yield(configuration)
   end
-  mattr_accessor :companies_house_api_key
 
-  # Addressbase config
-  mattr_accessor :addressbase_url
+  class Configuration
+    # General config
+    attr_accessor :service_name, :application_name, :git_repository_url, :years_before_expiry
+    # Companies house config
+    attr_accessor :companies_house_host, :companies_house_api_key
+    # Addressbase config
+    attr_accessor :addressbase_url
+    # Email config
+    attr_accessor :email_service_email
+    # PDF config
+    attr_accessor :use_xvfb_for_wickedpdf
 
-  # Email config
-  mattr_accessor :email_service_email
-
-  # PDF config
-  mattr_accessor :use_xvfb_for_wickedpdf do
-    "true"
+    def initialize
+      @service_name = "Waste Exemptions Service"
+      @years_before_expiry = 3
+      @companies_house_host = "https://api.companieshouse.gov.uk/company/"
+      @use_xvfb_for_wickedpdf = "true"
+    end
   end
 end


### PR DESCRIPTION
We have a known issue with the regex in the companies house validation and as we copied this from Waste Carriers it means the same issue is there. Rather than simply updating both, we are building a shared gem for validation that can then be used by both services.

As part of building the [Defra Ruby Validators gem](https://github.com/DEFRA/defra-ruby-validators) we needed to provide it with the companies house API key.

We didn't want to just rely on having the gem read env vars directly so we followed a common pattern of the host app using a configuration block to set the gem's configuration

```ruby
DefraRubyValidators.configure do |configuration|
  configuration.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
end
```

Prior to this change the engine followed a slightly different pattern of using module accessors that are called directly

```ruby
WasteExemptionsEngine.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
```

The problem we faced is that the actual implementation of the gem would be in this engine, which in turn would be hosted in the target application. And we need the host app to set configuration values, which are passed all the way down to the gem.

When first implementing we realised that the engine's initialisation of the gem was being called before the apps initialisation of the engine.

We found that if we converted to using the block configuration pattern for the engine as well as the gem, we could also pass values down to the gem when the engine was updated. It also made configuration consistent.

So this change is in preparation for implementation the new validators gem 😁