### PR TITLE
Form widths classes added to relevant views

### DIFF
--- a/app/views/waste_exemptions_engine/applicant_name_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/applicant_name_forms/new.html.erb
@@ -19,7 +19,7 @@
         <% end %>
 
         <%= f.label :first_name, t(".first_name_label"), class: "form-label" %>
-        <%= f.text_field :first_name, value: @applicant_name_form.first_name, class: "form-control" %>
+        <%= f.text_field :first_name, value: @applicant_name_form.first_name, class: "form-control govuk-input--width-2" %>
       </fieldset>
     </div>
 
@@ -34,7 +34,7 @@
         <% end %>
 
         <%= f.label :last_name, t(".last_name_label"), class: "form-label" %>
-        <%= f.text_field :last_name, value: @applicant_name_form.last_name, class: "form-control" %>
+        <%= f.text_field :last_name, value: @applicant_name_form.last_name, class: "form-control govuk-input--width-2" %>
       </fieldset>
     </div>
 

--- a/app/views/waste_exemptions_engine/applicant_name_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/applicant_name_forms/new.html.erb
@@ -19,7 +19,7 @@
         <% end %>
 
         <%= f.label :first_name, t(".first_name_label"), class: "form-label" %>
-        <%= f.text_field :first_name, value: @applicant_name_form.first_name, class: "form-control govuk-input--width-2" %>
+        <%= f.text_field :first_name, value: @applicant_name_form.first_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>
 
@@ -34,7 +34,7 @@
         <% end %>
 
         <%= f.label :last_name, t(".last_name_label"), class: "form-label" %>
-        <%= f.text_field :last_name, value: @applicant_name_form.last_name, class: "form-control govuk-input--width-2" %>
+        <%= f.text_field :last_name, value: @applicant_name_form.last_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>
 

--- a/app/views/waste_exemptions_engine/applicant_phone_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/applicant_phone_forms/new.html.erb
@@ -20,7 +20,7 @@
           <%= t(".phone_number_label") %>
           <span class='form-hint'><%= t(".phone_number_hint") %></span>
         <% end %>
-        <%= f.telephone_field :phone_number, value: @applicant_phone_form.phone_number, class: "form-control" %>
+        <%= f.telephone_field :phone_number, value: @applicant_phone_form.phone_number, class: "form-control govuk-input--width-10" %>
       </fieldset>
     </div>
 

