### PR TITLE
Add message column to registration exemption

### DIFF
--- a/db/migrate/20190319133740_add_deregistration_message_to_registration_exemption.rb
+++ b/db/migrate/20190319133740_add_deregistration_message_to_registration_exemption.rb
@@ -1,0 +1,5 @@
+class AddDeregistrationMessageToRegistrationExemption < ActiveRecord::Migration
+  def change
+    add_column :registration_exemptions, :deregistration_message, :text
+  end
+end

--- a/spec/cassettes/company_no_valid.yml
+++ b/spec/cassettes/company_no_valid.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 07 Mar 2019 11:13:28 GMT
+      - Thu, 21 Mar 2019 14:55:42 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -49,9 +49,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '592'
+      - '595'
       X-Ratelimit-Reset:
-      - '1551957314'
+      - '1553180388'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -61,4 +61,5 @@ http_interactions:
       string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"next_due":"2019-09-30","next_made_up_to":"2018-12-31","next_accounts":{"overdue":false,"period_start_on":"2018-01-01","due_on":"2019-09-30","period_end_on":"2018-12-31"},"accounting_reference_date":{"month":"12","day":"31"},"last_accounts":{"period_end_on":"2017-12-31","period_start_on":"2017-01-01","made_up_to":"2017-12-31"},"overdue":false},"undeliverable_registered_office_address":false,"etag":"0ec9d00cab0ffee2ef1f5d59f4f714fa5b1618f5","company_number":"09360070","registered_office_address":{"postal_code":"SM3
         9ND","locality":"Sutton","region":"Surrey","address_line_1":"21 Haslam Avenue"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"overdue":false,"next_made_up_to":"2020-01-23","last_made_up_to":"2019-01-23","next_due":"2020-02-06"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Thu, 07 Mar 2019 11:13:28 GMT
+  recorded_at: Thu, 21 Mar 2019 14:55:44 GMT
+recorded_with: VCR 4.0.0

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190314161232) do
+ActiveRecord::Schema.define(version: 20190319133740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,8 +69,9 @@ ActiveRecord::Schema.define(version: 20190314161232) do
     t.date     "expires_on"
     t.integer  "registration_id"
     t.integer  "exemption_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.text     "deregistration_message"
   end
 
   add_index "registration_exemptions", ["exemption_id"], name: "index_registration_exemptions_on_exemption_id", using: :btree

--- a/spec/models/waste_exemptions_engine/transient_registration_exemption_spec.rb
+++ b/spec/models/waste_exemptions_engine/transient_registration_exemption_spec.rb
@@ -9,7 +9,7 @@ module WasteExemptionsEngine
     describe "public interface" do
       associations = %i[transient_registration exemption]
 
-      (Helpers::ModelProperties::REGISTRATION_EXEMPTION + associations).each do |property|
+      (Helpers::ModelProperties::TRANSIENT_REGISTRATION_EXEMPTION + associations).each do |property|
         it "responds to property" do
           expect(transient_registration_exemption).to respond_to(property)
         end
@@ -19,7 +19,7 @@ module WasteExemptionsEngine
     describe "#exemption_attributes" do
       it "returns attributes specific to defining an exemption" do
         attributes = transient_registration_exemption.exemption_attributes
-        exemption_attributes = Helpers::ModelProperties::REGISTRATION_EXEMPTION.map(&:to_s) + ["exemption_id"]
+        exemption_attributes = Helpers::ModelProperties::TRANSIENT_REGISTRATION_EXEMPTION.map(&:to_s) + ["exemption_id"]
         expect(attributes.keys).to match_array(exemption_attributes)
       end
     end

--- a/spec/support/helpers/model_properties.rb
+++ b/spec/support/helpers/model_properties.rb
@@ -41,9 +41,12 @@ module Helpers
 
     REGISTRATION_EXEMPTION = %i[
       state
+      deregistration_message
       registered_on
       expires_on
     ].freeze
+
+    TRANSIENT_REGISTRATION_EXEMPTION = (REGISTRATION_EXEMPTION - [:deregistration_message]).freeze
 
     REGISTRATION = %i[
       reference


### PR DESCRIPTION
The "deregister individual exemptions" feature in the WEX back-office needs a new column on the `registration_exemptions` table. The `deregistration_message` column is used to store the reason why an exemption is being deregistered.