### PR TITLE
 Add deregistered_on to registration_exemptions

### DIFF
--- a/db/migrate/20190326133420_add_deregistered_on_to_registration_exemption.rb
+++ b/db/migrate/20190326133420_add_deregistered_on_to_registration_exemption.rb
@@ -1,0 +1,5 @@
+class AddDeregisteredOnToRegistrationExemption < ActiveRecord::Migration
+  def change
+    add_column :registration_exemptions, :deregistered_on, :date
+  end
+end

--- a/spec/cassettes/postcode_no_matches.yml
+++ b/spec/cassettes/postcode_no_matches.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Mar 2019 08:55:57 GMT
+      - Tue, 26 Mar 2019 13:37:33 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -35,5 +35,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAFWOywrCMBBF/2UWXZWm3QaCBHSpuBcpYxJpMSYhMymK+O8GHwuX5z7gPIAjo98im8kRyL4FYsz8DkCG4n0LLtg/LnkeOY5UUvKzyyBhYk4khcA0dzHbgME4Knlx987ErlxE8lgTsQwCrc2OqEKKxCZat/JZbXbND5XWw6B1c8VbHRbPpIa+bywykmO13mv4KJxzvI6mGgSuCsTlVIvvBeTh+HwB/2bVRt0AAAA=
     http_version: 
-  recorded_at: Tue, 12 Mar 2019 08:55:57 GMT
+  recorded_at: Tue, 26 Mar 2019 13:37:34 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/postcode_valid.yml
+++ b/spec/cassettes/postcode_valid.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 Mar 2019 08:55:51 GMT
+      - Tue, 26 Mar 2019 13:37:32 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -35,5 +35,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAM2TXWvbMBSG/4rRRa6MLSVNnBrCcBbThKV2sJONbgyj2lprplhCH6Wh9L/vOB9rzHqxXuzjSjrn6Lzn5TzoCRlhKL+mprxnGoUDF2lDldknUEhcxJrqGEDNqrowotBWSl4zhUJ0b4zUoe9TWXtCVQ1tSqatemA7rxSe/e5LTiHjPxCfVpViWkMghTalqNg7riZx0juFk2lOhtG8t6WP8NByoycE415FDdXMTGarCB0sfFNiW5TgoDFgQRt7C4VjCwq/PCErVQOGLzAhIxcdB8PTJFpvsmjpxMnVMkpmrjNPs8XnNIFzk8euM4ujJM5unCyNoDjNFvk6XcIlJw4YgyFC3dGm1tTUovlVDx5Ixba1bleJOtqoXaxizBQvbs6nQZ2LkvLa7FDYWM5dVO7v6Oii1T7uqU3+dPQI0WA47uOhhwcQty0k6Ad47OEA4lIAlrqhhhV6pw3bnuSBM+Rgua0e6fsE+32ML6HllktbHMqHcYeGdjzlJ/+dEhd3NZjfN9luSQuryv0cWpidbIdVkqJn90QJEF+SYIRHF/gc1TzKrvM4ca6ydLNynXW2SGdp7kyj5MPbOXXEupTOhf80JDLAHnlhNBoH3vi3GR0yf5fN/gcF51jW82zxMXayOIk/RdNlnDur5fu3A3lVpgPmtID/Fcc/+DJfn38ABFoygK8FAAA=
     http_version: 
-  recorded_at: Tue, 12 Mar 2019 08:55:52 GMT
+  recorded_at: Tue, 26 Mar 2019 13:37:33 GMT
 recorded_with: VCR 4.0.0

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190319133740) do
+ActiveRecord::Schema.define(version: 20190326133420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 20190319133740) do
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.text     "deregistration_message"
+    t.date     "deregistered_on"
   end
 
   add_index "registration_exemptions", ["exemption_id"], name: "index_registration_exemptions_on_exemption_id", using: :btree

--- a/spec/support/helpers/model_properties.rb
+++ b/spec/support/helpers/model_properties.rb
@@ -42,11 +42,12 @@ module Helpers
     REGISTRATION_EXEMPTION = %i[
       state
       deregistration_message
+      deregistered_on
       registered_on
       expires_on
     ].freeze
 
-    TRANSIENT_REGISTRATION_EXEMPTION = (REGISTRATION_EXEMPTION - [:deregistration_message]).freeze
+    TRANSIENT_REGISTRATION_EXEMPTION = (REGISTRATION_EXEMPTION - %i[deregistration_message deregistered_on]).freeze
 
     REGISTRATION = %i[
       reference


### PR DESCRIPTION
The exemption de-registration functionality needs to record the DateTime when the de-registration occurs. This PR adds the date column necessary to record this data.

This is a dependency for the completion of DEFRA/waste-exemptions-back-office-ta/pull/90/. 