### PR TITLE
Unlock Rails version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       os_map_ref (~> 0.5)
       pg (~> 0.18.4)
       phonelib
-      rails (= 4.2.11)
+      rails (~> 4.2.11)
       rest-client (~> 2.0)
       uk_postcode
       validates_email_format_of

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "aasm", "~> 4.12"
   s.add_dependency "has_secure_token"
   s.add_dependency "high_voltage", "~> 3.1"
-  s.add_dependency "rails", "4.2.11"
+  s.add_dependency "rails", "~> 4.2.11"
   # Use rest-client for external requests, eg. to Companies House
   s.add_dependency "rest-client", "~> 2.0"
 


### PR DESCRIPTION
Previously our Gemfiles locked Rails to a specific version (4.2.11). This meant that Dependabot would not prompt us with upgrades. As there is now a critical security patch we'd like to apply, we've decided it's better to accept 4.2.11 and above (within the 4.2 range). This should allow Dependabot to submit PRs for patch-level changes to Rails.