### PR TITLE
Add `layout: false` when rendering PDF views to string.

### DIFF
--- a/app/services/waste_exemptions_engine/confirmation_pdf_generator_service.rb
+++ b/app/services/waste_exemptions_engine/confirmation_pdf_generator_service.rb
@@ -19,6 +19,7 @@ module WasteExemptionsEngine
         pdf: "certificate",
         template: "waste_exemptions_engine/pdfs/certificate",
         encoding: "UTF-8",
+        layout: false,
         locals: locals
       )
     end


### PR DESCRIPTION
This solves a bug on the most recent refactoring for which the `render_to_string` method fails outside of a request scope because the included application Layout depends on the presence of a `@_request` object. Since we don't need our PDF's views to be rendered with a layout, this PR explicitly tells rails not to fetch it.