### PR TITLE
Show error messages in line with address select fields

### DIFF
--- a/app/views/waste_exemptions_engine/shared/_select_address.html.erb
+++ b/app/views/waste_exemptions_engine/shared/_select_address.html.erb
@@ -1,5 +1,13 @@
-<div class="form-group <%= "form-group-error" if form.errors[:addresses].any? %>">
+<div class="form-group <%= "form-group-error" if form.errors[:addresses].any? || form.errors[:temp_address].any? %>">
   <fieldset id="temp_address">
+    <% if form.errors[:temp_address].any? %>
+      <span class="error-message"><%= form.errors[:temp_address].join(", ") %></span>
+    <% end %>
+
+    <% if form.errors[:addresses].any? %>
+      <span class="error-message"><%= form.errors[:addresses].join(", ") %></span>
+    <% end %>
+
     <%= f.label :temp_address, t(".address_label"), class: "form-label" %>
     <%= f.select(:temp_address,
                  options_for_select(form.temp_addresses.map { |a| [a["address"], a["uprn"]] }, form.temp_address),

--- a/app/views/waste_exemptions_engine/shared/_select_address.html.erb
+++ b/app/views/waste_exemptions_engine/shared/_select_address.html.erb
@@ -1,11 +1,7 @@
-<div class="form-group <%= "form-group-error" if form.errors[:addresses].any? || form.errors[:temp_address].any? %>">
+<div class="form-group <%= "form-group-error" if form.errors[:temp_address].any? %>">
   <fieldset id="temp_address">
     <% if form.errors[:temp_address].any? %>
       <span class="error-message"><%= form.errors[:temp_address].join(", ") %></span>
-    <% end %>
-
-    <% if form.errors[:addresses].any? %>
-      <span class="error-message"><%= form.errors[:addresses].join(", ") %></span>
     <% end %>
 
     <%= f.label :temp_address, t(".address_label"), class: "form-label" %>


### PR DESCRIPTION
While working on setting up spec tests for the errors we show to the user, we found that the address lookup pages were the only pages not showing the message in line with the field.
Seems like some of the code necessary for the field to show was there but pointing to `addresses` rather than `temp_addresses`. I decided to just adapt the code to work in both cases when there are errors on `addresses` and when there are in `temp_addresses`.

Test coverage will come in a separate PR. 

<img width="708" alt="Screenshot 2019-07-05 at 12 01 06" src="https://user-images.githubusercontent.com/1385397/60718752-74906980-9f1d-11e9-8a5f-f85a465b1a28.png">
