### PR TITLE
Refactor address workflow tests to use shared examples

### DIFF
--- a/spec/models/waste_exemptions_engine/transient_registration_workflow_state/contact_address_lookup_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/transient_registration_workflow_state/contact_address_lookup_form_spec.rb
@@ -5,64 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe TransientRegistration, type: :model do
     describe "#workflow_state" do
-      previous_state = :contact_postcode_form
-      current_state = :contact_address_lookup_form
-      subject(:transient_registration) { create(:transient_registration, workflow_state: current_state) }
-
-      context "when a TransientRegistration's state is #{current_state}" do
-        context "when transient_registration.skip_to_manual_address? is false" do
-          next_state = :on_a_farm_form
-          alt_state = :contact_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = false }
-
-          it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state, alt_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-
-          it "changes to #{alt_state} after the 'skip_to_manual_address' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration)
-              .to transition_from(current_state)
-              .to(alt_state)
-              .on_event(:skip_to_manual_address)
-          end
-        end
-
-        context "when transient_registration.skip_to_manual_address? is true" do
-          next_state = :contact_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = true }
-
-          it "can only transition to either #{previous_state} or #{next_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(true)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-
-          it "changes to #{next_state} after the 'skip_to_manual_address' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(true)
-            expect(transient_registration)
-              .to transition_from(current_state)
-              .to(next_state)
-              .on_event(:skip_to_manual_address)
-          end
-        end
-
-        it "changes to #{previous_state} after the 'back' event" do
-          expect(transient_registration).to transition_from(current_state).to(previous_state).on_event(:back)
-        end
-      end
+      it_behaves_like "an address lookup transition",
+                      next_state_if_not_skipping_to_manual: :on_a_farm_form,
+                      address_type: "contact"
     end
   end
 end

--- a/spec/models/waste_exemptions_engine/transient_registration_workflow_state/contact_postcode_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/transient_registration_workflow_state/contact_postcode_form_spec.rb
@@ -5,56 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe TransientRegistration, type: :model do
     describe "#workflow_state" do
-      previous_state = :contact_email_form
-      current_state = :contact_postcode_form
-      subject(:transient_registration) { create(:transient_registration, workflow_state: current_state) }
-
-      context "when a TransientRegistration's state is #{current_state}" do
-        context "when transient_registration.skip_to_manual_address? is false" do
-          next_state = :contact_address_lookup_form
-          alt_state = :contact_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = false }
-
-          it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state, alt_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-
-          it "changes to #{alt_state} after the 'skip_to_manual_address' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration)
-              .to transition_from(current_state)
-              .to(alt_state)
-              .on_event(:skip_to_manual_address)
-          end
-        end
-
-        context "when transient_registration.skip_to_manual_address? is true" do
-          next_state = :contact_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = true }
-
-          it "can only transition to either #{previous_state} or #{next_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(true)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-        end
-
-        it "changes to #{previous_state} after the 'back' event" do
-          expect(transient_registration).to transition_from(current_state).to(previous_state).on_event(:back)
-        end
-      end
+      it_behaves_like "a postcode transition",
+                      previous_state: :contact_email_form,
+                      address_type: "contact"
     end
   end
 end

--- a/spec/models/waste_exemptions_engine/transient_registration_workflow_state/operator_address_lookup_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/transient_registration_workflow_state/operator_address_lookup_form_spec.rb
@@ -5,64 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe TransientRegistration, type: :model do
     describe "#workflow_state" do
-      previous_state = :operator_postcode_form
-      current_state = :operator_address_lookup_form
-      subject(:transient_registration) { create(:transient_registration, workflow_state: current_state) }
-
-      context "when a TransientRegistration's state is #{current_state}" do
-        context "when transient_registration.skip_to_manual_address? is false" do
-          next_state = :contact_name_form
-          alt_state = :operator_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = false }
-
-          it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state, alt_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-
-          it "changes to #{alt_state} after the 'skip_to_manual_address' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration)
-              .to transition_from(current_state)
-              .to(alt_state)
-              .on_event(:skip_to_manual_address)
-          end
-        end
-
-        context "when transient_registration.skip_to_manual_address? is true" do
-          next_state = :operator_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = true }
-
-          it "can only transition to either #{previous_state} or #{next_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(true)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-
-          it "changes to #{next_state} after the 'skip_to_manual_address' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(true)
-            expect(transient_registration)
-              .to transition_from(current_state)
-              .to(next_state)
-              .on_event(:skip_to_manual_address)
-          end
-        end
-
-        it "changes to #{previous_state} after the 'back' event" do
-          expect(transient_registration).to transition_from(current_state).to(previous_state).on_event(:back)
-        end
-      end
+      it_behaves_like "an address lookup transition",
+                      next_state_if_not_skipping_to_manual: :contact_name_form,
+                      address_type: "operator"
     end
   end
 end

