### PR TITLE
Create a hash for business types

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_have_registration_attributes.rb
@@ -4,13 +4,23 @@ module WasteExemptionsEngine
   module CanHaveRegistrationAttributes
     extend ActiveSupport::Concern
 
+    BUSINESS_TYPES = HashWithIndifferentAccess.new(
+      sole_trader: "soleTrader",
+      limited_company: "limitedCompany",
+      partnership: "partnership",
+      limited_liability_partnership: "limitedLiabilityPartnership",
+      local_authority: "localAuthority",
+      charity: "charity"
+    )
+
     # Some business types should not have a company_no
     def company_no_required?
-      %w[limitedCompany limitedLiabilityPartnership].include?(business_type)
+      [BUSINESS_TYPES[:limited_company],
+       BUSINESS_TYPES[:limited_liability_partnership]].include?(business_type)
     end
 
     def partnership?
-      %w[partnership].include?(business_type)
+      [BUSINESS_TYPES[:partnership]].include?(business_type)
     end
 
     def operator_address

--- a/app/models/concerns/waste_exemptions_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_have_registration_attributes.rb
@@ -20,7 +20,7 @@ module WasteExemptionsEngine
     end
 
     def partnership?
-      [BUSINESS_TYPES[:partnership]].include?(business_type)
+      BUSINESS_TYPES[:partnership] == business_type
     end
 
     def operator_address

--- a/app/models/concerns/waste_exemptions_engine/can_limit_number_of_main_people.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_limit_number_of_main_people.rb
@@ -26,7 +26,7 @@ module WasteExemptionsEngine
     def maximum_main_people
       return unless business_type.present?
 
-      limits = main_people_limits.fetch(business_type.to_sym, nil)
+      limits = main_people_limits.fetch(business_type, nil)
       return unless limits.present?
 
       limits[:maximum]
@@ -36,7 +36,7 @@ module WasteExemptionsEngine
       # Business type should always be set, but use 1 as the default, just in case
       return 1 unless business_type.present?
 
-      limits = main_people_limits.fetch(business_type.to_sym, nil)
+      limits = main_people_limits.fetch(business_type, nil)
       return 1 unless limits.present?
 
       limits[:minimum]
@@ -49,13 +49,15 @@ module WasteExemptionsEngine
     private
 
     def main_people_limits
+      business_types = TransientRegistration::BUSINESS_TYPES
+
       {
-        limitedCompany: { minimum: 1, maximum: nil },
-        limitedLiabilityPartnership: { minimum: 1, maximum: nil },
-        localAuthority: { minimum: 1, maximum: nil },
-        charity: { minimum: 1, maximum: nil },
-        partnership: { minimum: 2, maximum: nil },
-        soleTrader: { minimum: 1, maximum: 1 }
+        business_types[:limited_company] => { minimum: 1, maximum: nil },
+        business_types[:limited_liability_partnership] => { minimum: 1, maximum: nil },
+        business_types[:local_authority] => { minimum: 1, maximum: nil },
+        business_types[:charity] => { minimum: 1, maximum: nil },
+        business_types[:partnership] => { minimum: 2, maximum: nil },
+        business_types[:sole_trader] => { minimum: 1, maximum: 1 }
       }
     end
   end

--- a/app/models/concerns/waste_exemptions_engine/can_limit_number_of_main_people.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_limit_number_of_main_people.rb
@@ -4,6 +4,15 @@ module WasteExemptionsEngine
   module CanLimitNumberOfMainPeople
     extend ActiveSupport::Concern
 
+    MAIN_PEOPLE_LIMITS = HashWithIndifferentAccess.new(
+      TransientRegistration::BUSINESS_TYPES[:limited_company] => { minimum: 1, maximum: nil },
+      TransientRegistration::BUSINESS_TYPES[:limited_liability_partnership] => { minimum: 1, maximum: nil },
+      TransientRegistration::BUSINESS_TYPES[:local_authority] => { minimum: 1, maximum: nil },
+      TransientRegistration::BUSINESS_TYPES[:charity] => { minimum: 1, maximum: nil },
+      TransientRegistration::BUSINESS_TYPES[:partnership] => { minimum: 2, maximum: nil },
+      TransientRegistration::BUSINESS_TYPES[:sole_trader] => { minimum: 1, maximum: 1 }
+    )
+
     def enough_main_people?
       return false if number_of_existing_main_people < minimum_main_people
 
@@ -26,7 +35,7 @@ module WasteExemptionsEngine
     def maximum_main_people
       return unless business_type.present?
 
