### PR TITLE
[WIP] Require wicked pdf in the engine for applications to use

### DIFF
--- a/lib/waste_exemptions_engine/engine.rb
+++ b/lib/waste_exemptions_engine/engine.rb
@@ -5,6 +5,7 @@ require "has_secure_token"
 require "high_voltage"
 require "paper_trail"
 require "defra_ruby_validators"
+require "wicked_pdf"
 
 module WasteExemptionsEngine
   class Engine < ::Rails::Engine


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-223

Given we want to use wicked_pdf superpowers in the WEX back office, in order to require the gem correctly along with its Rails helpers, it must be required in the engine file.