### PR TITLE
Add cannot edit to the exemptions section in edit screen

### DIFF
--- a/app/assets/stylesheets/waste_exemptions_engine/partials/_edit.scss
+++ b/app/assets/stylesheets/waste_exemptions_engine/partials/_edit.scss
@@ -18,4 +18,12 @@
     width: 6em;
     text-align: right;
   }
+
+  .split-title {
+    display: inline;
+
+    &--right {
+      float: right;
+    }
+  }
 }

--- a/app/views/waste_exemptions_engine/edit_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/edit_forms/new.html.erb
@@ -283,7 +283,12 @@
 
       <table class="edit_table">
         <caption class="heading-medium">
-          <%= t(".sections.exemptions.heading") %>
+          <div class="split-title">
+            <%= t(".sections.exemptions.heading") %>
+          </div>
+          <div class="text-align-right font-small split-title split-title--right">
+            <%= t(".edit_links.no_edit") %>
+          </div>
         </caption>
         <tbody>
           <% @edit_form.registration_exemptions.includes(:exemption).each do |re| %>


### PR DESCRIPTION
Addresses point 6 of QA document from https://eaflood.atlassian.net/browse/RUBY-62

It was necessary to add missing classes in order to make this work as intended. BEM style has been used. It was not possible to achieve this by using the grid system for alignment issues and this simple solution looked better than hacking into the styles classes.

<details> <summary>Responsiveness</summary>
![ZqpC6wE8tq (1)](https://user-images.githubusercontent.com/1385397/57783388-f1754300-7725-11e9-82b5-9f941e68b067.gif)


 </details> 