### PR TITLE
Remove rspec use transaction fixtures config

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,11 +33,6 @@ support_files = Dir["./spec/support/**/*.rb"].reject { |file| file == "./spec/su
 support_files.each { |f| require f }
 
 RSpec.configure do |config|
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  config.use_transactional_fixtures = false
-
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.


### PR DESCRIPTION
When aligning the engine's rspec setup with the back-office-ta project spotted that we had the line

```ruby
config.use_transactional_fixtures = false
```

in `rails_helper.rb`. We didn't have this in the back-office-ta project, and as we are using Databasecleaner it doesn't make sense to also have this line confusing issues. Hence this change removes it.