--- a/spec/models/waste_exemptions_engine/transient_registration_workflow_state/operator_postcode_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/transient_registration_workflow_state/operator_postcode_form_spec.rb
@@ -5,56 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe TransientRegistration, type: :model do
     describe "#workflow_state" do
-      previous_state = :operator_name_form
-      current_state = :operator_postcode_form
-      subject(:transient_registration) { create(:transient_registration, workflow_state: current_state) }
-
-      context "when a TransientRegistration's state is #{current_state}" do
-        context "when transient_registration.skip_to_manual_address? is false" do
-          next_state = :operator_address_lookup_form
-          alt_state = :operator_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = false }
-
-          it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state, alt_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-
-          it "changes to #{alt_state} after the 'skip_to_manual_address' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration)
-              .to transition_from(current_state)
-              .to(alt_state)
-              .on_event(:skip_to_manual_address)
-          end
-        end
-
-        context "when transient_registration.skip_to_manual_address? is true" do
-          next_state = :operator_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = true }
-
-          it "can only transition to either #{previous_state} or #{next_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(true)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-        end
-
-        it "changes to #{previous_state} after the 'back' event" do
-          expect(transient_registration).to transition_from(current_state).to(previous_state).on_event(:back)
-        end
-      end
+      it_behaves_like "a postcode transition",
+                      previous_state: :operator_name_form,
+                      address_type: "operator"
     end
   end
 end

--- a/spec/models/waste_exemptions_engine/transient_registration_workflow_state/site_address_lookup_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/transient_registration_workflow_state/site_address_lookup_form_spec.rb
@@ -5,64 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe TransientRegistration, type: :model do
     describe "#workflow_state" do
-      previous_state = :site_postcode_form
-      current_state = :site_address_lookup_form
-      subject(:transient_registration) { create(:transient_registration, workflow_state: current_state) }
-
-      context "when a TransientRegistration's state is #{current_state}" do
-        context "when transient_registration.skip_to_manual_address? is false" do
-          next_state = :exemptions_form
-          alt_state = :site_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = false }
-
-          it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state, alt_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-
-          it "changes to #{alt_state} after the 'skip_to_manual_address' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration)
-              .to transition_from(current_state)
-              .to(alt_state)
-              .on_event(:skip_to_manual_address)
-          end
-        end
-
-        context "when transient_registration.skip_to_manual_address? is true" do
-          next_state = :site_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = true }
-
-          it "can only transition to either #{previous_state} or #{next_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(true)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-
-          it "changes to #{next_state} after the 'skip_to_manual_address' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(true)
-            expect(transient_registration)
-              .to transition_from(current_state)
-              .to(next_state)
-              .on_event(:skip_to_manual_address)
-          end
-        end
-
-        it "changes to #{previous_state} after the 'back' event" do
-          expect(transient_registration).to transition_from(current_state).to(previous_state).on_event(:back)
-        end
-      end
+      it_behaves_like "an address lookup transition",
+                      next_state_if_not_skipping_to_manual: :exemptions_form,
+                      address_type: "site"
     end
   end
 end

--- a/spec/models/waste_exemptions_engine/transient_registration_workflow_state/site_postcode_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/transient_registration_workflow_state/site_postcode_form_spec.rb
@@ -5,56 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe TransientRegistration, type: :model do
     describe "#workflow_state" do
-      previous_state = :site_grid_reference_form
-      current_state = :site_postcode_form
-      subject(:transient_registration) { create(:transient_registration, workflow_state: current_state) }
-
-      context "when a TransientRegistration's state is #{current_state}" do
-        context "when transient_registration.skip_to_manual_address? is false" do
-          next_state = :site_address_lookup_form
-          alt_state = :site_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = false }
-
-          it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state, alt_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-
-          it "changes to #{alt_state} after the 'skip_to_manual_address' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(false)
-            expect(transient_registration)
-              .to transition_from(current_state)
-              .to(alt_state)
-              .on_event(:skip_to_manual_address)
-          end
-        end
-
-        context "when transient_registration.skip_to_manual_address? is true" do
-          next_state = :site_address_manual_form
-
-          before(:each) { transient_registration.address_finder_error = true }
-
-          it "can only transition to either #{previous_state} or #{next_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(transient_registration)
-            expect(permitted_states).to match_array([previous_state, next_state])
-          end
-
-          it "changes to #{next_state} after the 'next' event" do
-            expect(transient_registration.send(:skip_to_manual_address?)).to eq(true)
-            expect(transient_registration).to transition_from(current_state).to(next_state).on_event(:next)
-          end
-        end
-
-        it "changes to #{previous_state} after the 'back' event" do
-          expect(transient_registration).to transition_from(current_state).to(previous_state).on_event(:back)
-        end
-      end
+      it_behaves_like "a postcode transition",
+                      previous_state: :site_grid_reference_form,
+                      address_type: "site"
     end
   end
 end

