### PR TITLE
Fix `cannot edit` label in caption to float right inline with title

### DIFF
--- a/app/assets/stylesheets/waste_exemptions_engine/partials/_edit.scss
+++ b/app/assets/stylesheets/waste_exemptions_engine/partials/_edit.scss
@@ -9,6 +9,10 @@
     .heading-medium {
       margin-bottom: .1em;
     }
+
+    .float-right {
+      float: right;
+    }
   }
 
   .label_column {
@@ -20,13 +24,5 @@
     width: 6em;
     text-align: right;
     vertical-align: top;
-  }
-
-  .split-title {
-    display: inline;
-
-    &--right {
-      float: right;
-    }
   }
 }

--- a/app/views/waste_exemptions_engine/edit_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/edit_forms/new.html.erb
@@ -293,12 +293,10 @@
 
       <table class="edit_table">
         <caption>
-          <div class="split-title">
-            <h2 class="heading-medium"> <%= t(".sections.exemptions.heading") %> </h2>
-          </div>
-          <div class="text-align-right font-small split-title split-title--right">
-            <%= t(".edit_links.no_edit") %>
-          </div>
+          <h2 class="heading-medium">
+            <%= t(".sections.exemptions.heading") %>
+            <small class="font-small float-right"><%= t(".edit_links.no_edit") %></small>
+          </h2>
         </caption>
         <tbody>
           <% @edit_form.registration_exemptions.includes(:exemption).each do |re| %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-367

This fixes once and for all the position of the `cannot edit` label to be the far right of the caption heading. A `small` tag has been used as it is one of the few W3C allowed tags to nest, however, classes have been used to achieve a reduced font size and the floating right behaviour.

<details>
<summary>View</summary>
<img width="795" alt="Screenshot 2019-05-21 at 18 07 39" src="https://user-images.githubusercontent.com/1385397/58116284-d5751400-7bf3-11e9-8011-1c0a62adf7f0.png">
</details>