### PR TITLE
Format dates with unpadded day instead of blank-padded

### DIFF
--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
-Date::DATE_FORMATS[:day_month_year] = "%e %B %Y"
+# Returns a date in this format: 1 January 2019
+Date::DATE_FORMATS[:day_month_year] = "%-d %B %Y"


### PR DESCRIPTION
Spotted that we were using `%e` for our default date formats, which actaully returns a blank-padded day of the month (eg ` 1` with a space in front of it) instead of the unpadded value we want (eg `1`). This update fixes the format.