### PR TITLE
Raise completition errors to the customer

### DIFF
--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -23,6 +23,8 @@ module WasteExemptionsEngine
     rescue StandardError => error
       Airbrake.notify(error, reference: @registration.reference) if defined?(Airbrake)
       Rails.logger.error "Completing registration error: #{error}"
+
+      raise error
     end
 
     private

--- a/spec/requests/waste_exemptions_engine/registration_complete_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/registration_complete_forms_spec.rb
@@ -42,7 +42,7 @@ module WasteExemptionsEngine
         end
       end
 
-      context "when an error happens during completition" do
+      context "when an error happens during completion" do
         it "returns a 500 error for the user" do
           custom_error = StandardError.new("completition error")
           expect(Registration).to receive(:new).and_raise(custom_error)

--- a/spec/requests/waste_exemptions_engine/registration_complete_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/registration_complete_forms_spec.rb
@@ -41,6 +41,15 @@ module WasteExemptionsEngine
           expect(registration.reload.versions.last.whodunnit).to eq("public user")
         end
       end
+
+      context "when an error happens during completition" do
+        it "returns a 500 error for the user" do
+          custom_error = StandardError.new("completition error")
+          expect(Registration).to receive(:new).and_raise(custom_error)
+
+          expect { get request_path }.to raise_error(custom_error)
+        end
+      end
     end
 
     describe "unable to go submit GET back" do

--- a/spec/requests/waste_exemptions_engine/registration_complete_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/registration_complete_forms_spec.rb
@@ -44,7 +44,7 @@ module WasteExemptionsEngine
 
       context "when an error happens during completion" do
         it "returns a 500 error for the user" do
-          custom_error = StandardError.new("completition error")
+          custom_error = StandardError.new("completion error")
           expect(Registration).to receive(:new).and_raise(custom_error)
 
           expect { get request_path }.to raise_error(custom_error)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-221

Raise error to the end user when it is resqued from the completition service.