### PR TITLE
Refactor CanChangeExemptionStatus into CanActivateExemption

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_activate_exemption.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_activate_exemption.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
-  module CanChangeExemptionStatus
+  module CanActivateExemption
     extend ActiveSupport::Concern
 
     included do
@@ -10,9 +10,6 @@ module WasteExemptionsEngine
       aasm column: :state do
         state :pending, initial: true
         state :active
-        state :ceased
-        state :expired
-        state :revoked
 
         event :activate do
           transitions from: :pending,

--- a/app/models/waste_exemptions_engine/transient_registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/transient_registration_exemption.rb
@@ -2,7 +2,7 @@
 
 module WasteExemptionsEngine
   class TransientRegistrationExemption < ActiveRecord::Base
-    include CanChangeExemptionStatus
+    include CanActivateExemption
 
     self.table_name = "transient_registration_exemptions"
 


### PR DESCRIPTION
We decided to limit the scope of `CanChangeExemptionStatus` in the WEX engine to only handle activations. Deregistrations will be handled through a service in the back-office repository.