### PR TITLE
Do not save un-persisted objects in workflow setup

### DIFF
--- a/app/controllers/waste_exemptions_engine/forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/forms_controller.rb
@@ -79,9 +79,9 @@ module WasteExemptionsEngine
       return unless state_can_navigate_flexibly?(@transient_registration.workflow_state)
       return unless state_can_navigate_flexibly?(requested_state)
 
-      if @transient_registration.persisted?
-        @transient_registration.update_attributes(workflow_state: requested_state)
-      end
+      return unless @transient_registration.persisted?
+      
+      @transient_registration.update_attributes(workflow_state: requested_state)
     end
 
     def state_can_navigate_flexibly?(state)

--- a/app/controllers/waste_exemptions_engine/forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/forms_controller.rb
@@ -78,9 +78,20 @@ module WasteExemptionsEngine
     def set_workflow_state
       return unless state_can_navigate_flexibly?(@transient_registration.workflow_state)
       return unless state_can_navigate_flexibly?(requested_state)
-      return unless @transient_registration.persisted?
 
-      @transient_registration.update_attributes(workflow_state: requested_state)
+      if @transient_registration.persisted?
+        update_workflow_state(requested_state)
+      else
+        assign_workflow_state(requested_state)
+      end
+    end
+
+    def update_workflow_state(workflow_state)
+      @transient_registration.update_attributes(workflow_state: workflow_state)
+    end
+
+    def assign_workflow_state(workflow_state)
+      @transient_registration.workflow_state = workflow_state
     end
 
     def state_can_navigate_flexibly?(state)

--- a/app/controllers/waste_exemptions_engine/forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/forms_controller.rb
@@ -80,7 +80,7 @@ module WasteExemptionsEngine
       return unless state_can_navigate_flexibly?(requested_state)
 
       return unless @transient_registration.persisted?
-      
+
       @transient_registration.update_attributes(workflow_state: requested_state)
     end
 

--- a/app/controllers/waste_exemptions_engine/forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/forms_controller.rb
@@ -78,7 +78,6 @@ module WasteExemptionsEngine
     def set_workflow_state
       return unless state_can_navigate_flexibly?(@transient_registration.workflow_state)
       return unless state_can_navigate_flexibly?(requested_state)
-
       return unless @transient_registration.persisted?
 
       @transient_registration.update_attributes(workflow_state: requested_state)

--- a/app/controllers/waste_exemptions_engine/forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/forms_controller.rb
@@ -79,7 +79,9 @@ module WasteExemptionsEngine
       return unless state_can_navigate_flexibly?(@transient_registration.workflow_state)
       return unless state_can_navigate_flexibly?(requested_state)
 
-      @transient_registration.update_attributes(workflow_state: requested_state)
+      if @transient_registration.persisted?
+        @transient_registration.update_attributes(workflow_state: requested_state)
+      end
     end
 
     def state_can_navigate_flexibly?(state)

--- a/app/forms/waste_exemptions_engine/edit_form.rb
+++ b/app/forms/waste_exemptions_engine/edit_form.rb
@@ -24,7 +24,7 @@ module WasteExemptionsEngine
     # This form has a lot of attributes, so we have to disable the length cop.
     # rubocop:disable Metrics/MethodLength
     def initialize(registration)
-      registration.save!
+      registration.save! unless registration.persisted?
 
       super
 

--- a/app/forms/waste_exemptions_engine/edit_form.rb
+++ b/app/forms/waste_exemptions_engine/edit_form.rb
@@ -24,7 +24,10 @@ module WasteExemptionsEngine
     # This form has a lot of attributes, so we have to disable the length cop.
     # rubocop:disable Metrics/MethodLength
     def initialize(registration)
+      registration.save!
+
       super
+
       self.applicant_email          = @transient_registration.applicant_email
       self.applicant_phone          = @transient_registration.applicant_phone
       self.business_type            = @transient_registration.business_type

--- a/app/forms/waste_exemptions_engine/edit_form.rb
+++ b/app/forms/waste_exemptions_engine/edit_form.rb
@@ -23,6 +23,7 @@ module WasteExemptionsEngine
 
     # This form has a lot of attributes, so we have to disable the length cop.
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def initialize(registration)
       registration.save! unless registration.persisted?
 
@@ -51,6 +52,7 @@ module WasteExemptionsEngine
                                                 @transient_registration.contact_last_name)
     end
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-352

The registration was saved at every refresh because of the workflow setup.
Since the object is persisted already at every `submit`, I have added a guard clause to avoid updating it unless it is persisted. 
BUT the editing journey is instead expecting a persisted object since the first call. Hence a fix there was necessary too.  

I wasn't able to find a nice way to test it :/ we should run some tests in truncation mode or do some weird stubbing and expectations.