### PR TITLE
Update to work with validators namespace change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
     database_cleaner (1.7.0)
     defra_ruby_style (0.1.1)
       rubocop
-    defra_ruby_validators (0.1.1)
+    defra_ruby_validators (1.0.0)
       activemodel
       rest-client (~> 2.0)
     diff-lcs (1.3)
@@ -126,7 +126,7 @@ GEM
     method_source (0.9.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.0331)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -248,7 +248,7 @@ GEM
     uk_postcode (2.1.3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
     unicode-display_width (1.5.0)
     uniform_notifier (1.12.1)
     validates_email_format_of (1.6.3)

--- a/app/forms/waste_exemptions_engine/check_your_answers_form.rb
+++ b/app/forms/waste_exemptions_engine/check_your_answers_form.rb
@@ -70,7 +70,7 @@ module WasteExemptionsEngine
     validates :applicant_email, "waste_exemptions_engine/email": true
 
     validates :business_type, "waste_exemptions_engine/business_type": true
-    validates :company_no, "defra_ruby_validators/companies_house_number": true, if: :company_no_required?
+    validates :company_no, "defra_ruby/validators/companies_house_number": true, if: :company_no_required?
     validates :operator_name, "waste_exemptions_engine/operator_name": true
     validates :operator_address, "waste_exemptions_engine/address": true
 

--- a/app/forms/waste_exemptions_engine/registration_number_form.rb
+++ b/app/forms/waste_exemptions_engine/registration_number_form.rb
@@ -22,7 +22,7 @@ module WasteExemptionsEngine
       super(attributes, params[:token])
     end
 
-    validates :company_no, "defra_ruby_validators/companies_house_number": true
+    validates :company_no, "defra_ruby/validators/companies_house_number": true
 
     private
 

--- a/lib/waste_exemptions_engine.rb
+++ b/lib/waste_exemptions_engine.rb
@@ -59,13 +59,13 @@ module WasteExemptionsEngine
     end
 
     def companies_house_host=(value)
-      DefraRubyValidators.configure do |configuration|
+      DefraRuby::Validators.configure do |configuration|
         configuration.companies_house_host = value
       end
     end
 
     def companies_house_api_key=(value)
-      DefraRubyValidators.configure do |configuration|
+      DefraRuby::Validators.configure do |configuration|
         configuration.companies_house_api_key = value
       end
     end

--- a/spec/forms/waste_exemptions_engine/check_your_answers_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/check_your_answers_form_spec.rb
@@ -46,7 +46,7 @@ module WasteExemptionsEngine
       it "validates the company_no using the CompaniesHouseNumberValidator class" do
         expect(validators.keys).to include(:company_no)
         expect(validators[:company_no].first.class)
-          .to eq(DefraRubyValidators::CompaniesHouseNumberValidator)
+          .to eq(DefraRuby::Validators::CompaniesHouseNumberValidator)
 
         expect(validators[:company_no].first.options).to eq(if: :company_no_required?)
       end

--- a/spec/forms/waste_exemptions_engine/registration_number_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/registration_number_form_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RegistrationNumberForm, type: :model do
     before do
-      allow_any_instance_of(DefraRubyValidators::CompaniesHouseService).to receive(:status).and_return(:active)
+      allow_any_instance_of(DefraRuby::Validators::CompaniesHouseService).to receive(:status).and_return(:active)
     end
 
     subject(:form) { build(:registration_number_form) }
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
       validators = form._validators
       expect(validators.keys).to include(:company_no)
       expect(validators[:company_no].first.class)
-        .to eq(DefraRubyValidators::CompaniesHouseNumberValidator)
+        .to eq(DefraRuby::Validators::CompaniesHouseNumberValidator)
     end
 
     it_behaves_like "a validated form", :registration_number_form do


### PR DESCRIPTION
[defra-ruby-validators](https://github.com/DEFRA/defra-ruby-validators) updated its namespace to fall inline with our new agreed convention of using `DefraRuby::MyNamespace`, as set out in [defra-ruby-exporters](https://github.com/DEFRA/defra-ruby-exporters).

This obviously means the engine has to update it's references to it hence these changes.