### PR TITLE
Move up reference link to manual address for site form

### DIFF
--- a/app/views/waste_exemptions_engine/site_grid_reference_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/site_grid_reference_forms/new.html.erb
@@ -6,6 +6,13 @@
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
+    <div class="panel panel-border-wide">
+      <p class="strong">
+        <%= t(".grid_reference_or_address.message") %>
+        <%= link_to(t(".grid_reference_or_address.manual_address_label"), skip_to_address_site_grid_reference_forms_path(@site_grid_reference_form.token)) %>
+      </p>
+    </div>
+
     <% if @site_grid_reference_form.errors[:grid_reference].any? %>
     <div class="form-group form-group-error">
     <% else %>

--- a/config/locales/forms/site_grid_reference_forms/en.yml
+++ b/config/locales/forms/site_grid_reference_forms/en.yml
@@ -4,6 +4,9 @@ en:
       new:
         title: Site grid reference
         heading: Where will this waste operation take place?
+        grid_reference_or_address:
+          message: Enter a grid reference or
+          manual_address_label: use an address instead
         grid_reference_label: National Grid reference
         grid_reference_hint: Enter 2 letters and 10 digits. For example, ST 58132 72695
         grid_reference_help_link: Help finding a grid reference


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-341

Add a message regarding the possibility for the user to insert an address manually at the top of the page, just below the heading. This is because it has been reported that the user doesn't notice the link at the bottom of the page and is a temporary solution until we make include a switch form

<details>
<summary>Screenshot</summary>
<img width="836" alt="Screenshot 2019-05-17 at 13 47 31" src="https://user-images.githubusercontent.com/1385397/57929302-d7b13880-78aa-11e9-9846-f62268a46af9.png">

 </details>