-      limits = main_people_limits.fetch(business_type, nil)
+      limits = MAIN_PEOPLE_LIMITS.fetch(business_type, nil)
       return unless limits.present?
 
       limits[:maximum]
@@ -36,7 +45,7 @@ module WasteExemptionsEngine
       # Business type should always be set, but use 1 as the default, just in case
       return 1 unless business_type.present?
 
-      limits = main_people_limits.fetch(business_type, nil)
+      limits = MAIN_PEOPLE_LIMITS.fetch(business_type, nil)
       return 1 unless limits.present?
 
       limits[:minimum]
@@ -44,21 +53,6 @@ module WasteExemptionsEngine
 
     def number_of_existing_main_people
       @transient_registration.transient_people.count
-    end
-
-    private
-
-    def main_people_limits
-      business_types = TransientRegistration::BUSINESS_TYPES
-
-      {
-        business_types[:limited_company] => { minimum: 1, maximum: nil },
-        business_types[:limited_liability_partnership] => { minimum: 1, maximum: nil },
-        business_types[:local_authority] => { minimum: 1, maximum: nil },
-        business_types[:charity] => { minimum: 1, maximum: nil },
-        business_types[:partnership] => { minimum: 2, maximum: nil },
-        business_types[:sole_trader] => { minimum: 1, maximum: 1 }
-      }
     end
   end
 end

--- a/app/validators/waste_exemptions_engine/business_type_validator.rb
+++ b/app/validators/waste_exemptions_engine/business_type_validator.rb
@@ -5,12 +5,7 @@ module WasteExemptionsEngine
     include CanValidateSelection
 
     def validate_each(record, attribute, value)
-      valid_business_types = %w[charity
-                                limitedCompany
-                                limitedLiabilityPartnership
-                                localAuthority
-                                partnership
-                                soleTrader]
+      valid_business_types = TransientRegistration::BUSINESS_TYPES.values
 
       value_is_included?(record, attribute, value, valid_business_types)
     end

--- a/app/views/waste_exemptions_engine/business_type_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/business_type_forms/new.html.erb
@@ -23,28 +23,46 @@
         <% end %>
 
         <div class="multiple-choice">
-          <%= f.radio_button :business_type, 'soleTrader' %>
-          <%= f.label :business_type, t(".options.individual"), value: 'soleTrader' %>
+          <%= f.radio_button :business_type,
+                             WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:sole_trader] %>
+          <%= f.label :business_type,
+                      t(".options.individual"),
+                      value: WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:sole_trader] %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :business_type, 'limitedCompany' %>
-          <%= f.label :business_type, t(".options.limited_company"), value: 'limitedCompany' %>
+          <%= f.radio_button :business_type,
+                             WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:limited_company] %>
+          <%= f.label :business_type,
+                      t(".options.limited_company"),
+                      value: WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:limited_company] %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :business_type, 'partnership' %>
-          <%= f.label :business_type, t(".options.partnership"), value: 'partnership' %>
+          <%= f.radio_button :business_type,
+                             WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:partnership] %>
+          <%= f.label :business_type,
+                      t(".options.partnership"),
+                      value: WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:partnership] %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :business_type, 'limitedLiabilityPartnership' %>
-          <%= f.label :business_type, t(".options.limited_liability_partnership"), value: 'limitedLiabilityPartnership' %>
+          <%= f.radio_button :business_type,
+                             WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:limited_liability_partnership] %>
+          <%= f.label :business_type,
+                      t(".options.limited_liability_partnership"),
+                      value: WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:limited_liability_partnership] %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :business_type, 'localAuthority' %>
-          <%= f.label :business_type, t(".options.local_authority"), value: 'localAuthority' %>
+          <%= f.radio_button :business_type,
+                             WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:local_authority] %>
+          <%= f.label :business_type,
+                      t(".options.local_authority"),
+                      value: WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:local_authority] %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :business_type, 'charity' %>
-          <%= f.label :business_type, t(".options.charity"), value: 'charity' %>
+          <%= f.radio_button :business_type,
+                             WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:charity] %>
+          <%= f.label :business_type,
+                      t(".options.charity"),
+                      value: WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:charity] %>
         </div>
       </fieldset>
     </div>

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -3,27 +3,27 @@
 FactoryBot.define do
   factory :new_registration, class: WasteExemptionsEngine::NewRegistration do
     trait :limited_company do
-      business_type { "limitedCompany" }
+      business_type { WasteExemptionsEngine::NewRegistration::BUSINESS_TYPES[:limited_company] }
     end
 
     trait :limited_liability_partnership do
-      business_type { "limitedLiabilityPartnership" }
+      business_type { WasteExemptionsEngine::NewRegistration::BUSINESS_TYPES[:limited_liability_partnership] }
     end
 
     trait :local_authority do
