### PR TITLE
Allow a service main method to receive no params

### DIFF
--- a/app/services/waste_exemptions_engine/base_service.rb
+++ b/app/services/waste_exemptions_engine/base_service.rb
@@ -2,8 +2,12 @@
 
 module WasteExemptionsEngine
   class BaseService
-    def self.run(attrs)
-      new.run(attrs)
+    def self.run(attrs=nil)
+      if attrs
+        new.run(attrs)
+      else
+        new.run
+      end
     end
   end
 end

--- a/app/services/waste_exemptions_engine/base_service.rb
+++ b/app/services/waste_exemptions_engine/base_service.rb
@@ -2,7 +2,7 @@
 
 module WasteExemptionsEngine
   class BaseService
-    def self.run(attrs=nil)
+    def self.run(attrs = nil)
       if attrs
         new.run(attrs)
       else


### PR DESCRIPTION
Since not all services always needs params, let's make sure we can run services without params. 

Bug came out while I was working on: https://github.com/DEFRA/waste-exemptions-back-office-ta/pull/191/files 