### PR TITLE
Inherit authorisation/authentication preferences from host

### DIFF
--- a/app/controllers/waste_exemptions_engine/application_controller.rb
+++ b/app/controllers/waste_exemptions_engine/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
-  class ApplicationController < ActionController::Base
+  class ApplicationController < ::ApplicationController
     # Prevent CSRF attacks by raising an exception.
     # For APIs, you may want to use :null_session instead.
     protect_from_forgery with: :exception


### PR DESCRIPTION
Improved testing during DEFRA/waste-exemptions-back-office-ta#21 revealed that the mounted engine wasn't using any of the auth checks provided by Devise in the host app - an unauthenticated user couldn't access routes from the host app, but could access ones in the mounted engine.

This also applied to checks for abilities as well.

The front-office doesn't use Devise or CanCanCan to manage authorisation or authentication, but the engine should be able to handle it when the host app specifies it.