### PR TITLE
Raise error in completion service

### DIFF
--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -16,6 +16,9 @@ module WasteExemptionsEngine
         copy_people
 
         add_metadata
+
+        raise "Flux capacitor beyond 88mph"
+
         @registration.save!
         @transient_registration.destroy
       end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-221

In order to test RUBY-221 we need to raise an error in the completion service to ensure that the user sees an error page rather than the completion page.

DO NOT MERGE IN!