### PR TITLE
Refactor AddressValidator

### DIFF
--- a/app/forms/waste_exemptions_engine/postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/postcode_form.rb
@@ -28,6 +28,10 @@ module WasteExemptionsEngine
 
     validates :postcode, "waste_exemptions_engine/postcode": true
 
+    def address_finder_error(error_occurred)
+      transient_registration.address_finder_error = error_occurred
+    end
+
     private
 
     def format_postcode(postcode)

--- a/app/validators/concerns/waste_exemptions_engine/can_validate_presence.rb
+++ b/app/validators/concerns/waste_exemptions_engine/can_validate_presence.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
-  module ValidatesPresence
+  module CanValidatePresence
     extend ActiveSupport::Concern
 
     included do

--- a/app/validators/concerns/waste_exemptions_engine/validates_presence.rb
+++ b/app/validators/concerns/waste_exemptions_engine/validates_presence.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module ValidatesPresence
+    extend ActiveSupport::Concern
+
+    included do
+      private
+
+      def value_is_present?(record, attribute, value)
+        return true if value.present?
+
+        record.errors[attribute] << error_message(record, attribute, "blank")
+        false
+      end
+    end
+  end
+end

--- a/app/validators/waste_exemptions_engine/address_validator.rb
+++ b/app/validators/waste_exemptions_engine/address_validator.rb
@@ -1,25 +1,13 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
-  class AddressValidator < ActiveModel::EachValidator
+  class AddressValidator < BaseValidator
+    include ValidatesPresence
+
     def validate_each(record, attribute, value)
       return false unless value_is_present?(record, attribute, value)
 
       false
-    end
-
-    private
-
-    def value_is_present?(record, attribute, value)
-      return true if value.present?
-
-      record.errors[attribute] << error_message(record, attribute, "blank")
-      false
-    end
-
-    def error_message(record, attribute, error)
-      class_name = record.class.to_s.underscore
-      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
     end
   end
 end

--- a/app/validators/waste_exemptions_engine/address_validator.rb
+++ b/app/validators/waste_exemptions_engine/address_validator.rb
@@ -5,9 +5,7 @@ module WasteExemptionsEngine
     include CanValidatePresence
 
     def validate_each(record, attribute, value)
-      return false unless value_is_present?(record, attribute, value)
-
-      false
+      value_is_present?(record, attribute, value)
     end
   end
 end

--- a/app/validators/waste_exemptions_engine/address_validator.rb
+++ b/app/validators/waste_exemptions_engine/address_validator.rb
@@ -2,7 +2,7 @@
 
 module WasteExemptionsEngine
   class AddressValidator < BaseValidator
-    include ValidatesPresence
+    include CanValidatePresence
 
     def validate_each(record, attribute, value)
       return false unless value_is_present?(record, attribute, value)

--- a/app/validators/waste_exemptions_engine/base_validator.rb
+++ b/app/validators/waste_exemptions_engine/base_validator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class BaseValidator < ActiveModel::EachValidator
+
+    protected
+
+    def error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/app/validators/waste_exemptions_engine/postcode_validator.rb
+++ b/app/validators/waste_exemptions_engine/postcode_validator.rb
@@ -30,14 +30,14 @@ module WasteExemptionsEngine
     def postcode_returns_results?(record, attribute, value)
       address_finder = AddressFinderService.new(value)
       case address_finder.search_by_postcode
-      when :not_found
+      when :not_found, []
         record.errors[attribute] << error_message(record, attribute, "no_results")
         false
       when :error
-        record.transient_registration.address_finder_error = true
+        record.address_finder_error(true) if record.respond_to? :address_finder_error
         true
       else
-        record.transient_registration.address_finder_error = false
+        record.address_finder_error(false) if record.respond_to? :address_finder_error
         true
       end
     end

--- a/lib/waste_exemptions_engine/engine.rb
+++ b/lib/waste_exemptions_engine/engine.rb
@@ -15,6 +15,8 @@ module WasteExemptionsEngine
       g.factory_bot dir: "spec/factories"
     end
 
+    config.autoload_paths << "#{config.root}/app/validators/concerns"
+
     # Load I18n translation files from engine before loading ones from the host app
     # This means values in the host app can override those in the engine
     config.before_initialize do

