### PR TITLE
Add html view which is used to generate PDF privacy

### DIFF
--- a/app/views/waste_exemptions_engine/pdfs/privacy_policy.html
+++ b/app/views/waste_exemptions_engine/pdfs/privacy_policy.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Privacy policy</title>
+    <style type='text/css'>
+      * {
+        font-family: Helvetica, Arial, Sans-Serif !important;
+        background: #FFF;
+      }
+      body {
+        margin: 40px 60px;
+      }
+      li, p {
+        font-size: 14px;
+        line-height: 1.3;
+      }
+      p.small {
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="wrapper">
+      <main id="content" role="main">
+        <div>
+          <div>
+            <!-- Header section -->
+            <header>
+              <div>
+                <h1>
+                  Privacy Policy: how we use your personal information
+                </h1>
+              </div>
+            </header>
+
+            <p>
+              We are the Environment Agency and we run the Register Your Waste Exemptions service. We are the
+              data controller for this service. A data controller determines how and why personal data
+              (personal information) is processed.
+            </p>
+            <p>
+              Our <a href="https://www.gov.uk/government/organisations/environment-agency/about/personal-information-charter">personal information charter</a>
+              explains your rights and how we deal with your personal information. You can access the charter
+              using the link or go to gov.uk and search 'Environment Agency personal information charter’.
+            </p>
+
+            <h2>
+              The personal data we need
+            </h2>
+            <p>The personal data we collect about you includes:</p>
+            <ul>
+              <li>the name and address of your business or organisation</li>
+              <li>contact details</li>
+              <li>the type of exempt waste operations being carried out</li>
+              <li>the locations of these operations</li>
+            </ul>
+            <p>
+              We are allowed to process your personal data because we have official authority to register
+              waste exemptions. The lawful basis for processing your personal data is to perform a task in
+              the public interest that is set out in law.
+            </p>
+
+            <h2>
+              What we do with your personal data
+            </h2>
+            <p>
+              We use your personal data in order to process your registration. If you don't provide the
+              information requested, we can't register your waste exemptions.
+            </p>
+            <p>
+              We do not use your personal data to make an automated decision or for automated profiling.
+            </p>
+            <p>
+              We will not share or disclose your personal data to any party outside the Environment Agency
+              without your explicit consent unless we are lawfully able to do so.
+            </p>
+            <p>
+              We put some of the information from your registration on a public register. This will include
+              the name and address of your business, the type of exempt waste operations being carried out,
+              and the locations of these operations. We will not share or disclose your personal data to any
+              other party outside the Environment Agency without your explicit consent, unless lawfully able
+              to do so.
+            </p>
+
+            <h2>
+              How long we keep your personal data
+            </h2>
+            <p>
+              We will keep your personal data for 7 years after a registration has ended.
+            </p>
+
+            <h2>
+              Where your personal data is processed and stored
+            </h2>
+            <p>
+              We store and process your personal data on our servers within the European Economic Area (EEA).
+              We will not transfer your personal data outside the EEA.
+            </p>
+
+            <h2>
+              Contact details
+            </h2>
+            <p>
+              Our Data Protection Officer (DPO) is responsible for independent advice and monitoring of the
+              Environment Agency’s use of personal information.
+            </p>
+            <p>
+              If you have any concerns or queries about how we process personal data, or if you would like to
+              make a complaint or request relating to data protection, please contact:
+            </p>
+            <p>
+              Data Protection Officer<br>
+              Environment Agency<br>
+              Horizon House<br>
+              Deanery Road<br>
+              Bristol<br>
+              BS1 5AH
+            </p>
+            <p>
+              Email: <a href="mailto:dataprotection@environment-agency.gov.uk">dataprotection@environment-agency.gov.uk</a>
+            <p>
+            <p>
+              The Information Commissioner's Office (ICO) is the supervisory authority for data protection
+              legislation. <a href="https://ico.org.uk/your-data-matters">The ICO website</a>
+              has a full list of your rights under data protection legislation.
+            </p>
+            <p>
+              You have the <a href="https://ico.org.uk/make-a-complaint">right to lodge a complaint with the ICO</a> at any time.
+            </p>
+            <p class="small">
+              This notice was last updated on 14 February 2019.
+            </p>
+          </div>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-216

Data protection asked us to include a copy of the privacy policy for those users who complete their registration via NCCC as assisted digital.

The team looked at the problem and decided it would just be simpler and meet the need more if we just attached a copy of the policy to all emails.

However as the policy contains no dynamic elements there would be no need to generate it each time we send the email. It would be better if we could generate the PDF ahead of time, add it as a static asset to the projects and then just attach that asset to the confirmation email.

The need to generate and update the PDF will be very infrequent (we are talking years) so rather than try and do anything ourselves we will just take advantage of available online generators.

For them to work they need to be provided with the HTML to convert, hence this change which adds pdf specific version of the privacu policy we can upload to be converted.

N.B. At this time (April 2019) we are using https://html2pdf.com/ to convert the html to PDF.