### PR TITLE
Refactor boolean config values to behave as booleans

### DIFF
--- a/config/initializers/wickedpdf.rb
+++ b/config/initializers/wickedpdf.rb
@@ -2,7 +2,7 @@
 
 require "wicked_pdf"
 
-if WasteExemptionsEngine.configuration.use_xvfb_for_wickedpdf == "true"
+if WasteExemptionsEngine.configuration.use_xvfb_for_wickedpdf
   WickedPdf.config = {
     exe_path: WasteExemptionsEngine::Engine.root.join("script", "wkhtmltopdf.sh").to_s
   }

--- a/lib/waste_exemptions_engine.rb
+++ b/lib/waste_exemptions_engine.rb
@@ -27,7 +27,7 @@ module WasteExemptionsEngine
     # Email config
     attr_accessor :email_service_email
     # PDF config
-    attr_accessor :use_xvfb_for_wickedpdf
+    attr_writer :use_xvfb_for_wickedpdf
     # PaperTrail config
     attr_accessor :use_current_user_for_whodunnit
 
@@ -37,7 +37,12 @@ module WasteExemptionsEngine
     def initialize
       @service_name = "Waste Exemptions Service"
       @years_before_expiry = 3
-      @use_xvfb_for_wickedpdf = "true"
+      @use_xvfb_for_wickedpdf = true
+    end
+
+    def use_xvfb_for_wickedpdf
+      @use_xvfb_for_wickedpdf = @use_xvfb_for_wickedpdf == "true" if @use_xvfb_for_wickedpdf.is_a?(String)
+      @use_xvfb_for_wickedpdf
     end
 
     def companies_house_host=(value)


### PR DESCRIPTION
We noticed that the one boolean config values is being used as a string in the code requiring the `value =="true"` pattern.

This PR refactors this so the config value can be set as a string but referenced as a boolean in the code.