### PR TITLE
Handle refresh on the completion page

### DIFF
--- a/app/controllers/waste_exemptions_engine/forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/forms_controller.rb
@@ -63,10 +63,17 @@ module WasteExemptionsEngine
       redirect_to form_path
     end
 
-    # Get the path based on the workflow state, with token as params, ie:
-    # new_state_name_path/:token
+    # Get the path based on the workflow state
     def form_path
-      send("new_#{@transient_registration.workflow_state}_path".to_sym, @transient_registration.token)
+      if @transient_registration.token.present?
+        # If we have a token on the registration we generate the path based on
+        # current workflow state and the token
+        send("new_#{@transient_registration.workflow_state}_path".to_sym, @transient_registration.token)
+      else
+        # If the registration doesn't have a token it's because it is newly
+        # instantiated so we redirect to root to restart the journey
+        "/"
+      end
     end
 
     def setup_checks_pass?

--- a/spec/controllers/waste_exemptions_engine/forms_controller_spec.rb
+++ b/spec/controllers/waste_exemptions_engine/forms_controller_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe FormsController, type: :controller do
+    routes { WasteExemptionsEngine::Engine.routes }
+
+    controller do
+      def new
+        super(LocationForm, "location_form")
+      end
+    end
+
+    context "when a GET request is made" do
+      context "and the token is not recognised" do
+        it "returns a 302 response" do
+          get :new, token: "foobar12345"
+          expect(response).to have_http_status 302
+        end
+
+        it "redirects to the start page" do
+          get :new, token: "foobar12345"
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-23

It was noted in testing that if you hit refresh on the last page of the journey you would get an error.

The problem is that between the declaration page being submitted and the end (completion) page being shown the transient registration has passed through the `RegistrationCompletionService`. This converts the transient registration to a registration, and deletes the transient.

So if a user hits refresh they are essentially requesting they wish to see a transient registration that no longer exists.

In consultation with our QA and the Product Manager we have agreed that if a user makes a request for a transient registration that does not exist (the **token** is not recognised) they will be redirected to the root page of the service.

This change ensures that is what happens in this scenario. For example it was noted that even though we previously requested a path without token in `FormsController.form_path` in the code, if you debugged and checked what happens the helper automatically adds the existing `params[:token]` to the path anyway. By specifiying the path rather than using the helpers we are making it clear what our intention is.

We have also added a basic controller test to cover our expected behaviour in this scenario.