-      business_type { "localAuthority" }
+      business_type { WasteExemptionsEngine::NewRegistration::BUSINESS_TYPES[:local_authority] }
     end
 
     trait :charity do
-      business_type { "charity" }
+      business_type { WasteExemptionsEngine::NewRegistration::BUSINESS_TYPES[:charity] }
     end
 
     trait :partnership do
-      business_type { "partnership" }
+      business_type { WasteExemptionsEngine::NewRegistration::BUSINESS_TYPES[:partnership] }
     end
 
     trait :sole_trader do
-      business_type { "soleTrader" }
+      business_type { WasteExemptionsEngine::NewRegistration::BUSINESS_TYPES[:sole_trader] }
     end
 
     trait :same_applicant_and_contact_email do

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -16,28 +16,28 @@ FactoryBot.define do
     end
 
     trait :limited_company do
-      business_type { "limitedCompany" }
+      business_type { WasteExemptionsEngine::Registration::BUSINESS_TYPES[:limited_company] }
     end
 
     trait :limited_liability_partnership do
-      business_type { "limitedLiabilityPartnership" }
+      business_type { WasteExemptionsEngine::Registration::BUSINESS_TYPES[:limited_liability_partnership] }
     end
 
     trait :local_authority do
-      business_type { "localAuthority" }
+      business_type { WasteExemptionsEngine::Registration::BUSINESS_TYPES[:local_authority] }
     end
 
     trait :charity do
-      business_type { "charity" }
+      business_type { WasteExemptionsEngine::Registration::BUSINESS_TYPES[:charity] }
     end
 
     trait :partnership do
-      business_type { "partnership" }
+      business_type { WasteExemptionsEngine::Registration::BUSINESS_TYPES[:partnership] }
       people { build_list(:person, 2) }
     end
 
     trait :sole_trader do
-      business_type { "soleTrader" }
+      business_type { WasteExemptionsEngine::Registration::BUSINESS_TYPES[:sole_trader] }
     end
 
     trait :with_manual_site_address do
@@ -63,7 +63,7 @@ FactoryBot.define do
       applicant_last_name { Faker::Name.last_name }
       applicant_phone { "01234567890" }
       applicant_email { Faker::Internet.safe_email }
-      business_type { "limitedCompany" }
+      business_type { WasteExemptionsEngine::Registration::BUSINESS_TYPES[:limited_company] }
       company_no { "09360070" }
       operator_name { Faker::Company.name }
       contact_first_name { Faker::Name.first_name }

--- a/spec/forms/waste_exemptions_engine/business_type_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/business_type_form_spec.rb
@@ -6,12 +6,7 @@ module WasteExemptionsEngine
   RSpec.describe BusinessTypeForm, type: :model do
     subject(:form) { build(:business_type_form) }
 
-    BUSINESS_TYPES = %w[charity
-                        limitedCompany
-                        limitedLiabilityPartnership
-                        localAuthority
-                        partnership
-                        soleTrader].freeze
+    BUSINESS_TYPES = TransientRegistration::BUSINESS_TYPES.values
 
     it "validates the business type using the BusinessTypeValidator class" do
       validators = form._validators

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/business_type_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/business_type_form_spec.rb
@@ -14,7 +14,8 @@ module WasteExemptionsEngine
         "new_registration.skip_registration_number? are true" do
           next_state = :registration_number_form
 
-          %w[limitedCompany limitedLiabilityPartnership].each do |business_type|
+          [TransientRegistration::BUSINESS_TYPES[:limited_company],
+           TransientRegistration::BUSINESS_TYPES[:limited_liability_partnership]].each do |business_type|
             before(:each) { new_registration.business_type = business_type }
 
             context "and the business type is #{business_type}" do
@@ -35,7 +36,7 @@ module WasteExemptionsEngine
         context "when new_registration.partnership? is true" do
           next_state = :main_people_form
 
-          ["partnership"].each do |business_type|
+          [TransientRegistration::BUSINESS_TYPES[:partnership]].each do |business_type|
             before(:each) { new_registration.business_type = business_type }
 
             context "and the business type is #{business_type}" do
@@ -56,7 +57,9 @@ module WasteExemptionsEngine
         context "when new_registration.skip_registration_number? is true" do
           next_state = :operator_name_form
 
