### PR TITLE
Fix database cleaner config

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -4,9 +4,16 @@
 require "database_cleaner"
 
 RSpec.configure do |config|
-  # Clean the database before running tests
+  # Clean the database before running tests. Setup as per
+  # https://github.com/DatabaseCleaner/database_cleaner#rspec-example
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 end


### PR DESCRIPTION
When working on PR #53 found we found we were struggling to get the tests to run without PG errors about violation of unique keys popping up.

Some digging found the database was not actually being cleaned before the tests started. A review of [DatabaseCleaner's guidance](https://github.com/DatabaseCleaner/database_cleaner#rspec-example) suggested a different config setup to what we have, and implementing it resolved all our issues with the test.

Hence this change to fix the config.