### PR TITLE
Save the assistance mode for a registration

### DIFF
--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -15,7 +15,7 @@ module WasteExemptionsEngine
         copy_exemptions
         copy_people
 
-        @registration.submitted_at = Date.today
+        add_metadata
         @registration.save!
         @transient_registration.destroy
       end
@@ -49,6 +49,11 @@ module WasteExemptionsEngine
       @transient_registration.transient_people.each do |trans_person|
         @registration.people << Person.new(trans_person.person_attributes)
       end
+    end
+
+    def add_metadata
+      @registration.assistance_mode = WasteExemptionsEngine.configuration.default_assistance_mode
+      @registration.submitted_at = Date.today
     end
 
     def include_people?

--- a/db/migrate/20190314161232_add_assistance_mode_to_registrations.rb
+++ b/db/migrate/20190314161232_add_assistance_mode_to_registrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAssistanceModeToRegistrations < ActiveRecord::Migration
+  def change
+    add_column :registrations, :assistance_mode, :string
+  end
+end

--- a/lib/waste_exemptions_engine.rb
+++ b/lib/waste_exemptions_engine.rb
@@ -21,7 +21,7 @@ module WasteExemptionsEngine
 
   class Configuration
     # General config
-    attr_accessor :service_name, :application_name, :git_repository_url, :years_before_expiry
+    attr_accessor :service_name, :application_name, :git_repository_url, :years_before_expiry, :default_assistance_mode
     # Addressbase config
     attr_accessor :addressbase_url
     # Email config

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190228152336) do
+ActiveRecord::Schema.define(version: 20190314161232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 20190228152336) do
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
     t.date     "submitted_at"
+    t.string   "assistance_mode"
   end
 
   add_index "registrations", ["reference"], name: "index_registrations_on_reference", unique: true, using: :btree

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -30,6 +30,17 @@ module WasteExemptionsEngine
           expect(registration.submitted_at).to eq(Date.current)
         end
 
+        context "when the default_assistance_mode is set" do
+          before do
+            allow(WasteExemptionsEngine.configuration).to receive(:default_assistance_mode).and_return("foo")
+          end
+
+          it "updates the registration's route to the correct value" do
+            registration_completion_service.complete
+            expect(registration.reload.assistance_mode).to eq("foo")
+          end
+        end
+
         it "deletes the transient registration" do
           registration_completion_service.complete
           expect(TransientRegistration.where(reference: transient_registration.reference).count).to eq(0)

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -41,6 +41,17 @@ module WasteExemptionsEngine
           end
         end
 
+        context "when the default_assistance_mode is not set" do
+          before do
+            allow(WasteExemptionsEngine.configuration).to receive(:default_assistance_mode).and_return(nil)
+          end
+
+          it "updates the registration's route to the correct value" do
+            registration_completion_service.complete
+            expect(registration.reload.assistance_mode).to eq(nil)
+          end
+        end
+
         it "deletes the transient registration" do
           registration_completion_service.complete
           expect(TransientRegistration.where(reference: transient_registration.reference).count).to eq(0)

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RegistrationCompletionService do
+    let(:transient_registration) { create(:transient_registration, :complete, workflow_state: "registration_complete_form") }
+    let(:registration) { Registration.where(reference: transient_registration.reference).first }
+
+    let(:registration_completion_service) { RegistrationCompletionService.new(transient_registration) }
+
+    describe "#complete" do
+      context "when the registration can be completed" do
+        it "copies attributes from the transient_registration to the registration" do
+          transient_registration_attribute = transient_registration.operator_name
+          registration_completion_service.complete
+          registration_attribute = registration.operator_name
+          expect(registration_attribute).to eq(transient_registration_attribute)
+        end
+
+        it "copies attributes from associated transient objects to non-transient objects" do
+          transient_registration_attribute = transient_registration.site_address.description
+          registration_completion_service.complete
+          registration_attribute = registration.site_address.description
+          expect(registration_attribute).to eq(transient_registration_attribute)
+        end
+
+        it "sets the correct value for submitted_at" do
+          registration_completion_service.complete
+          expect(registration.submitted_at).to eq(Date.current)
+        end
+
+        it "deletes the transient registration" do
+          registration_completion_service.complete
+          expect(TransientRegistration.where(reference: transient_registration.reference).count).to eq(0)
+        end
+
+        it "sends a confirmation email" do
+          old_emails_sent_count = ActionMailer::Base.deliveries.count
+          registration_completion_service.complete
+          expect(ActionMailer::Base.deliveries.count).to eq(old_emails_sent_count + 1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-200

A registration should have a different assistance_mode depending on whether it was submitted through the front-office or back-office. This allows us to track what proportion of registrations are assisted digital.