--- a/spec/cassettes/postcode_no_matches.yml
+++ b/spec/cassettes/postcode_no_matches.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=AA11AA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      Host:
+      - localhost:9002
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Feb 2019 13:11:40 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAFWOywrCMBBF/2UWXZWm3QaCBHSpuBcpYxJpMSYhMymK+O8GHwuX5z7gPIAjo98im8kRyL4FYsz8DkCG4n0LLtg/LnkeOY5UUvKzyyBhYk4khcA0dzHbgME4Knlx987ErlxE8lgTsQwCrc2OqEKKxCZat/JZbXbND5XWw6B1c8VbHRbPpIa+bywykmO13mv4KJxzvI6mGgSuCsTlVIvvBeTh+HwB/2bVRt0AAAA=
+    http_version: 
+  recorded_at: Mon, 11 Feb 2019 13:26:44 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/postcode_valid.yml
+++ b/spec/cassettes/postcode_valid.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      Host:
+      - localhost:9002
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Feb 2019 13:12:14 GMT
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAM2TXWvbMBSG/4rRRa6MLSVNnBrCcBbThKV2sJONbgyj2lprplhCH6Wh9L/vOB9rzHqxXuzjSjrn6Lzn5TzoCRlhKL+mprxnGoUDF2lDldknUEhcxJrqGEDNqrowotBWSl4zhUJ0b4zUoe9TWXtCVQ1tSqatemA7rxSe/e5LTiHjPxCfVpViWkMghTalqNg7riZx0juFk2lOhtG8t6WP8NByoycE415FDdXMTGarCB0sfFNiW5TgoDFgQRt7C4VjCwq/PCErVQOGLzAhIxcdB8PTJFpvsmjpxMnVMkpmrjNPs8XnNIFzk8euM4ujJM5unCyNoDjNFvk6XcIlJw4YgyFC3dGm1tTUovlVDx5Ixba1bleJOtqoXaxizBQvbs6nQZ2LkvLa7FDYWM5dVO7v6Oii1T7uqU3+dPQI0WA47uOhhwcQty0k6Ad47OEA4lIAlrqhhhV6pw3bnuSBM+Rgua0e6fsE+32ML6HllktbHMqHcYeGdjzlJ/+dEhd3NZjfN9luSQuryv0cWpidbIdVkqJn90QJEF+SYIRHF/gc1TzKrvM4ca6ydLNynXW2SGdp7kyj5MPbOXXEupTOhf80JDLAHnlhNBoH3vi3GR0yf5fN/gcF51jW82zxMXayOIk/RdNlnDur5fu3A3lVpgPmtID/Fcc/+DJfn38ABFoygK8FAAA=
+    http_version: 
+  recorded_at: Mon, 11 Feb 2019 13:27:18 GMT
+recorded_with: VCR 4.0.0

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -27,6 +27,7 @@ module Dummy
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.i18n.load_path += Dir["#{config.root}/config/locales/**/*.yml"]
   end
 end
-

