### PR TITLE
Fix address form 500 error

### DIFF
--- a/app/forms/waste_exemptions_engine/address_form.rb
+++ b/app/forms/waste_exemptions_engine/address_form.rb
@@ -19,7 +19,7 @@ module WasteExemptionsEngine
         matched_address.delete
       end
 
-      updated_addresses << address
+      updated_addresses << address if address
 
       updated_addresses
     end

--- a/app/forms/waste_exemptions_engine/address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/address_lookup_form.rb
@@ -20,13 +20,15 @@ module WasteExemptionsEngine
       # Assign the params for validation and pass them to the BaseForm method for updating
       new_address = create_address(params[:temp_address])
 
-      self.temp_addresses = add_or_replace_address(new_address, @transient_registration.transient_addresses)
-      attributes = { transient_addresses: temp_addresses }
+      self.temp_address = new_address
+      attributes = { 
+        transient_addresses: add_or_replace_address(new_address, @transient_registration.transient_addresses) 
+      }
 
       super(attributes, params[:token])
     end
 
-    validates :temp_addresses, presence: true
+    validates :temp_address, "waste_exemptions_engine/address": true
 
     private
 

--- a/app/forms/waste_exemptions_engine/address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/address_lookup_form.rb
@@ -21,8 +21,8 @@ module WasteExemptionsEngine
       new_address = create_address(params[:temp_address])
 
       self.temp_address = new_address
-      attributes = { 
-        transient_addresses: add_or_replace_address(new_address, @transient_registration.transient_addresses) 
+      attributes = {
+        transient_addresses: add_or_replace_address(new_address, @transient_registration.transient_addresses)
       }
 
       super(attributes, params[:token])

--- a/config/locales/forms/contact_address_lookup_forms/en.yml
+++ b/config/locales/forms/contact_address_lookup_forms/en.yml
@@ -12,9 +12,9 @@ en:
   activemodel:
     errors:
       models:
-        waste_exemptions_engine/contact_address_lookup_forms:
+        waste_exemptions_engine/contact_address_lookup_form:
           attributes:
-            addresses:
+            temp_address:
               blank: "You must select an address"
             token:
               invalid_format: "The token is not valid"

--- a/config/locales/forms/operator_address_lookup_forms/en.yml
+++ b/config/locales/forms/operator_address_lookup_forms/en.yml
@@ -18,9 +18,9 @@ en:
   activemodel:
     errors:
       models:
-        waste_exemptions_engine/operator_address_lookup_forms:
+        waste_exemptions_engine/operator_address_lookup_form:
           attributes:
-            addresses:
+            temp_address:
               blank: "You must select an address"
             token:
               invalid_format: "The token is not valid"

--- a/config/locales/forms/site_address_lookup_forms/en.yml
+++ b/config/locales/forms/site_address_lookup_forms/en.yml
@@ -12,9 +12,9 @@ en:
   activemodel:
     errors:
       models:
-        waste_exemptions_engine/site_address_lookup_forms:
+        waste_exemptions_engine/site_address_lookup_form:
           attributes:
-            addresses:
+            temp_address:
               blank: "You must select an address"
             token:
               invalid_format: "The token is not valid"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-83

While testing RUBY-83, Tim found an unhandled 500 error when submitting the address form. This PR attempts to fix that error.

WIPThe includes includes an adjustment of the validation in the AddressLookupForm class to ensure the messaging and behaviour is consistent with WCR.