### PR TITLE
Display metadata about EditRegistration

### DIFF
--- a/app/helpers/waste_exemptions_engine/edit_helper.rb
+++ b/app/helpers/waste_exemptions_engine/edit_helper.rb
@@ -9,5 +9,9 @@ module WasteExemptionsEngine
     def edit_finished_path(_edit_registration)
       "/"
     end
+
+    def edits_made?(edit_registration)
+      edit_registration.updated_at != edit_registration.created_at
+    end
   end
 end

--- a/app/views/waste_exemptions_engine/edit_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/edit_forms/new.html.erb
@@ -9,6 +9,19 @@
 
       <p><%= t(".paragraph_1") %></p>
       <p><%= t(".paragraph_2") %></p>
+
+      <div class="panel">
+        <p>
+          <%= t(".edit_meta.created_at",
+                created_at: @edit_form.transient_registration.created_at.to_formatted_s(:time_on_day_month_year)) %>
+        </p>
+        <% if edits_made?(@edit_form.transient_registration) %>
+          <p>
+            <%= t(".edit_meta.updated_at",
+                  updated_at: @edit_form.transient_registration.updated_at.to_formatted_s(:time_on_day_month_year)) %>
+          </p>
+        <% end %>
+      </div>
     </div>
   </div>
   <div class="grid-row">

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -2,3 +2,5 @@
 
 # Returns a date in this format: 1 January 2019
 Date::DATE_FORMATS[:day_month_year] = "%-d %B %Y"
+# Returns a time in this format: 1:23am on 1 January 2019
+Time::DATE_FORMATS[:time_on_day_month_year] = "%-l:%M%P on %-d %B %Y"

--- a/config/locales/forms/edit_forms/en.yml
+++ b/config/locales/forms/edit_forms/en.yml
@@ -6,6 +6,9 @@ en:
         heading: Edit %{reference} registration
         paragraph_1: "Use the links below to make changes to this registration. Changes will not be applied until you hit the continue button at the bottom of the page."
         paragraph_2: "You must confirm these changes using the 'continue' button."
+        edit_meta:
+          created_at: "This edit was started at %{created_at}."
+          updated_at: "It was last updated at %{updated_at}. There may be unsaved changes."
         sections:
           location:
             heading: "Where operation is taking place"

--- a/spec/helpers/waste_exemptions_engine/edit_helper_spec.rb
+++ b/spec/helpers/waste_exemptions_engine/edit_helper_spec.rb
@@ -15,5 +15,23 @@ module WasteExemptionsEngine
         expect(helper.edit_finished_path(build(:edit_registration))).to eq("/")
       end
     end
+
+    describe "edits_made?" do
+      let(:edit_registration) { create(:edit_registration) }
+
+      context "when the edit_registration has the same created_at and updated_at" do
+        it "returns false" do
+          expect(helper.edits_made?(edit_registration)).to eq(false)
+        end
+      end
+
+      context "when the edit_registration has a different created_at and updated_at" do
+        before { edit_registration.updated_at = edit_registration.created_at + 1.minute }
+
+        it "returns true" do
+          expect(helper.edits_made?(edit_registration)).to eq(true)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-62

This PR displays some metadata about when the EditRegistration was created and updated. This is to reduce the risk of a user coming to an already-in-progress edit and not realising that previous changes have been made.