### PR TITLE
Fix location of git_repository_url on version page

### DIFF
--- a/app/views/pages/version.html.erb
+++ b/app/views/pages/version.html.erb
@@ -6,7 +6,7 @@
     <label><%= t(".commit") %></label>
     <strong>
       <%= link_to(current_git_commit,
-                  "#{WasteExemptionsEngine.configuration_repository_url}\/commit\/#{current_git_commit}",
+                  "#{WasteExemptionsEngine.configuration.git_repository_url}\/commit\/#{current_git_commit}",
                   target: "_blank",
                   class: "btn-link") %>
     </strong>


### PR DESCRIPTION
This was moved to the configuration block in https://github.com/DEFRA/waste-exemptions-engine/pull/48.

---

Spotted when running tests on the back-office.