### PR TITLE
Raise I18n errors during tests

### DIFF
--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   config.exceptions_app = WasteExemptionsEngine::Engine.routes
 


### PR DESCRIPTION
Translation errors should be caught during unit tests so none of them make it through our CI.