--- a/spec/support/shared_examples/models/transient_registration_workflow_state/a_postcode_transition.rb
+++ b/spec/support/shared_examples/models/transient_registration_workflow_state/a_postcode_transition.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a postcode transition" do |previous_state:, address_type:, factory: :transient_registration|
+  describe "#workflow_state" do
+    current_state = "#{address_type}_postcode_form".to_sym
+    subject(:subject) { create(factory, workflow_state: current_state) }
+
+    context "when subject.skip_to_manual_address? is false" do
+      next_state = "#{address_type}_address_lookup_form".to_sym
+      alt_state = "#{address_type}_address_manual_form".to_sym
+
+      before(:each) { subject.address_finder_error = false }
+
+      it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
+        permitted_states = Helpers::WorkflowStates.permitted_states(subject)
+        expect(permitted_states).to match_array([previous_state, next_state, alt_state])
+      end
+
+      it "changes to #{next_state} after the 'next' event" do
+        expect(subject.send(:skip_to_manual_address?)).to eq(false)
+        expect(subject).to transition_from(current_state).to(next_state).on_event(:next)
+      end
+
+      it "changes to #{alt_state} after the 'skip_to_manual_address' event" do
+        expect(subject.send(:skip_to_manual_address?)).to eq(false)
+        expect(subject)
+          .to transition_from(current_state)
+          .to(alt_state)
+          .on_event(:skip_to_manual_address)
+      end
+    end
+
+    context "when subject.skip_to_manual_address? is true" do
+      next_state = "#{address_type}_address_manual_form".to_sym
+
+      before(:each) { subject.address_finder_error = true }
+
+      it "can only transition to either #{previous_state} or #{next_state}" do
+        permitted_states = Helpers::WorkflowStates.permitted_states(subject)
+        expect(permitted_states).to match_array([previous_state, next_state])
+      end
+
+      it "changes to #{next_state} after the 'next' event" do
+        expect(subject.send(:skip_to_manual_address?)).to eq(true)
+        expect(subject).to transition_from(current_state).to(next_state).on_event(:next)
+      end
+    end
+
+    it "changes to #{previous_state} after the 'back' event" do
+      expect(subject).to transition_from(current_state).to(previous_state).on_event(:back)
+    end
+  end
+end

--- a/spec/support/shared_examples/models/transient_registration_workflow_state/an_address_lookup_transition.rb
+++ b/spec/support/shared_examples/models/transient_registration_workflow_state/an_address_lookup_transition.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "an address lookup transition" do |next_state_if_not_skipping_to_manual:, address_type:, factory: :transient_registration|
+  describe "#workflow_state" do
+    previous_state = "#{address_type}_postcode_form".to_sym
+    current_state = "#{address_type}_address_lookup_form".to_sym
+    subject(:subject) { create(factory, workflow_state: current_state) }
+
+    context "when subject.skip_to_manual_address? is false" do
+      next_state = next_state_if_not_skipping_to_manual
+      alt_state = "#{address_type}_address_manual_form".to_sym
+
+      before(:each) { subject.address_finder_error = false }
+
+      it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
+        permitted_states = Helpers::WorkflowStates.permitted_states(subject)
+        expect(permitted_states).to match_array([previous_state, next_state, alt_state])
+      end
+
+      it "changes to #{next_state} after the 'next' event" do
+        expect(subject.send(:skip_to_manual_address?)).to eq(false)
+        expect(subject).to transition_from(current_state).to(next_state).on_event(:next)
+      end
+
+      it "changes to #{alt_state} after the 'skip_to_manual_address' event" do
+        expect(subject.send(:skip_to_manual_address?)).to eq(false)
+        expect(subject)
+          .to transition_from(current_state)
+          .to(alt_state)
+          .on_event(:skip_to_manual_address)
+      end
+    end
+
+    context "when subject.skip_to_manual_address? is true" do
+      next_state = "#{address_type}_address_manual_form".to_sym
+
+      before(:each) { subject.address_finder_error = true }
+
+      it "can only transition to either #{previous_state} or #{next_state}" do
+        permitted_states = Helpers::WorkflowStates.permitted_states(subject)
+        expect(permitted_states).to match_array([previous_state, next_state])
+      end
+
+      it "changes to #{next_state} after the 'next' event" do
+        expect(subject.send(:skip_to_manual_address?)).to eq(true)
+        expect(subject).to transition_from(current_state).to(next_state).on_event(:next)
+      end
+
+      it "changes to #{next_state} after the 'skip_to_manual_address' event" do
+        expect(subject.send(:skip_to_manual_address?)).to eq(true)
+        expect(subject)
+          .to transition_from(current_state)
+          .to(next_state)
+          .on_event(:skip_to_manual_address)
+      end
+    end
+
+    it "changes to #{previous_state} after the 'back' event" do
+      expect(subject).to transition_from(current_state).to(previous_state).on_event(:back)
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-62

This PR adds some shared examples for the address workflow tests.

This will reduce duplication now, and prevent even more of it when we add more workflow tests for the edit workflow.