### PR TITLE
Move edit authorization checking to its own service

### DIFF
--- a/app/controllers/concerns/waste_exemptions_engine/edit_permission_checks.rb
+++ b/app/controllers/concerns/waste_exemptions_engine/edit_permission_checks.rb
@@ -12,7 +12,9 @@ module WasteExemptionsEngine
       end
 
       def current_user_can_edit?
-        EditPermissionCheckerService.run(current_user: current_user)
+        user = current_user rescue nil
+
+        EditPermissionCheckerService.run(current_user: user)
       end
 
       def edit_enabled?

--- a/app/controllers/concerns/waste_exemptions_engine/edit_permission_checks.rb
+++ b/app/controllers/concerns/waste_exemptions_engine/edit_permission_checks.rb
@@ -12,7 +12,15 @@ module WasteExemptionsEngine
       end
 
       def current_user_can_edit?
-        user = current_user rescue nil
+        user = nil
+
+        # rubocop:disable Lint/HandleExceptions
+        begin
+          user = current_user
+        rescue NotImplementedError
+          # do nothing
+        end
+        # rubocop:enable Lint/HandleExceptions
 
         EditPermissionCheckerService.run(current_user: user)
       end

--- a/app/controllers/concerns/waste_exemptions_engine/edit_permission_checks.rb
+++ b/app/controllers/concerns/waste_exemptions_engine/edit_permission_checks.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# This concern is responsible for performing permissions checks. It's intended
-# to be included overriden in host applications which have their own specific
-# permissions and roles.
 module WasteExemptionsEngine
   module EditPermissionChecks
     extend ActiveSupport::Concern
@@ -15,7 +12,7 @@ module WasteExemptionsEngine
       end
 
       def current_user_can_edit?
-        true
+        EditPermissionCheckerService.run(current_user: current_user)
       end
 
       def edit_enabled?

--- a/app/services/waste_exemptions_engine/edit_permission_checker_service.rb
+++ b/app/services/waste_exemptions_engine/edit_permission_checker_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# This concern is responsible for performing permissions checks. It's intended
+# to be included overriden in host applications which have their own specific
+# permissions and roles.
+module WasteExemptionsEngine
+  class EditPermissionCheckerService < BaseService
+    def run(current_user:)
+      true
+    end
+  end
+end

--- a/app/services/waste_exemptions_engine/edit_permission_checker_service.rb
+++ b/app/services/waste_exemptions_engine/edit_permission_checker_service.rb
@@ -5,7 +5,7 @@
 # permissions and roles.
 module WasteExemptionsEngine
   class EditPermissionCheckerService < BaseService
-    def run(current_user:)
+    def run(*)
       true
     end
   end


### PR DESCRIPTION
Part of https://eaflood.atlassian.net/browse/RUBY-330

This moves the permissions checkers in its own service to allow easier re-define of class on the engine apps