### PR TITLE
Add versions archive table migration

### DIFF
--- a/db/migrate/20190625221942_create_version_archives.rb
+++ b/db/migrate/20190625221942_create_version_archives.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# This is not used directly by Paper trail, but is created for holding paper
+# trail records from the previous version of the service. Hence we have copied
+# the code from the `create_versions` migration as we want a table structured
+# in exactly the same way.
+class CreateVersionArchives < ActiveRecord::Migration
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :version_archives do |t|
+      t.string   :item_type, null: false
+      t.integer  :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object,    limit: TEXT_BYTES
+      t.datetime :created_at
+    end
+    add_index :version_archives, %i(item_type item_id)
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190603215354) do
+ActiveRecord::Schema.define(version: 20190625221942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,12 +43,6 @@ ActiveRecord::Schema.define(version: 20190603215354) do
   end
 
   add_index "addresses", ["registration_id"], name: "index_addresses_on_registration_id", using: :btree
-
-  create_table "defra_ruby_exporters_bulk_export_files", force: :cascade do |t|
-    t.string   "file_name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
   create_table "exemptions", force: :cascade do |t|
     t.integer "category"
@@ -109,6 +103,14 @@ ActiveRecord::Schema.define(version: 20190603215354) do
   end
 
   add_index "registrations", ["reference"], name: "index_registrations_on_reference", unique: true, using: :btree
+
+  create_table "reports_generated_reports", force: :cascade do |t|
+    t.string   "file_name"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.date     "data_from_date"
+    t.date     "data_to_date"
+  end
 
   create_table "transient_addresses", force: :cascade do |t|
     t.integer  "address_type",              default: 0
@@ -223,6 +225,17 @@ ActiveRecord::Schema.define(version: 20190603215354) do
   add_index "users", ["invitation_token"], name: "index_users_on_invitation_token", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
+
+  create_table "version_archives", force: :cascade do |t|
+    t.string   "item_type",  null: false
+    t.integer  "item_id",    null: false
+    t.string   "event",      null: false
+    t.string   "whodunnit"
+    t.text     "object"
+    t.datetime "created_at"
+  end
+
+  add_index "version_archives", ["item_type", "item_id"], name: "index_version_archives_on_item_type_and_item_id", using: :btree
 
   create_table "versions", force: :cascade do |t|
     t.string   "item_type",  null: false


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-25

As part of the first release of this version of the service we will be migrating data from the existing version into our new schema.

The migration will include audit history stored in the existing data. We already have a migration in place and tested for the user records. As the structure of the user records has changed very little this has not been an issue, and how [papertrail](https://github.com/paper-trail-gem/paper_trail) is working for the User model is sufficient.

However when it comes to the registrations, the structure has changed considerably. Plus we reviewed how auditing is currently working in this version of the service to help inform the migration work. What we found is that

- when we create a registration we get 4 entries; 1 registration `create` and 3 address `create` entries
- if we edit the registration in the back office we get; 1 registration `update` and 3 address `create` entries
- if we edit only an address on the registration (no direct registration properties) we get; just 3 address `create` entries

This is because we have paper trail attached to the address model (taking our lead from the current service, but the way this version works is that addresses get recreated each time a change occurs. So there will never be an edit.

So this is not reflecting what we feel is actually taking place, nor that we consider the addresses as being part of the registration, not something separate. As such we are looking at how we can improve our audit functionality.

This is a long winded way of saying

- the existing audit history data does not match with how this version works
- the existing audit history data will definately not match with how we are likely to make auditing work
- the existing audit history data isn't that great anyway

As such the migration will move the data to an archive table, which we can access if ever needed but which to begin with we are not intending to represent in a model or linked to the `Registration`.

This means we need a new table, hence this change to create it using active record migrations, so that all structure and logic related to the database remains in one place.