### PR TITLE
Change headings and table layout on edit site location

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_be_located_by_grid_reference.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_be_located_by_grid_reference.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module CanBeLocatedByGridReference
+    extend ActiveSupport::Concern
+
+    included do
+      def located_by_grid_reference?
+        site? && auto?
+      end
+    end
+  end
+end

--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -2,6 +2,8 @@
 
 module WasteExemptionsEngine
   class Address < ActiveRecord::Base
+    include CanBeLocatedByGridReference
+
     has_paper_trail ignore: %i[blpu_state_code
                                logical_status_code
                                country_iso
@@ -13,9 +15,5 @@ module WasteExemptionsEngine
 
     enum address_type: { unknown: 0, operator: 1, contact: 2, site: 3 }
     enum mode: { unknown_mode: 0, lookup: 1, manual: 2, auto: 3 }
-
-    def located_by_grid_reference?
-      site? && auto?
-    end
   end
 end

--- a/app/models/waste_exemptions_engine/transient_address.rb
+++ b/app/models/waste_exemptions_engine/transient_address.rb
@@ -4,8 +4,9 @@ require "os_map_ref"
 
 module WasteExemptionsEngine
   class TransientAddress < ActiveRecord::Base
-
     self.table_name = "transient_addresses"
+
+    include CanBeLocatedByGridReference
 
     belongs_to :transient_registration
 

--- a/app/views/waste_exemptions_engine/edit_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/edit_forms/new.html.erb
@@ -254,30 +254,43 @@
           <%= t(".sections.site.heading") %>
         </caption>
         <tbody>
-          <tr>
-            <td class="label_column">
-              <%= t(".sections.site.labels.site_address") %>
-            </td>
-            <td>
-              <% if @edit_form.site_address.grid_reference.present? %>
-                <%= @edit_form.site_address.grid_reference %>
-                <br><br>
-                <%= @edit_form.site_address.description %>
-              <% else %>
-              <ul>
-                <% displayable_address(@edit_form.contact_address).each do |address_line| %>
-                <li><%= address_line %></li>
+          <% if @edit_form.site_address.located_by_grid_reference? %>
+            <tr>
+              <th class="label_column"><%=t ".sections.site.labels.grid_reference" %></th>
+              <td> <%= @edit_form.site_address.grid_reference %> </td>
+              <td class="change_link_column">
+                <%= link_to site_grid_reference_edit_forms_path(@edit_form.token) do %>
+                  <%= t(".edit_links.default") %>
+                  <span class="visually-hidden"> <%= t(".edit_links.visually_hidden.site_address") %></span>
                 <% end %>
-              </ul>
-              <% end %>
-            </td>
-            <td class="change_link_column">
-              <%= link_to site_grid_reference_edit_forms_path(@edit_form.token) do %>
-                <%= t(".edit_links.default") %>
-                <span class="visually-hidden"> <%= t(".edit_links.visually_hidden.site_address") %></span>
-              <% end %>
-            </td>
-          </tr>
+              </td>
+            </tr>
+            <tr>
+              <th class="label_column"><%=t ".sections.site.labels.site_details" %></th>
+              <td> <%= @edit_form.site_address.description %> </td>
+              <td class="change_link_column">
+                <%= link_to site_grid_reference_edit_forms_path(@edit_form.token) do %>
+                  <%= t(".edit_links.default") %>
+                  <span class="visually-hidden"> <%= t(".edit_links.visually_hidden.site_address") %></span>
+                <% end %>
+              </td>
+            </tr>
+          <% else %>
+            <tr>
+              <th class="label_column"><%=t ".sections.site.labels.site_address" %></th>
+              <td>
+                <% displayable_address(@edit_form.site_address).each do |line| %>
+                  <%= line %><br>
+                <% end %>
+              </td>
+              <td class="change_link_column">
+                <%= link_to site_grid_reference_edit_forms_path(@edit_form.token) do %>
+                  <%= t(".edit_links.default") %>
+                  <span class="visually-hidden"> <%= t(".edit_links.visually_hidden.site_address") %></span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
         </tbody>
       </table>
 

--- a/config/locales/forms/edit_forms/en.yml
+++ b/config/locales/forms/edit_forms/en.yml
@@ -51,9 +51,11 @@ en:
               contact_email: "Email address"
               contact_address: "Address"
           site:
-            heading: "Site address"
+            heading: "Waste operation details"
             labels:
-              site_address: "Address"
+              grid_reference: Grid Reference
+              site_details: Site details
+              site_address: Site address
           exemptions:
             heading: "Exemptions"
           farm:


### PR DESCRIPTION
Addresses point 10 of QA document from https://eaflood.atlassian.net/browse/RUBY-62

In order to address some consistency issues with the way we display site addresses,
this change introduces an if statement to deal with different heading and table rows whether an address is located by grid reference or is inserted manually.

<details>
<summary> Site address </summary>
<img width="640" alt="Screenshot 2019-05-15 at 15 49 16" src="https://user-images.githubusercontent.com/1385397/57785352-83327f80-7729-11e9-84e5-7faf5b9534c0.png">
</details>

<details>
<summary> Manual address </summary>
<img width="529" alt="Screenshot 2019-05-15 at 15 49 43" src="https://user-images.githubusercontent.com/1385397/57785354-83327f80-7729-11e9-8fca-c324f51187a6.png">
</details>

Mind that the 2 `Change` links in the grid reference section redirect to the same location. I have tried a `rowspan=2` but it looked really horrible. We might want to consider to put the link at the caption level as done for the `no edit` in https://github.com/DEFRA/waste-exemptions-engine/pull/173 but this is more a question for designers. This result IMO is good enough for release and any other action can be a future enhancement :) 