### PR TITLE
Make find_address_by_type work with reg addresses

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_have_registration_attributes.rb
@@ -28,6 +28,14 @@ module WasteExemptionsEngine
     private
 
     def find_address_by_type(address_type)
+      if addresses.present?
+        addresses.where(address_type: address_type).first
+      else
+        find_transient_address_by_type(address_type)
+      end
+    end
+
+    def find_transient_address_by_type(address_type)
       return nil unless transient_addresses.present?
 
       transient_addresses.where(address_type: address_type).first


### PR DESCRIPTION
This came out of https://eaflood.atlassian.net/browse/RUBY-60.

This commit should allow us to call `find_address_by_type` on a registration and return the correct addresses. Previously it would only check related transient_addresses, which a registration should never have.