### PR TITLE
Add missing label text for person name form partial

### DIFF
--- a/config/locales/partials/person_name.en.yml
+++ b/config/locales/partials/person_name.en.yml
@@ -1,0 +1,6 @@
+en:
+  waste_exemptions_engine:
+    shared:
+      person_name:
+        first_name: "First name"
+        last_name: "Last name"


### PR DESCRIPTION
This should fix the `translation missing: en.waste_exemptions_engine.shared.person_name.first_name` error encountered in the back office.