### PR TITLE
Fix typo on check details page

### DIFF
--- a/config/locales/forms/check_your_answers_forms/en.yml
+++ b/config/locales/forms/check_your_answers_forms/en.yml
@@ -35,7 +35,7 @@ en:
           company_no_html: "the Companies House number is <span class=\"strong\">%{value}</span>"
           subheading_address: Operator address
         contact:
-          subheading: Contact deatils
+          subheading: Contact details
           name_html: "the contact's name is <span class=\"strong\">%{value}</span>"
           position_html: "the contact's position is <span class=\"strong\">%{value}</span>"
           phone_html: "the contact's phone number is <span class=\"strong\">%{value}</span>"


### PR DESCRIPTION
This should be `contact details` and not `contact deatils`.