--- a/app/views/waste_exemptions_engine/contact_name_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_name_forms/new.html.erb
@@ -18,7 +18,7 @@
         <span class="error-message"><%= @contact_name_form.errors[:first_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :first_name, t(".first_name_label"), class: "form-label form-control" %>
+        <%= f.label :first_name, t(".first_name_label"), class: "form-label" %>
         <%= f.text_field :first_name, value: @contact_name_form.first_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>
@@ -33,7 +33,7 @@
         <span class="error-message"><%= @contact_name_form.errors[:last_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :last_name, t(".last_name_label"), class: "form-label form-control" %>
+        <%= f.label :last_name, t(".last_name_label"), class: "form-label" %>
         <%= f.text_field :last_name, value: @contact_name_form.last_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>

--- a/app/views/waste_exemptions_engine/contact_name_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_name_forms/new.html.erb
@@ -18,7 +18,7 @@
         <span class="error-message"><%= @contact_name_form.errors[:first_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :first_name, t(".first_name_label"), class: "form-label" %>
+        <%= f.label :first_name, t(".first_name_label"), class: "form-label form-control govuk-input--width-20" %>
         <%= f.text_field :first_name, value: @contact_name_form.first_name, class: "form-control" %>
       </fieldset>
     </div>
@@ -33,7 +33,7 @@
         <span class="error-message"><%= @contact_name_form.errors[:last_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :last_name, t(".last_name_label"), class: "form-label" %>
+        <%= f.label :last_name, t(".last_name_label"), class: "form-label form-control govuk-input--width-20" %>
         <%= f.text_field :last_name, value: @contact_name_form.last_name, class: "form-control" %>
       </fieldset>
     </div>

--- a/app/views/waste_exemptions_engine/contact_name_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_name_forms/new.html.erb
@@ -18,8 +18,8 @@
         <span class="error-message"><%= @contact_name_form.errors[:first_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :first_name, t(".first_name_label"), class: "form-label form-control govuk-input--width-20" %>
-        <%= f.text_field :first_name, value: @contact_name_form.first_name, class: "form-control" %>
+        <%= f.label :first_name, t(".first_name_label"), class: "form-label form-control" %>
+        <%= f.text_field :first_name, value: @contact_name_form.first_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>
 
@@ -33,8 +33,8 @@
         <span class="error-message"><%= @contact_name_form.errors[:last_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :last_name, t(".last_name_label"), class: "form-label form-control govuk-input--width-20" %>
-        <%= f.text_field :last_name, value: @contact_name_form.last_name, class: "form-control" %>
+        <%= f.label :last_name, t(".last_name_label"), class: "form-label form-control" %>
+        <%= f.text_field :last_name, value: @contact_name_form.last_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>
 

--- a/app/views/waste_exemptions_engine/contact_phone_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_phone_forms/new.html.erb
@@ -20,7 +20,7 @@
           <%= t(".phone_number_label") %>
           <span class='form-hint'><%= t(".phone_number_hint") %></span>
         <% end %>
-        <%= f.telephone_field :phone_number, value: @contact_phone_form.phone_number, class: "form-control" %>
+        <%= f.telephone_field :phone_number, value: @contact_phone_form.phone_number, class: "form-control govuk-input--width-10" %>
       </fieldset>
     </div>
 

--- a/app/views/waste_exemptions_engine/contact_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_postcode_forms/new.html.erb
@@ -24,7 +24,7 @@
           <%= t(".postcode_label") %>
           <span class='form-hint'><%= t(".postcode_hint") %></span>
         <% end %>
-        <%= f.text_field :postcode, value: @contact_postcode_form.postcode, class: "form-control" %>
+        <%= f.text_field :postcode, value: @contact_postcode_form.postcode, class: "form-control govuk-input--width-10" %>
 
       </fieldset>
     </div>

--- a/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
@@ -20,7 +20,7 @@
         <span class="error-message"><%= @operator_postcode_form.errors[:postcode].join(", ") %></span>
         <% end %>
 
-        <%= f.label :postcode, class: "form-label govuk-input--width-10" do %>
+        <%= f.label :postcode, class: "form-label" do %>
           <%= t(".postcode_label") %>
           <span class='form-hint'><%= t(".postcode_hint") %></span>
         <% end %>

--- a/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
@@ -24,7 +24,7 @@
           <%= t(".postcode_label") %>
           <span class='form-hint'><%= t(".postcode_hint") %></span>
         <% end %>
-        <%= f.text_field :postcode, value: @operator_postcode_form.postcode, class: "form-control" %>
+        <%= f.text_field :postcode, value: @operator_postcode_form.postcode, class: "form-control govuk-input--width-10" %>
 
       </fieldset>
     </div>

--- a/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
@@ -20,7 +20,7 @@
         <span class="error-message"><%= @operator_postcode_form.errors[:postcode].join(", ") %></span>
         <% end %>
 
-        <%= f.label :postcode, class: "form-label" do %>
+        <%= f.label :postcode, class: "form-label govuk-input--width-10" do %>
           <%= t(".postcode_label") %>
           <span class='form-hint'><%= t(".postcode_hint") %></span>
         <% end %>

--- a/app/views/waste_exemptions_engine/site_grid_reference_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/site_grid_reference_forms/new.html.erb
@@ -20,7 +20,7 @@
           <%= t(".grid_reference_label") %>
           <span class='form-hint'><%= t(".grid_reference_hint") %></span>
         <% end %>
-        <%= f.text_field :grid_reference, value: @site_grid_reference_form.grid_reference, class: "form-control" %>
+        <%= f.text_field :grid_reference, value: @site_grid_reference_form.grid_reference, class: "form-control govuk-input--width-10" %>
       </fieldset>
     </div>
 

--- a/app/views/waste_exemptions_engine/site_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/site_postcode_forms/new.html.erb
@@ -20,7 +20,7 @@
         <span class="error-message"><%= @site_postcode_form.errors[:postcode].join(", ") %></span>
         <% end %>
 
-        <%= f.label :postcode, class: "form-label" do %>
+        <%= f.label :postcode, class: "form-label govuk-input--width-10" do %>
           <%= t(".postcode_label") %>
           <span class='form-hint'><%= t(".postcode_hint") %></span>
         <% end %>

--- a/app/views/waste_exemptions_engine/site_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/site_postcode_forms/new.html.erb
@@ -20,11 +20,11 @@
         <span class="error-message"><%= @site_postcode_form.errors[:postcode].join(", ") %></span>
         <% end %>
 
-        <%= f.label :postcode, class: "form-label govuk-input--width-10" do %>
+        <%= f.label :postcode, class: "form-label" do %>
           <%= t(".postcode_label") %>
           <span class='form-hint'><%= t(".postcode_hint") %></span>
         <% end %>
-        <%= f.text_field :postcode, value: @site_postcode_form.postcode, class: "form-control" %>
+        <%= f.text_field :postcode, value: @site_postcode_form.postcode, class: "form-control govuk-input--width-10" %>
 
       </fieldset>
     </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-96

* This will replace existing form input width styling with that of the gov design system, making approximation where required (i.e. we can't import the actual styles yet, but replication should make a clean upgrade path).

This need to be reviewed in tandem with https://github.com/DEFRA/waste-exemptions-front-office/pull/23

Merge this before the front-office PR to prevent layout regression.