### PR TITLE
Update address lookup test, reload cassettes

### DIFF
--- a/spec/cassettes/company_no_valid.yml
+++ b/spec/cassettes/company_no_valid.yml
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 03 Jun 2019 08:45:31 GMT
+      - Tue, 18 Jun 2019 09:20:48 GMT
       Pragma:
       - no-cache
       Server:
@@ -47,9 +47,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '597'
+      - '596'
       X-Ratelimit-Reset:
-      - '1559551750'
+      - '1560849847'
       X-Ratelimit-Window:
       - 5m
       Content-Length:
@@ -60,6 +60,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"next_due":"2019-09-30","next_made_up_to":"2018-12-31","next_accounts":{"overdue":false,"period_start_on":"2018-01-01","due_on":"2019-09-30","period_end_on":"2018-12-31"},"accounting_reference_date":{"month":"12","day":"31"},"last_accounts":{"period_end_on":"2017-12-31","period_start_on":"2017-01-01","made_up_to":"2017-12-31"},"overdue":false},"undeliverable_registered_office_address":false,"etag":"0ec9d00cab0ffee2ef1f5d59f4f714fa5b1618f5","company_number":"09360070","registered_office_address":{"postal_code":"SM3
         9ND","locality":"Sutton","region":"Surrey","address_line_1":"21 Haslam Avenue"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"overdue":false,"next_made_up_to":"2020-01-23","last_made_up_to":"2019-01-23","next_due":"2020-02-06"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
-    http_version: 
-  recorded_at: Mon, 03 Jun 2019 08:45:28 GMT
+    http_version:
+  recorded_at: Tue, 18 Jun 2019 09:20:47 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/postcode_no_matches.yml
+++ b/spec/cassettes/postcode_no_matches.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Jun 2019 08:45:27 GMT
+      - Tue, 18 Jun 2019 09:20:49 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -35,5 +35,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAAFWOywrCMBBF/2UWXZWm3QaCBHSpuBcpYxJpMSYhMymK+O8GHwuX5z7gPIAjo98im8kRyL4FYsz8DkCG4n0LLtg/LnkeOY5UUvKzyyBhYk4khcA0dzHbgME4Knlx987ErlxE8lgTsQwCrc2OqEKKxCZat/JZbXbND5XWw6B1c8VbHRbPpIa+bywykmO13mv4KJxzvI6mGgSuCsTlVIvvBeTh+HwB/2bVRt0AAAA=
     http_version: 
-  recorded_at: Mon, 03 Jun 2019 08:45:29 GMT
+  recorded_at: Tue, 18 Jun 2019 09:20:51 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/postcode_valid.yml
+++ b/spec/cassettes/postcode_valid.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 03 Jun 2019 08:45:21 GMT
+      - Tue, 18 Jun 2019 09:20:44 GMT
       Content-Type:
       - application/json
       Content-Encoding:
@@ -33,7 +33,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAAM2T22rjMBCGX8XoolfGlpImTg1hcRrRhE3sYKddustiVFvbmlUso0NpKH33jnPYxtCL7cUerqSZ0fzzMx96RkYaJpbMFA9co7DvIm2YMrsEComLeF0eAqhZVeVG5to2jai4QiF6MKbRoe+zpvKkKmtWF1xb9ci3XiE9+9NvBIOM/0h8VpaKaw1BI7UpZMk/CTWm8dkxHE8yMohmZxv2BA+tMHpMMD4rmWGam/F0FaG9hR9KbvICHNQGLGhj76BwaEHht2dkG1WD4XNMyNBFh8HwlMY38zSJlzReO9EVjS9vXWeWpPOvSQzndUZdZ0qjmKa3TppEU9eZpPNsnSzgkhEHvMEcqe5ZXWlmKlm/KwlvGsU3lW4XijryqF2v4tzkb55OB0JdyIKJymxRWFshXFTs7uhgpNU+bKtN/jL1BFF/MOrhgYf7ELctJOgFeOThAOJCApyqZobneqsN3xzlgTbkYMWtHun5BPs9jC+g5U40Nt+X9+P2De14Jo7+OyUh7yswv2uy3ZKWVhW7OSw326YdVjYMvbhHVgD6ggRDPDzHp8BmUbrMaOxcpcn1ynXW6TyZJpkzieLPH0fVEetSOhX+05BIH3vkjdFwFHij32a0z/xdNrt/FJxiWc/S+Q11UhrTL9FkQTNntbj8OJB3ZTpgjgv4X3H8gy/z/eUVtUctS7UFAAA=
+        H4sIAAAAAAAAAM1RXWvbMBT9K0YPeTK25Cx1ZgjDacQSSO1iZx3dGEa1tdZMsYQ+SkPpf9914qw19GUPgz1J536cc7jnGVlpmbhitn7gBiWRj4xl2h4LKCE+4l0zAOg53VZWVsYpJVquUYIerFUmCUOm2kDqpmNdzY3Tj/wQ1DJwv0IlGFTCRxKyptHcGABKGlvLhn8SekGzyRkuliWZpevJnj3BoBPWLAjGk4ZZZrhdrK5TdLLwU8t9VYODzoIFY90dNIYVlHx/Rk7pDiXTD5iQCx8NwjBKs5tNkWdXNNt56WeaXd763jovNt/yDN4vJfW9FU0zWtx6RZ6ufG9ZbMpdvoVPSTzwBjpS37OuNcy2snuXEmaU5vvW9AdFI3rUn1dzbqtXT28FoS9kzURrDyjpnBA+qo9/NBjpuYdr9cU/pp4ATWfzCM8CPAXcr5A4ivE8wDHgWkI4bccsr8zBWL4/00PaUIMT93wkCgkOI4w/wsqdUK46tU9yp4Venomz/1FLyPsWzB+X3LhlpNP1UYdV9qB6sUYx9OKPsorfZrVbF5sb6hU0o1/T5ZaW3vX28u/zeZdmFNH5EP8wFzLFAXmN5WIeB/P/OZYfL78Bx560zRkEAAA=
     http_version: 
-  recorded_at: Mon, 03 Jun 2019 08:45:23 GMT
+  recorded_at: Tue, 18 Jun 2019 09:20:46 GMT
 recorded_with: VCR 5.0.0

--- a/spec/support/shared_examples/forms/address_lookup_form.rb
+++ b/spec/support/shared_examples/forms/address_lookup_form.rb
@@ -34,7 +34,7 @@ RSpec.shared_examples "an address lookup form", vcr: true do |form_factory|
     context "when the form is valid" do
       it "updates the transient registration with the selected address" do
         form = build(form_factory)
-        address_uprn = %w[340116 10091760640 340117].sample
+        address_uprn = %w[340116 340117].sample
         valid_params = { token: form.token, temp_address: address_uprn }
         transient_registration = form.transient_registration
 


### PR DESCRIPTION
When updating our VCR cassettes, we noticed that the data we get back from OS Places for our test postcode has changed. This meant that the address tests could fail if a no-longer-valid UPRN was used.

This commit fixes the test and refreshes the cassettes.