### PR TITLE
Copy over to transient Edit registration only active exemptions

### DIFF
--- a/app/models/waste_exemptions_engine/edit_registration.rb
+++ b/app/models/waste_exemptions_engine/edit_registration.rb
@@ -43,7 +43,7 @@ module WasteExemptionsEngine
     end
 
     def copy_exemptions_from_registration(registration)
-      self.exemptions = registration.exemptions
+      self.exemptions = registration.active_exemptions
     end
   end
 end

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -12,5 +12,11 @@ module WasteExemptionsEngine
     has_many :people
     has_many :registration_exemptions
     has_many :exemptions, through: :registration_exemptions
+    has_many(
+      :active_exemptions,
+      -> { WasteExemptionsEngine::RegistrationExemption.active },
+      through: :registration_exemptions,
+      source: :exemption
+    )
   end
 end

--- a/app/models/waste_exemptions_engine/registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/registration_exemption.rb
@@ -2,10 +2,11 @@
 
 module WasteExemptionsEngine
   class RegistrationExemption < ActiveRecord::Base
-
     self.table_name = "registration_exemptions"
 
     belongs_to :registration
     belongs_to :exemption
+
+    scope :active, -> { where(state: :active) }
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
       format("WEX9%05d", n)
     end
 
+    trait :with_active_exemptions do
+      registration_exemptions { build_list(:registration_exemption, 5, state: :active) }
+    end
+
     trait :limited_company do
       business_type { "limitedCompany" }
     end

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -17,5 +17,17 @@ module WasteExemptionsEngine
     it_behaves_like "an owner of registration attributes", :registration, :address
     it_behaves_like "it has PaperTrail", model_factory: :registration,
                                          field: :operator_name
+
+    describe ".active_exemptions" do
+      subject(:registration) { create(:registration, :with_active_exemptions) }
+
+      it "returns a list of registrations in an active status" do
+        pending_exemption = registration.registration_exemptions.first
+        pending_exemption.state = :pending
+        pending_exemption.save
+
+        expect(registration.active_exemptions.count).to eq(registration.exemptions.count - 1)
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-62 this addresses point 1 of the QA document

This define a new association in the Registration model so that we can get an handy list of only active registration. I have defined the scope manually on the `RegistrationExemption` class rather then include the `CanActivateExemption` concern, since we don't really want that class to be able to deal with changing the status of an exemption (yet).
Thought it might make sense to externalise the list of statuses (for validations purposes and the ability to have the status AASM scopes defined in the model) and leave only the transaction code in the `CanActivateExemption`.

In the meantime this does the job :D