### PR TITLE
Ignore auto populated grid ref. in journey

### DIFF
--- a/spec/forms/waste_exemptions_engine/site_grid_reference_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/site_grid_reference_form_spec.rb
@@ -4,7 +4,16 @@ require "rails_helper"
 
 module WasteExemptionsEngine
   RSpec.describe SiteGridReferenceForm, type: :model do
-    subject(:form) { build(:site_grid_reference_form) }
+    subject(:form) { build(:site_grid_reference_form, grid_reference: "foo") }
+
+    context "the site address is already populated" do
+      context "and the grid reference was automatically populated" do
+        it "does not populate the grid reference" do
+          expect(form.grid_reference).to be_blank
+          expect(form.description).to be_blank
+        end
+      end
+    end
 
     describe "validationsvalidation" do
       subject(:validators) { form._validators }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-25

PR #214 added the ability to automatically populate the grid reference of an site record where we know the x & y reference. So this could be an address selected using the OS Places lookup, or because of our background search against OS Places when a manual address is entered.

What we now have to consider is the following scenario

1. User comes to site location screen and chooses the option to use an address
2. User enters the address and progresses to check your details
3. User decides something needs correcting, so uses back, either in the browser or via the back link to navigate to a page prior to the site location
4. When they come to site location, the grid reference will now be populated. The first issue is this may confuse them because they did not enter it. The second is if they choose to select continue instead of use an address they will get a validation error because site description is not populated. This again could cause confusion

To avoid this we are making a change to the site location screen. If the address type is lookup (`1`) or manual (`2`) then we won't populate the grid reference field in the site location screen, even if the grid reference is populated.