### PR TITLE
Don't modify status of unedited exemptions

### DIFF
--- a/app/services/waste_exemptions_engine/edit_completion_service.rb
+++ b/app/services/waste_exemptions_engine/edit_completion_service.rb
@@ -43,10 +43,10 @@ module WasteExemptionsEngine
     end
 
     def copy_exemptions
-      @registration.exemptions = []
-      @edit_registration.exemptions.each do |exemption|
-        @registration.exemptions << exemption
-      end
+      unchanged_exemptions = @registration.exemptions & @edit_registration.exemptions
+
+      remove_unwanted_exemptions(unchanged_exemptions)
+      add_new_exemptions(unchanged_exemptions)
     end
 
     def copy_people
@@ -54,6 +54,22 @@ module WasteExemptionsEngine
       @edit_registration.transient_people.each do |transient_person|
         new_person = Person.new(transient_person.person_attributes)
         @registration.people << new_person
+      end
+    end
+
+    def remove_unwanted_exemptions(unchanged_exemptions)
+      @registration.registration_exemptions.each do |registration_exemption|
+        next if unchanged_exemptions.include?(registration_exemption.exemption)
+
+        registration_exemption.destroy
+      end
+    end
+
+    def add_new_exemptions(unchanged_exemptions)
+      @edit_registration.exemptions.each do |exemption|
+        next if unchanged_exemptions.include?(exemption)
+
+        @registration.exemptions << exemption
       end
     end
   end

--- a/app/services/waste_exemptions_engine/edit_completion_service.rb
+++ b/app/services/waste_exemptions_engine/edit_completion_service.rb
@@ -43,10 +43,7 @@ module WasteExemptionsEngine
     end
 
     def copy_exemptions
-      unchanged_exemptions = @registration.exemptions & @edit_registration.exemptions
-
-      remove_unwanted_exemptions(unchanged_exemptions)
-      add_new_exemptions(unchanged_exemptions)
+      @registration.exemptions = @edit_registration.exemptions
     end
 
     def copy_people
@@ -54,22 +51,6 @@ module WasteExemptionsEngine
       @edit_registration.transient_people.each do |transient_person|
         new_person = Person.new(transient_person.person_attributes)
         @registration.people << new_person
-      end
-    end
-
-    def remove_unwanted_exemptions(unchanged_exemptions)
-      @registration.registration_exemptions.each do |registration_exemption|
-        next if unchanged_exemptions.include?(registration_exemption.exemption)
-
-        registration_exemption.destroy
-      end
-    end
-
-    def add_new_exemptions(unchanged_exemptions)
-      @edit_registration.exemptions.each do |exemption|
-        next if unchanged_exemptions.include?(exemption)
-
-        @registration.exemptions << exemption
       end
     end
   end

--- a/spec/services/waste_exemptions_engine/edit_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/edit_completion_service_spec.rb
@@ -56,9 +56,25 @@ module WasteExemptionsEngine
         }.from(old_people_data).to(new_people_data)
       end
 
-      it "copies the exemptions from the registration" do
+      it "does not change the status of unmodified registration_exemptions" do
+        registration.registration_exemptions.first.update(state: "foo")
+        edit_registration.exemptions << registration.exemptions.first
+
+        expect { service }.to_not change { registration.reload.registration_exemptions.first.state }
+      end
+
+      it "removes no-longer-used registration_exemptions" do
+        exemption = registration.exemptions.first
+
         service
-        expect(edit_registration.exemptions).to match_array(registration.exemptions)
+        expect(registration.reload.exemptions).to_not include(exemption)
+      end
+
+      it "adds newly-added registration_exemptions" do
+        exemption = edit_registration.exemptions.first
+
+        service
+        expect(registration.reload.exemptions).to include(exemption)
       end
 
       it "removes no-longer-used attribute from the registration" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-62

When a registration is edited, if it keeps the same exemptions, the status of those exemptions should not change.

This fixes a bug which always reset the status to active.