### PR TITLE
Remove duplicate partnership? method

### DIFF
--- a/app/presenters/waste_exemptions_engine/certificate_presenter.rb
+++ b/app/presenters/waste_exemptions_engine/certificate_presenter.rb
@@ -2,9 +2,6 @@
 
 module WasteExemptionsEngine
   class CertificatePresenter < BasePresenter
-    def partnership?
-      business_type == "partnership"
-    end
 
     def partners_names
       people.select(&:partner?).map do |person|

--- a/spec/presenters/waste_exemptions_engine/certificate_presenter_spec.rb
+++ b/spec/presenters/waste_exemptions_engine/certificate_presenter_spec.rb
@@ -6,24 +6,6 @@ module WasteExemptionsEngine
   RSpec.describe CertificatePresenter do
     subject { described_class.new(registration) }
 
-    describe "#partnership?" do
-      context "when the business type is partnership" do
-        let(:registration) { build(:registration, :partnership) }
-
-        it "returns true" do
-          expect(subject).to be_partnership
-        end
-      end
-
-      context "when the business type is not partnership" do
-        let(:registration) { build(:registration, :limited_company) }
-
-        it "returns false" do
-          expect(subject).to_not be_partnership
-        end
-      end
-    end
-
     describe "#partners_names" do
       let(:registration) { build(:registration, :partnership) }
 


### PR DESCRIPTION
Spotted in a the `CertificatePresenter` that we had a `partnership?`method  however we already have that built into the registration via the `CanHaveRegistrationAttributes`.

As the `CertificatePresenter` delegates any calls it does not recognise down to the registration instance, deleting the method will have no impact on anything that uses the presenter.