-          %w[localAuthority charity soleTrader].each do |business_type|
+          [TransientRegistration::BUSINESS_TYPES[:charity],
+           TransientRegistration::BUSINESS_TYPES[:local_authority],
+           TransientRegistration::BUSINESS_TYPES[:sole_trader]].each do |business_type|
             before(:each) { new_registration.business_type = business_type }
 
             context "and the business type is #{business_type}" do

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/operator_name_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/operator_name_form_spec.rb
@@ -18,7 +18,8 @@ module WasteExemptionsEngine
         "new_registration.skip_registration_number? are true" do
           previous_state = :registration_number_form
 
-          %w[limitedCompany limitedLiabilityPartnership].each do |business_type|
+          [TransientRegistration::BUSINESS_TYPES[:limited_company],
+           TransientRegistration::BUSINESS_TYPES[:limited_liability_partnership]].each do |business_type|
             before(:each) { new_registration.business_type = business_type }
 
             context "and the business type is #{business_type}" do
@@ -39,7 +40,7 @@ module WasteExemptionsEngine
         context "when new_registration.partnership? is true" do
           previous_state = :main_people_form
 
-          ["partnership"].each do |business_type|
+          [TransientRegistration::BUSINESS_TYPES[:partnership]].each do |business_type|
             before(:each) { new_registration.business_type = business_type }
 
             context "and the business type is #{business_type}" do
@@ -60,7 +61,9 @@ module WasteExemptionsEngine
         context "when new_registration.skip_registration_number? is true" do
           previous_state = :business_type_form
 
-          %w[localAuthority charity soleTrader].each do |business_type|
+          [TransientRegistration::BUSINESS_TYPES[:charity],
+           TransientRegistration::BUSINESS_TYPES[:local_authority],
+           TransientRegistration::BUSINESS_TYPES[:sole_trader]].each do |business_type|
             before(:each) { new_registration.business_type = business_type }
 
             context "and the business type is #{business_type}" do

--- a/spec/support/shared_examples/models/owner_of_registration_attributes.rb
+++ b/spec/support/shared_examples/models/owner_of_registration_attributes.rb
@@ -17,34 +17,34 @@ RSpec.shared_examples "an owner of registration attributes" do |model_factory, a
 
   describe "#company_no_required?" do
     it "returns a boolean indicating whether a company number is required" do
-      instance.business_type = "charity"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:charity]
       expect(instance.company_no_required?).to eq(false)
-      instance.business_type = "limitedCompany"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:limited_company]
       expect(instance.company_no_required?).to eq(true)
-      instance.business_type = "limitedLiabilityPartnership"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:limited_liability_partnership]
       expect(instance.company_no_required?).to eq(true)
-      instance.business_type = "localAuthority"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:local_authority]
       expect(instance.company_no_required?).to eq(false)
-      instance.business_type = "partnership"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:partnership]
       expect(instance.company_no_required?).to eq(false)
-      instance.business_type = "soleTrader"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:sole_trader]
       expect(instance.company_no_required?).to eq(false)
     end
   end
 
   describe "#partnership?" do
     it "returns true when the business type is a partnership else returns false" do
-      instance.business_type = "charity"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:charity]
       expect(instance.partnership?).to eq(false)
-      instance.business_type = "limitedCompany"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:limited_company]
       expect(instance.partnership?).to eq(false)
-      instance.business_type = "limitedLiabilityPartnership"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:limited_liability_partnership]
       expect(instance.partnership?).to eq(false)
-      instance.business_type = "localAuthority"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:local_authority]
       expect(instance.partnership?).to eq(false)
-      instance.business_type = "partnership"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:partnership]
       expect(instance.partnership?).to eq(true)
-      instance.business_type = "soleTrader"
+      instance.business_type = WasteExemptionsEngine::TransientRegistration::BUSINESS_TYPES[:sole_trader]
       expect(instance.partnership?).to eq(false)
 
     end

--- a/spec/validators/waste_exemptions_engine/business_type_validator_spec.rb
+++ b/spec/validators/waste_exemptions_engine/business_type_validator_spec.rb
@@ -12,14 +12,7 @@ end
 
 module WasteExemptionsEngine
   RSpec.describe BusinessTypeValidator, type: :model do
-    valid_type = %w[
-      charity
-      limitedCompany
-      limitedLiabilityPartnership
-      localAuthority
-      partnership
-      soleTrader
-    ].sample
+    valid_type = TransientRegistration::BUSINESS_TYPES.values.sample
 
     it_behaves_like "a validator", Test::BusinessTypeValidatable, :business_type, valid_type
     it_behaves_like "a selection validator", Test::BusinessTypeValidatable, :business_type


### PR DESCRIPTION
Resolves https://github.com/DEFRA/ruby-services-team/issues/17

This commit creates a new HashWithIndifferentAccess for storing the string values for business types. It also starts using that hash in the checks in the module.