### PR TITLE
Fix our simplecov configuration

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,11 +27,10 @@ end
 # end with _spec.rb. You can configure this pattern with the --pattern
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
 #
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-Dir["./spec/support/**/*.rb"].each { |f| require f }
+# We make an exception for simplecov because that will already have been
+# required and run at the very top of spec_helper.rb
+support_files = Dir["./spec/support/**/*.rb"].reject { |file| file == "./spec/support/simplecov.rb" }
+support_files.each { |f| require f }
 
 RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require "simplecov"
-SimpleCov.start
+# Require and run our simplecov initializer as the very first thing we do.
+# This is as per its docs https://github.com/colszowka/simplecov#getting-started
+require "./spec/support/simplecov"
 
 # Support debugging in the tests
 require "byebug"

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "simplecov"
+
+# We start it with the rails param to ensure it includes coverage for all code
+# started by the rails app, and not just the files touched by our unit tests.
+# This gives us the most accurate assessment of our unit test coverage
+# https://github.com/colszowka/simplecov#getting-started
+SimpleCov.start("rails") do
+  # We filter the spec folder, mainly to ensure that any dummy apps don't get
+  # included in the coverage report. However our intent is that nothing in the
+  # spec folder should be included
+  add_filter "/spec/"
+  # Our db folder contains migrations and seeding, functionality we are ok not
+  # to have tests for
+  add_filter "/db/"
+  # The version file is simply just that, so we do not feel the need to ensure
+  # we have a test for it
+  add_filter "lib/waste_exemptions_engine/version"
+
+  add_group "Forms", "app/forms"
+  add_group "Presenters", "app/presenters"
+  add_group "Services", "app/services"
+  add_group "Validators", "app/validators"
+end


### PR DESCRIPTION
We always drop simplecov into our projects to give us our test coverage. We did this as usual in this project and were a little surprised to see very high test coverage even though we know we are very few tests 😳.

As we have started adding tests the total coverage has started to fluctuate quite drastically so we took a deeper look at our test coverage.

What we found is that

- our dummy app's code files were being included, and reported as having 100% test coverage which inflated our overall figure
- simplecov was only reporting test coverage for files 'touched' by the existing unit tests

Clearly this is wrong and not giving us the accurate figure we need to make a proper assessment about our unit test coverage.

Therefore this change is intended to fix the issue. It follows our adopted pattern of configuring test dependencies in separate files, but ensures it still fulfills simplecov's requirement of being the first thing required. It also ensures it doesn't get included twice.

Other than that it makes sure we exclude files from the coverage that are irrelevant, whilst ensuring that all files in the project are included and not just the ones touched by unit tests.