--- a/spec/dummy/config/initializers/waste_exemptions_engine.rb
+++ b/spec/dummy/config/initializers/waste_exemptions_engine.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+WasteExemptionsEngine.configure do |config|
+  # General config
+  config.application_name = "waste-exemptions-front-office"
+  config.git_repository_url = "https://github.com/DEFRA/waste-exemptions-front-office"
+
+  # Companies house API config
+  config.companies_house_host = ENV["COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"
+  config.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
+
+  # Addressbase facade config
+  config.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:9002"
+
+  # Email config
+  config.email_service_email = ENV["EMAIL_SERVICE_EMAIL"] || "wex-local@example.com"
+
+  # PDF config
+  config.use_xvfb_for_wickedpdf = ENV["USE_XVFB_FOR_WICKEDPDF"] || "true"
+end

--- a/spec/dummy/config/locales/postcode_validator/en.yml
+++ b/spec/dummy/config/locales/postcode_validator/en.yml
@@ -1,0 +1,13 @@
+en:
+  activemodel:
+    errors:
+      models:
+        test/postcode_validatable:
+          attributes:
+            postcode:
+              blank: "Enter a postcode"
+              wrong_format: "Enter a valid UK postcode"
+              no_results: "We cannot find any addresses for that postcode. Check the postcode or enter the address manually."
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -185,6 +185,32 @@ ActiveRecord::Schema.define(version: 20190121092357) do
   add_index "transient_registrations", ["reference"], name: "index_transient_registrations_on_reference", unique: true, using: :btree
   add_index "transient_registrations", ["token"], name: "index_transient_registrations_on_token", unique: true, using: :btree
 
+  create_table "users", force: :cascade do |t|
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer  "invitation_limit"
+    t.integer  "invited_by_id"
+    t.string   "invited_by_type"
+    t.integer  "failed_attempts",        default: 0,  null: false
+    t.string   "unlock_token"
+    t.datetime "locked_at"
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.string   "session_token"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.string   "role"
+  end
+
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["invitation_token"], name: "index_users_on_invitation_token", unique: true, using: :btree
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
+
   add_foreign_key "addresses", "registrations"
   add_foreign_key "people", "registrations"
   add_foreign_key "transient_addresses", "transient_registrations"

--- a/spec/factories/forms/contact_postcodes_form.rb
+++ b/spec/factories/forms/contact_postcodes_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :contact_postcode_form, class: WasteExemptionsEngine::ContactPostcodeForm do
+    initialize_with do
+      new(create(:transient_registration, workflow_state: "contact_postcode_form"))
+    end
+  end
+end

--- a/spec/factories/forms/operator_postcodes_form.rb
+++ b/spec/factories/forms/operator_postcodes_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :operator_postcode_form, class: WasteExemptionsEngine::OperatorPostcodeForm do
+    initialize_with do
+      new(create(:transient_registration, workflow_state: "operator_postcode_form"))
+    end
+  end
+end

--- a/spec/factories/forms/site_postcodes_form.rb
+++ b/spec/factories/forms/site_postcodes_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :site_postcode_form, class: WasteExemptionsEngine::SitePostcodeForm do
+    initialize_with do
+      new(create(:transient_registration, workflow_state: "site_postcode_form"))
+    end
+  end
+end

--- a/spec/forms/waste_exemptions_engine/contact_postcode_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/contact_postcode_form_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe ContactPostcodeForm, type: :model do
+    it_behaves_like "a postcode form", :contact_postcode_form
+  end
+end

--- a/spec/forms/waste_exemptions_engine/exemptions_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/exemptions_form_spec.rb
@@ -4,31 +4,16 @@ require "rails_helper"
 
 module WasteExemptionsEngine
   RSpec.describe ExemptionsForm, type: :model do
-    before(:all) do
+    before(:context) do
       # Create a selection of exemptions. The ExemptionForm needs this as it
       # will validate the selected exemptions (our params) against the
       # collection of exemptions it pulls from the database.
       create_list(:exemption, 5)
     end
 
-    describe "#submit" do
-      context "when the form is valid" do
-        let(:form) { build(:exemptions_form) }
-        let(:valid_params) { { "token" => form.token, exemptions: %w[1 2 3] } }
-
-        it "should submit" do
-          expect(form.submit(valid_params)).to eq(true)
-        end
-      end
-
-      context "when the form is not valid" do
-        let(:form) { build(:exemptions_form) }
-        let(:invalid_params) { { token: form.token } }
-
-        it "should not submit" do
-          expect(form.submit(invalid_params)).to eq(false)
-        end
-      end
+    it_behaves_like "a validated form", :exemptions_form do
+      let(:valid_params) { { token: form.token, exemptions: %w[1 2 3] } }
+      let(:invalid_params) { { token: form.token } }
     end
   end
 end

--- a/spec/forms/waste_exemptions_engine/operator_postcode_form.rb
+++ b/spec/forms/waste_exemptions_engine/operator_postcode_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe OperatorPostcodeForm, type: :model do
+    it_behaves_like "a postcode form", :operator_postcode_form
+  end
+end

--- a/spec/forms/waste_exemptions_engine/registration_number_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/registration_number_form_spec.rb
@@ -5,28 +5,31 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RegistrationNumberForm, type: :model do
     before do
-      allow_any_instance_of(DefraRubyValidators::CompaniesHouseService).to receive(:status).and_return(:active)
+      allow_any_instance_of(DefraRubyValidators::CompaniesHouseService)
+        .to receive(:status)
+        .and_return(:active)
+    end
+
+    it_behaves_like "a validated form", :registration_number_form do
+      let(:valid_params) { { token: form.token, company_no: "09360070" } }
+      let(:invalid_params) { { token: form.token, company_no: "foo" } }
     end
 
     describe "#submit" do
       context "when the form is valid" do
-        let(:registration_number_form) { build(:registration_number_form) }
-        let(:valid_params) { { token: registration_number_form.token, company_no: "09360070" } }
-
-        it "should submit" do
-          expect(registration_number_form.submit(valid_params)).to eq(true)
-        end
+        subject(:form) { build(:registration_number_form) }
+        let(:valid_params) { { token: form.token, company_no: "09360070" } }
 
         context "when the company_no is less than 8 characters" do
           before(:each) { valid_params[:company_no] = "946107" }
 
-          it "should increase the length" do
-            registration_number_form.submit(valid_params)
-            expect(registration_number_form.company_no).to eq("00946107")
+          it "should pad company_no with 0s" do
+            form.submit(valid_params)
+            expect(form.company_no).to eq("00946107")
           end
 
           it "should submit" do
-            expect(registration_number_form.submit(valid_params)).to eq(true)
+            expect(form.submit(valid_params)).to eq(true)
           end
         end
 
@@ -34,12 +37,12 @@ module WasteExemptionsEngine
           before(:each) { valid_params[:company_no] = "sc534714" }
 
           it "should convert company_no to uppercase" do
-            registration_number_form.submit(valid_params)
-            expect(registration_number_form.company_no).to eq("SC534714")
+            form.submit(valid_params)
+            expect(form.company_no).to eq("SC534714")
           end
 
           it "should submit" do
-            expect(registration_number_form.submit(valid_params)).to eq(true)
+            expect(form.submit(valid_params)).to eq(true)
           end
         end
 
@@ -47,22 +50,13 @@ module WasteExemptionsEngine
           before(:each) { valid_params[:company_no] = "  SC534714  " }
 
           it "should remove the whitespace" do
-            registration_number_form.submit(valid_params)
-            expect(registration_number_form.company_no).to eq("SC534714")
+            form.submit(valid_params)
+            expect(form.company_no).to eq("SC534714")
           end
 
           it "should submit" do
-            expect(registration_number_form.submit(valid_params)).to eq(true)
+            expect(form.submit(valid_params)).to eq(true)
           end
-        end
-      end
-
-      context "when the form is invalid" do
-        let(:registration_number_form) { build(:registration_number_form) }
-        let(:invalid_params) { { token: registration_number_form.token, company_no: "foo" } }
-
-        it "should not submit" do
-          expect(registration_number_form.submit(invalid_params)).to eq(false)
         end
       end
     end

--- a/spec/forms/waste_exemptions_engine/site_postcode_form.rb
+++ b/spec/forms/waste_exemptions_engine/site_postcode_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe SitePostcodeForm, type: :model do
+    it_behaves_like "a postcode form", :site_postcode_form
+  end
+end

--- a/spec/support/helpers/error_translator.rb
+++ b/spec/support/helpers/error_translator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Helpers
+  module Translator
+    def self.error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/spec/support/shared_examples/forms/postcode_form.rb
+++ b/spec/support/shared_examples/forms/postcode_form.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a postcode form" do |form_factory|
+  it_behaves_like "a validated form", form_factory do
+    let(:valid_params) { { token: form.token, postcode: "BS1 5AH" } }
+    let(:invalid_params) { { token: form.token, postcode: "foo" } }
+  end
+
+  it "is a type of PostcodeForm" do
+    expect(described_class.ancestors)
+      .to include(WasteExemptionsEngine::PostcodeForm)
+  end
+
+  it "validates the postcode using the PostcodeValidator class" do
+    validators = build(form_factory)._validators
+    expect(validators.keys).to include(:postcode)
+    expect(validators[:postcode].first.class)
+      .to eq(WasteExemptionsEngine::PostcodeValidator)
+  end
+end

--- a/spec/support/shared_examples/forms/validated_form.rb
+++ b/spec/support/shared_examples/forms/validated_form.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a validated form" do |form_factory|
+  subject(:form) { build(form_factory) }
+  let(:valid_params) do
+    { override_me: "Set :valid_params in the calling spec." }
+  end
+  let(:invalid_params) do
+    { override_me: "Set :invalid_params in the calling spec." }
+  end
+
+  it "should be a type of BaseForm" do
+    expect(described_class.ancestors)
+      .to include(WasteExemptionsEngine::BaseForm)
+  end
+
+  describe "#submit" do
+    context "when the form is valid" do
+      it "should submit" do
+        expect(form.submit(valid_params)).to eq(true)
+      end
+    end
+
+    context "when the form is not valid" do
+      it "should not submit" do
+        expect(form.submit(invalid_params)).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/validators/presence_validator.rb
+++ b/spec/support/shared_examples/validators/presence_validator.rb
@@ -7,8 +7,8 @@ RSpec.shared_examples "a presence validator" do |validatable_class, property|
   # end
 
   describe "#validate_each" do
-    context "when the postcode is not valid" do
-      context "because the postcode is not present" do
+    context "when the #{property} is not valid" do
+      context "because the #{property} is not present" do
         subject(:validatable) { validatable_class.new }
 
         it "confirms the object is invalid" do

--- a/spec/support/shared_examples/validators/presence_validator.rb
+++ b/spec/support/shared_examples/validators/presence_validator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a presence validator" do |validatable_class, property|
+  # it "includes ValidatesPresence" do
+  #   expect(described_class.includes)
+  #     .to include(WasteExemptionsEngine::ValidatesPresence)
+  # end
+
+  describe "#validate_each" do
+    context "when the postcode is not valid" do
+      context "because the postcode is not present" do
+        subject(:validatable) { validatable_class.new }
+
+        it "confirms the object is invalid" do
+          expect(validatable).to_not be_valid
+        end
+
+        it "adds a single validation error to the record" do
+          validatable.valid?
+          expect(validatable.errors[property].count).to eq(1)
+        end
+
+        it "adds an appropriate validation error" do
+          error_msg = Helpers::Translator.error_message(validatable, property, :blank)
+          validatable.valid?
+          expect(validatable.errors[property]).to eq([error_msg])
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/validators/presence_validator.rb
+++ b/spec/support/shared_examples/validators/presence_validator.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "a presence validator" do |validatable_class, property|
-  # it "includes ValidatesPresence" do
-  #   expect(described_class.includes)
-  #     .to include(WasteExemptionsEngine::ValidatesPresence)
-  # end
+  it "includes CanValidatePresence" do
+    included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
+
+    expect(included_modules)
+      .to include(WasteExemptionsEngine::CanValidatePresence)
+  end
 
   describe "#validate_each" do
     context "when the #{property} is not valid" do

--- a/spec/support/shared_examples/validators/validator.rb
+++ b/spec/support/shared_examples/validators/validator.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "a validator" do |validator, validatable_class, valid_value|
+RSpec.shared_examples "a validator" do |validator, validatable_class, property, valid_value|
   it "is a type of BaseValidator" do
     expect(described_class.ancestors)
       .to include(WasteExemptionsEngine::BaseValidator)
   end
 
   describe "#validate_each" do
-    context "when the postcode is valid" do
+    context "when the #{property} is valid" do
       subject(:validatable) { validatable_class.new(valid_value) }
 
       it "gets called" do

--- a/spec/support/shared_examples/validators/validator.rb
+++ b/spec/support/shared_examples/validators/validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "a validator" do |validator, validatable_class, valid_value|
-  it "is a type of PostcodeForm" do
+  it "is a type of BaseValidator" do
     expect(described_class.ancestors)
       .to include(WasteExemptionsEngine::BaseValidator)
   end

--- a/spec/support/shared_examples/validators/validator.rb
+++ b/spec/support/shared_examples/validators/validator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a validator" do |validator, validatable_class, valid_value|
+  it "is a type of PostcodeForm" do
+    expect(described_class.ancestors)
+      .to include(WasteExemptionsEngine::BaseValidator)
+  end
+
+  describe "#validate_each" do
+    context "when the postcode is valid" do
+      subject(:validatable) { validatable_class.new(valid_value) }
+
+      it "gets called" do
+        expect_any_instance_of(validator)
+          .to receive(:validate_each)
+          .once
+
+        validatable.valid?
+      end
+
+      it "confirms the object is valid" do
+        expect(validatable).to be_valid
+      end
+
+      it "the errors are empty" do
+        validatable.valid?
+        expect(validatable.errors).to be_empty
+      end
+    end
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -16,6 +16,6 @@ VCR.configure do |c|
   # Strip out authorization info
   c.filter_sensitive_data("Basic <API_KEY>") do |interaction|
     auth = interaction.request.headers["Authorization"]
-    auth.first if auth.nil? || auth.empty?
+    auth.first unless auth.nil? || auth.empty?
   end
 end

--- a/spec/validators/waste_exemptions_engine/address_validator_spec.rb
+++ b/spec/validators/waste_exemptions_engine/address_validator_spec.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
   RSpec.describe AddressValidator, type: :model do
     valid_address = "Temple Quay House, 2 The Square, Temple Quay, Bristol"
 
-    it_behaves_like "a validator", AddressValidator, Test::AddressValidatable, valid_address
+    it_behaves_like "a validator", AddressValidator, Test::AddressValidatable, :address, valid_address
     it_behaves_like "a presence validator", Test::AddressValidatable, :address
   end
 end

--- a/spec/validators/waste_exemptions_engine/address_validator_spec.rb
+++ b/spec/validators/waste_exemptions_engine/address_validator_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Test
+  AddressValidatable = Struct.new(:address) do
+    include ActiveModel::Validations
+
+    validates :address, "waste_exemptions_engine/address": true
+  end
+end
+
+module WasteExemptionsEngine
+  RSpec.describe AddressValidator, type: :model do
+    valid_address = "Temple Quay House, 2 The Square, Temple Quay, Bristol"
+
+    it_behaves_like "a validator", AddressValidator, Test::AddressValidatable, valid_address
+    it_behaves_like "a presence validator", Test::AddressValidatable, :address
+  end
+end

--- a/spec/validators/waste_exemptions_engine/postcode_validator_spec.rb
+++ b/spec/validators/waste_exemptions_engine/postcode_validator_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Test
+  PostcodeValidatable = Struct.new(:postcode) do
+    include ActiveModel::Validations
+
+    validates :postcode, "waste_exemptions_engine/postcode": true
+  end
+end
+
+module WasteExemptionsEngine
+  RSpec.describe PostcodeValidator, type: :model do
+    let(:valid_postcode) { "BS1 5AH" }
+    let(:invalid_postcode) { "foo" }
+    let(:postcode_without_addresses) { "AA1 1AA" }
+
+    subject(:validatable) { Test::PostcodeValidatable.new(valid_postcode) }
+
+    describe "#validate_each" do
+      context "when the postcode is valid" do
+        before(:each) { VCR.insert_cassette("postcode_valid") }
+        after(:each) { VCR.eject_cassette }
+
+        it "gets called" do
+          expect_any_instance_of(PostcodeValidator)
+            .to receive(:validate_each)
+            .once
+
+          validatable.valid?
+        end
+
+        it "confirms the object is valid" do
+          expect(validatable).to be_valid
+        end
+
+        it "the errors are empty" do
+          validatable.valid?
+          expect(validatable.errors).to be_empty
+        end
+      end
+
+      context "when the postcode is not valid" do
+        context "because the postcode is not present" do
+          subject(:validatable) { Test::PostcodeValidatable.new }
+
+          it "confirms the object is invalid" do
+            expect(validatable).to_not be_valid
+          end
+
+          it "adds a single validation error to the record" do
+            validatable.valid?
+            expect(validatable.errors[:postcode].count).to eq(1)
+          end
+
+          it "adds an appropriate validation error" do
+            error_msg = Helpers::Translator.error_message(validatable, :postcode, :blank)
+            validatable.valid?
+            expect(validatable.errors[:postcode]).to eq([error_msg])
+          end
+        end
+
+        context "because the postcode is not correctly formated" do
+          subject(:validatable) { Test::PostcodeValidatable.new(invalid_postcode) }
+
+          it "confirms the object is invalid" do
+            expect(validatable).to_not be_valid
+          end
+
+          it "adds a single validation error to the record" do
+            validatable.valid?
+            expect(validatable.errors[:postcode].count).to eq(1)
+          end
+
+          it "adds an appropriate validation error" do
+            error_msg = Helpers::Translator.error_message(validatable, :postcode, :wrong_format)
+            validatable.valid?
+            expect(validatable.errors[:postcode]).to eq([error_msg])
+          end
+        end
+
+        context "because the postcode does not have associated adresses" do
+          subject(:validatable) do
+            Test::PostcodeValidatable.new(postcode_without_addresses)
+          end
+
+          before(:each) { VCR.insert_cassette("postcode_no_matches") }
+          after(:each) { VCR.eject_cassette }
+
+          it "confirms the object is invalid" do
+            expect(validatable).to_not be_valid
+          end
+
+          it "adds a single validation error to the record" do
+            validatable.valid?
+            expect(validatable.errors[:postcode].count).to eq(1)
+          end
+
+          it "adds an appropriate validation error" do
+            error_msg = Helpers::Translator.error_message(validatable, :postcode, :no_results)
+            validatable.valid?
+            expect(validatable.errors[:postcode]).to eq([error_msg])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In an effort to remove duplication in the validators, we would like to move duplicated code into the ValidatesPresence concern and BaseValidator class. 

Future refactoring efforts will include the creation of the ValidatesLength concern.

This PR is a sample of the intended refactoring. We decided it would be easier to review the changes if they are applied to a single validator before applying the pattern to the rest of the validators.