### PR TITLE
Remove second link to manual address

### DIFF
--- a/app/views/waste_exemptions_engine/site_grid_reference_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/site_grid_reference_forms/new.html.erb
@@ -85,10 +85,6 @@
       <p><%= t(".description_limit") %></p>
     </div>
 
-    <div class="form-group">
-      <%= link_to(t(".use_address_link"), skip_to_address_site_grid_reference_forms_path(@site_grid_reference_form.token)) %>
-    </div>
-
     <%= f.hidden_field :token, value: @site_grid_reference_form.token %>
     <div class="form-group">
       <%= f.submit t(".next_button"), class: "button" %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-370

Given the new design message, we now want to get rid of the second link to manual address form on the bottom of the page.

<details> <summary>Screenshot</summary> 
<img width="641" alt="Screenshot 2019-05-24 at 11 33 14" src="https://user-images.githubusercontent.com/1385397/58322281-5f9dc200-7e18-11e9-9736-72c1b7413220.png">
</details>