### PR TITLE
Load engine migrations before host app migrations

### DIFF
--- a/lib/waste_exemptions_engine/engine.rb
+++ b/lib/waste_exemptions_engine/engine.rb
@@ -29,7 +29,8 @@ module WasteExemptionsEngine
     initializer :append_migrations do |app|
       unless app.root.to_s.match?(root.to_s)
         config.paths["db/migrate"].expanded.each do |expanded_path|
-          app.config.paths["db/migrate"] << expanded_path
+          # Run the engine migrations before the host app migrations
+          app.config.paths["db/migrate"].unshift(expanded_path)
         end
       end
     end


### PR DESCRIPTION
This came out of our story to implement PaperTrail in this engine and the back office. Since we were tracking models in both projects, we ended up with two migrations to create a Versions table, which then caused a clash. So rather than have two migrations, it makes sense for the engine's migrations to take precidence, and for it to handle the creation of the versions table.