### PR TITLE
Set table name before including state machine concern

### DIFF
--- a/app/models/waste_exemptions_engine/transient_registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/transient_registration_exemption.rb
@@ -2,9 +2,9 @@
 
 module WasteExemptionsEngine
   class TransientRegistrationExemption < ActiveRecord::Base
-    include CanActivateExemption
-
     self.table_name = "transient_registration_exemptions"
+
+    include CanActivateExemption
 
     belongs_to :transient_registration
     belongs_to :exemption

--- a/spec/support/shared_examples/models/activator_of_exemptions.rb
+++ b/spec/support/shared_examples/models/activator_of_exemptions.rb
@@ -9,6 +9,10 @@ RSpec.shared_examples "an activator of exemptions" do |model_factory|
     expect(included_modules).to include(WasteExemptionsEngine::CanActivateExemption)
   end
 
+  it "can use AASM defined scopes on statuses" do
+    expect { described_class.active.first }.to_not raise_error
+  end
+
   describe "#activate_exemption" do
     it "updates the registration and expiration dates of exemption" do
       registration_date = Date.today


### PR DESCRIPTION
While working on some bugs I have found out that the authomatically defined scopes for states coming from AASM on the TransientRegistrationExemptions were generating wrong query due to the fact that the authomatically generated AASM model scopes for states were using the wrong table name. Added regression tests.

Before:
```
[3] pry(#<#<Class:0x00007f8f245ada38>>)> @edit_form.registration_exemptions.active.to_sql
=> "SELECT \"transient_registration_exemptions\".* FROM \"transient_registration_exemptions\" WHERE \"transient_registration_exemptions\".\"transient_registration_id\" = 10 AND \"waste_exemptions_engine_transient_registration_exemptions\".\"state\" = 'active'"
```

After:
```
[1] pry(#<#<Class:0x00007f91bb42b388>>)> @edit_form.registration_exemptions.active.to_sql
=> "SELECT \"transient_registration_exemptions\".* FROM \"transient_registration_exemptions\" WHERE \"transient_registration_exemptions\".\"transient_registration_id\" = 10 AND \"transient_registration_exemptions\".\"state\" = 'active'"
```

(notice `\"waste_exemptions_engine_transient_registration_exemptions\".\"state\" = 'active'"` VS `\"transient_registration_exemptions\".\"state\" = 'active'`)