### PR TITLE
Fix issues with company no. validation

### DIFF
--- a/app/forms/waste_exemptions_engine/registration_number_form.rb
+++ b/app/forms/waste_exemptions_engine/registration_number_form.rb
@@ -28,10 +28,10 @@ module WasteExemptionsEngine
     private
 
     def process_company_no(company_no)
-      number = company_no.to_s
+      number = company_no.to_s.strip
       # Should be 8 characters, so if it's not, add 0s to the start
       number = "0#{number}" while number.length < 8
-      number
+      number.upcase
     end
   end
 end

--- a/spec/factories/forms/registration_number_form.rb
+++ b/spec/factories/forms/registration_number_form.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :registration_number_form, class: WasteExemptionsEngine::RegistrationNumberForm do
+    initialize_with { new(create(:transient_registration, workflow_state: "registration_number_form")) }
+  end
+end

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -2,5 +2,8 @@
 
 FactoryBot.define do
   factory :transient_registration, class: WasteExemptionsEngine::TransientRegistration do
+    trait :limited_company do
+      business_type { "limitedCompany" }
+    end
   end
 end

--- a/spec/forms/waste_exemptions_engine/registration_number_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/registration_number_form_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RegistrationNumberForm, type: :model do
+    before do
+      allow_any_instance_of(DefraRubyValidators::CompaniesHouseService).to receive(:status).and_return(:active)
+    end
+
+    describe "#submit" do
+      context "when the form is valid" do
+        let(:registration_number_form) { build(:registration_number_form) }
+        let(:valid_params) { { token: registration_number_form.token, company_no: "09360070" } }
+
+        it "should submit" do
+          expect(registration_number_form.submit(valid_params)).to eq(true)
+        end
+
+        context "when the company_no is less than 8 characters" do
+          before(:each) { valid_params[:company_no] = "946107" }
+
+          it "should increase the length" do
+            registration_number_form.submit(valid_params)
+            expect(registration_number_form.company_no).to eq("00946107")
+          end
+
+          it "should submit" do
+            expect(registration_number_form.submit(valid_params)).to eq(true)
+          end
+        end
+
+        context "when the company_no is lowercase" do
+          before(:each) { valid_params[:company_no] = "sc534714" }
+
+          it "should convert company_no to uppercase" do
+            registration_number_form.submit(valid_params)
+            expect(registration_number_form.company_no).to eq("SC534714")
+          end
+
+          it "should submit" do
+            expect(registration_number_form.submit(valid_params)).to eq(true)
+          end
+        end
+
+        context "when the company_no starts or ends with whitespace" do
+          before(:each) { valid_params[:company_no] = "  SC534714  " }
+
+          it "should remove the whitespace" do
+            registration_number_form.submit(valid_params)
+            expect(registration_number_form.company_no).to eq("SC534714")
+          end
+
+          it "should submit" do
+            expect(registration_number_form.submit(valid_params)).to eq(true)
+          end
+        end
+      end
+
+      context "when the form is invalid" do
+        let(:registration_number_form) { build(:registration_number_form) }
+        let(:invalid_params) { { token: registration_number_form.token, company_no: "foo" } }
+
+        it "should not submit" do
+          expect(registration_number_form.submit(invalid_params)).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It was spotted during the testing of the new service that if you entered a registration number using lowercase characters, or added any whitespace then the check against companies house would fail.

The registration form should handle this on behalf of users rather than returning an error and expecting them to correct it. The changes included here will resolve both problems.