### PR TITLE
Add area attribute to addresses

### DIFF
--- a/db/migrate/20190603152123_add_area_to_addresses.rb
+++ b/db/migrate/20190603152123_add_area_to_addresses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAreaToAddresses < ActiveRecord::Migration
+  def change
+    add_column :addresses, :area, :string
+  end
+end

--- a/db/migrate/20190603215354_add_area_to_transient_addresses.rb
+++ b/db/migrate/20190603215354_add_area_to_transient_addresses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAreaToTransientAddresses < ActiveRecord::Migration
+  def change
+    add_column :transient_addresses, :area, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190522085202) do
+ActiveRecord::Schema.define(version: 20190603215354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20190522085202) do
     t.integer  "registration_id"
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
+    t.string   "area"
   end
 
   add_index "addresses", ["registration_id"], name: "index_addresses_on_registration_id", using: :btree
@@ -132,6 +133,7 @@ ActiveRecord::Schema.define(version: 20190522085202) do
     t.integer  "transient_registration_id"
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
+    t.string   "area"
   end
 
   add_index "transient_addresses", ["transient_registration_id"], name: "index_transient_addresses_on_transient_registration_id", using: :btree

--- a/spec/support/helpers/model_properties.rb
+++ b/spec/support/helpers/model_properties.rb
@@ -22,6 +22,7 @@ module Helpers
       country_iso
       grid_reference
       description
+      area
     ].freeze
 
     EXEMPTION = %i[


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-25

The existing service has the ability to lookup the EA admin area for a site using the easting and northing values. This is currently out of action whilst we await a fix (the external service we call changed supplier and we have been awaiting support for what the new query should be).

However it has been spotted in our work on migrating the old data to the new schema that we don't have a field for this. So on the basis we want to retain this data, and that we expect to implement the lookup feature in the new service once the issue is resolved, this change adds a migration to add the required field.