### PR TITLE
Include url helpers in request specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,4 +52,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before :each, type: :request do
+    config.include WasteExemptionsEngine::Engine.routes.url_helpers
+  end
 end


### PR DESCRIPTION
Admittedly we don't have any request specs at this stage, but in preparation and to align this engine with the test setup for the Waste Carriers engine, this change ensures url helpers are included before running any request specs.