### PR TITLE
Fix error routes to contain a constraint for the /error path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -370,7 +370,7 @@ WasteExemptionsEngine::Engine.routes.draw do
       constraints: ->(_request) { WasteExemptionsEngine.configuration.use_last_email_cache }
 
   # See http://patrickperey.com/railscast-053-handling-exceptions/
-  get "(errors)/:id", to: "errors#show", as: "error"
+  get "errors/:id", to: "errors#show", as: "error"
 
   # Static pages with HighVoltage
   resources :pages, only: [:show], controller: "pages"


### PR DESCRIPTION
Part of: https://eaflood.atlassian.net/browse/RUBY-261

The dummy app inside the engine correctly handles 404 and 500 errors but the applications
that inherit from the engine always render a general template for every error. 
This is because the wrong path is sent together as an ":id" and hence the information about the error template to use is lost in time and space. 
Changing the URL constraint fixed this issue. 

