### PR TITLE
Remove byebug and swap it with pry-byebug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.0.1)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -120,6 +121,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    method_source (0.9.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
@@ -148,6 +150,12 @@ GEM
       ttfunk
     pg (0.18.4)
     phonelib (0.6.33)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     psych (3.1.0)
     public_suffix (3.0.3)
     rack (1.6.11)
@@ -256,13 +264,13 @@ PLATFORMS
 
 DEPENDENCIES
   bullet
-  byebug
   database_cleaner
   defra_ruby_style
   dotenv-rails
   factory_bot_rails
   github_changelog_generator
   pdf-reader
+  pry-byebug
   rspec-rails (~> 3.8.0)
   simplecov
   timecop

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@
 require "./spec/support/simplecov"
 
 # Support debugging in the tests
-require "byebug"
+require "pry-byebug"
 
 # Support time travel and time freeze
 require "timecop"

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -56,12 +56,12 @@ Gem::Specification.new do |s|
   s.add_development_dependency "github_changelog_generator"
 
   s.add_development_dependency "bullet"
-  s.add_development_dependency "byebug"
   s.add_development_dependency "database_cleaner"
   s.add_development_dependency "defra_ruby_style"
   s.add_development_dependency "dotenv-rails"
   s.add_development_dependency "factory_bot_rails"
   s.add_development_dependency "pdf-reader"
+  s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rspec-rails", "~> 3.8.0"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "timecop"


### PR DESCRIPTION
byebug has a very similar interface as gdb, but byebug does not use the powerful Pry REPL.
binding.pry uses Pry, but lacks some of the byebug features.
[pry-byebug](https://github.com/deivid-rodriguez/pry-byebug) brings some capabilities byebug to binding.pry, so using that, will give you the most debugging powers.

Credits: https://docs.gitlab.com/ee/development/pry_debugging.html#byebug-vs-bindingpry
