### PR TITLE
Rename deregistered_on to deregistered_at

### DIFF
--- a/db/migrate/20190522085202_rename_deregistered_on_to_deregistered_at.rb
+++ b/db/migrate/20190522085202_rename_deregistered_on_to_deregistered_at.rb
@@ -1,0 +1,5 @@
+class RenameDeregisteredOnToDeregisteredAt < ActiveRecord::Migration
+  def change
+    rename_column :registration_exemptions, :deregistered_on, :deregistered_at
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190424143344) do
+ActiveRecord::Schema.define(version: 20190522085202) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,12 @@ ActiveRecord::Schema.define(version: 20190424143344) do
 
   add_index "addresses", ["registration_id"], name: "index_addresses_on_registration_id", using: :btree
 
+  create_table "defra_ruby_exporters_bulk_export_files", force: :cascade do |t|
+    t.string   "file_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "exemptions", force: :cascade do |t|
     t.integer "category"
     t.string  "code"
@@ -72,7 +78,7 @@ ActiveRecord::Schema.define(version: 20190424143344) do
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.text     "deregistration_message"
-    t.date     "deregistered_on"
+    t.date     "deregistered_at"
   end
 
   add_index "registration_exemptions", ["exemption_id"], name: "index_registration_exemptions_on_exemption_id", using: :btree

--- a/spec/support/helpers/model_properties.rb
+++ b/spec/support/helpers/model_properties.rb
@@ -42,12 +42,12 @@ module Helpers
     REGISTRATION_EXEMPTION = %i[
       state
       deregistration_message
-      deregistered_on
+      deregistered_at
       registered_on
       expires_on
     ].freeze
 
-    TRANSIENT_REGISTRATION_EXEMPTION = (REGISTRATION_EXEMPTION - %i[deregistration_message deregistered_on]).freeze
+    TRANSIENT_REGISTRATION_EXEMPTION = (REGISTRATION_EXEMPTION - %i[deregistration_message deregistered_at]).freeze
 
     REGISTRATION = %i[
       reference


### PR DESCRIPTION
This is just about keeping things consistent. Where we are recording a timestamp the pattern has been to use `name_of_field_at` rather than `name_of_field_on`.

For example `created_at`, `updated_at`, and `submitted_at`. This change is just about keeping things consistent.