### PR TITLE
Test coverage for error messages

### DIFF
--- a/app/views/waste_exemptions_engine/shared/_errors.html.erb
+++ b/app/views/waste_exemptions_engine/shared/_errors.html.erb
@@ -3,9 +3,9 @@
     <h2 class="heading-medium error-summary-heading"><%= t(".heading") %></h2>
 
     <ul class="error-summary-list">
-    <% object.errors.each do |field, message| %>
-      <li><a href="#<%= field %>"><%= message %></a></li>
-    <% end %>
+      <% object.errors.each do |field, message| %>
+        <li><a href="#<%= field %>"><%= message %></a></li>
+      <% end %>
     </ul>
   </div>
 <% end %>

--- a/app/views/waste_exemptions_engine/shared/_select_address.html.erb
+++ b/app/views/waste_exemptions_engine/shared/_select_address.html.erb
@@ -1,5 +1,13 @@
-<div class="form-group <%= "form-group-error" if form.errors[:addresses].any? %>">
+<div class="form-group <%= "form-group-error" if form.errors[:addresses].any? || form.errors[:temp_address].any? %>">
   <fieldset id="temp_address">
+    <% if form.errors[:temp_address].any? %>
+      <span class="error-message"><%= form.errors[:temp_address].join(", ") %></span>
+    <% end %>
+
+    <% if form.errors[:addresses].any? %>
+      <span class="error-message"><%= form.errors[:addresses].join(", ") %></span>
+    <% end %>
+
     <%= f.label :temp_address, t(".address_label"), class: "form-label" %>
     <%= f.select(:temp_address,
                  options_for_select(form.temp_addresses.map { |a| [a["address"], a["uprn"]] }, form.temp_address),

--- a/spec/requests/waste_exemptions_engine/applicant_email_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/applicant_email_forms_spec.rb
@@ -8,6 +8,13 @@ module WasteExemptionsEngine
     include_examples "go back", :applicant_email_form, "/applicant-email/back"
     include_examples "POST form", :applicant_email_form, "/applicant-email" do
       let(:form_data) { { applicant_email: "test@example.com", confirmed_email: "test@example.com" } }
+      let(:invalid_form_data) do
+        [
+          { applicant_email: "foo", confirmed_email: "Bar" },
+          { applicant_email: nil, confirmed_email: nil },
+          { applicant_email: "test@email.com", confirmed_email: "different-test@email.com" }
+        ]
+      end
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/applicant_name_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/applicant_name_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :applicant_name_form, "/applicant-name/back"
     include_examples "POST form", :applicant_name_form, "/applicant-name" do
       let(:form_data) { { first_name: "Joe", last_name: "Bloggs" } }
+      let(:invalid_form_data) { [{ first_name: nil, last_name: nil }] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/applicant_phone_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/applicant_phone_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :applicant_phone_form, "/applicant-phone/back"
     include_examples "POST form", :applicant_phone_form, "/applicant-phone" do
       let(:form_data) { { phone_number: "01234567890" } }
+      let(:invalid_form_data) { [{ phone_number: nil }, { phone_number: "1234" }] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/business_type_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/business_type_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :business_type_form, "/business-type/back"
     include_examples "POST form", :business_type_form, "/business-type" do
       let(:form_data) { { business_type: "limitedCompany" } }
+      let(:invalid_form_data) { [{ business_type: nil }] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/check_your_answers_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/check_your_answers_forms_spec.rb
@@ -16,6 +16,7 @@ module WasteExemptionsEngine
     include_examples "go back", :check_your_answers_form, "/check-your-answers/back"
     include_examples "POST form", :check_your_answers_form, "/check-your-answers", empty_form_is_valid do
       let(:form_data) { {} }
+      let(:invalid_form_data) { [] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/confirm_edit_cancelled_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/confirm_edit_cancelled_forms_spec.rb
@@ -27,6 +27,7 @@ module WasteExemptionsEngine
     include_examples "go back", :confirm_edit_cancelled_form, "/confirm-edit-cancelled/back"
     include_examples "POST form", :confirm_edit_cancelled_form, "/confirm-edit-cancelled", empty_form_is_valid do
       let(:form_data) { {} }
+      let(:invalid_form_data) { [] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/contact_address_lookup_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_address_lookup_forms_spec.rb
@@ -11,6 +11,7 @@ module WasteExemptionsEngine
     include_examples "go back", :contact_address_lookup_form, "/contact-address-lookup/back"
     include_examples "POST form", :contact_address_lookup_form, "/contact-address-lookup" do
       let(:form_data) { { temp_address: "340116" } }
+      let(:invalid_form_data) { [{ temp_address: nil }] }
     end
 
     include_examples "skip to manual address",

--- a/spec/requests/waste_exemptions_engine/contact_address_manual_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_address_manual_forms_spec.rb
@@ -19,6 +19,18 @@ module WasteExemptionsEngine
           postcode: "BS1 5AH"
         }
       end
+
+      let(:invalid_form_data) do
+        [
+          {
+            premises: nil,
+            street_address: nil,
+            locality: nil,
+            city: nil,
+            postcode: nil
+          }
+        ]
+      end
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/contact_email_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_email_forms_spec.rb
@@ -8,6 +8,13 @@ module WasteExemptionsEngine
     include_examples "go back", :contact_email_form, "/contact-email/back"
     include_examples "POST form", :contact_email_form, "/contact-email" do
       let(:form_data) { { contact_email: "test@example.com", confirmed_email: "test@example.com" } }
+      let(:invalid_form_data) do
+        [
+          { contact_email: "test@example.com", confirmed_email: "test_different@example.com" },
+          { contact_email: "invalid", confirmed_email: "invalid" },
+          { contact_email: nil, confirmed_email: nil }
+        ]
+      end
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/contact_name_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_name_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :contact_name_form, "/contact-name/back"
     include_examples "POST form", :contact_name_form, "/contact-name" do
       let(:form_data) { { first_name: "Joe", last_name: "Bloggs" } }
+      let(:invalid_form_data) { [{ first_name: nil, last_name: nil }] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/contact_phone_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_phone_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :contact_phone_form, "/contact-phone/back"
     include_examples "POST form", :contact_phone_form, "/contact-phone" do
       let(:form_data) { { phone_number: "01234567890" } }
+      let(:invalid_form_data) { [{ phone_number: "123" }, { phone_number: nil }] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/contact_position_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_position_forms_spec.rb
@@ -10,6 +10,7 @@ module WasteExemptionsEngine
     empty_form_is_valid = true
     include_examples "POST form", :contact_position_form, "/contact-position", empty_form_is_valid do
       let(:form_data) { { position: "Chief Waste Carrier" } }
+      let(:invalid_form_data) { [] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/contact_postcode_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_postcode_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :contact_postcode_form, "/contact-postcode/back"
     include_examples "POST form", :contact_postcode_form, "/contact-postcode" do
       let(:form_data) { { postcode: "BS1 5AH" } }
+      let(:invalid_form_data) { [{ postcode: "BA" }, { postcode: nil }] }
     end
 
     include_examples "skip to manual address",

--- a/spec/requests/waste_exemptions_engine/declaration_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/declaration_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :declaration_form, "/declaration/back"
     include_examples "POST form", :declaration_form, "/declaration" do
       let(:form_data) { { declaration: 1 } }
+      let(:invalid_form_data) { [] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/exemptions_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/exemptions_forms_spec.rb
@@ -13,6 +13,7 @@ module WasteExemptionsEngine
     include_examples "go back", :exemptions_form, "/exemptions/back"
     include_examples "POST form", :exemptions_form, "/exemptions" do
       let(:form_data) { { exemptions: Exemption.all.map(&:id).map(&:to_s) } }
+      let(:invalid_form_data) { [{ exemptions: [] }] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/is_a_farmer_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/is_a_farmer_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :is_a_farmer_form, "/is-a-farmer/back"
     include_examples "POST form", :is_a_farmer_form, "/is-a-farmer" do
       let(:form_data) { { is_a_farmer: "true" } }
+      let(:invalid_form_data) { [] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/location_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/location_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :location_form, "/location/back"
     include_examples "POST form", :location_form, "/location" do
       let(:form_data) { { location: "england" } }
+      let(:invalid_form_data) { [{ location: nil }] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/main_people_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/main_people_forms_spec.rb
@@ -17,6 +17,10 @@ module WasteExemptionsEngine
     include_examples "go back", :main_people_form, "/main-people/back"
     include_examples "POST form", :main_people_form, "/main-people" do
       let(:form_data) { person_one }
+      # TODO: There is a strange behaviour in validation of partners,
+      # which must be fixed before this can be implemented correctly.
+      # Tickets RUBY-463
+      let(:invalid_form_data) { [] }
     end
 
     describe "POST main_people_form" do

--- a/spec/requests/waste_exemptions_engine/on_a_farm_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/on_a_farm_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :on_a_farm_form, "/on-a-farm/back"
     include_examples "POST form", :on_a_farm_form, "/on-a-farm" do
       let(:form_data) { { on_a_farm: "true" } }
+      let(:invalid_form_data) { [] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/operator_address_lookup_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/operator_address_lookup_forms_spec.rb
@@ -11,6 +11,7 @@ module WasteExemptionsEngine
     include_examples "go back", :operator_address_lookup_form, "/operator-address-lookup/back"
     include_examples "POST form", :operator_address_lookup_form, "/operator-address-lookup" do
       let(:form_data) { { temp_address: "340116" } }
+      let(:invalid_form_data) { [{ temp_address: nil }] }
     end
 
     include_examples "skip to manual address",

--- a/spec/requests/waste_exemptions_engine/operator_address_manual_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/operator_address_manual_forms_spec.rb
@@ -19,6 +19,17 @@ module WasteExemptionsEngine
           postcode: "BS1 5AH"
         }
       end
+      let(:invalid_form_data) do
+        [
+          {
+            premises: nil,
+            street_address: nil,
+            locality: nil,
+            city: nil,
+            postcode: nil
+          }
+        ]
+      end
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/operator_name_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/operator_name_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :operator_name_form, "/operator-name/back"
     include_examples "POST form", :operator_name_form, "/operator-name" do
       let(:form_data) { { operator_name: "Acme Waste Carriers" } }
+      let(:invalid_form_data) { [{ operator_name: nil }] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/operator_postcode_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/operator_postcode_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :operator_postcode_form, "/operator-postcode/back"
     include_examples "POST form", :operator_postcode_form, "/operator-postcode" do
       let(:form_data) { { postcode: "BS1 5AH" } }
+      let(:invalid_form_data) { [{ postcode: "BA" }, { postcode: nil }] }
     end
 
     include_examples "skip to manual address",

--- a/spec/requests/waste_exemptions_engine/registration_number_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/registration_number_forms_spec.rb
@@ -10,6 +10,7 @@ module WasteExemptionsEngine
     include_examples "go back", :registration_number_form, "/registration-number/back"
     include_examples "POST form", :registration_number_form, "/registration-number" do
       let(:form_data) { { company_no: "09360070" } }
+      let(:invalid_form_data) { [{ company_no: nil }] }
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/site_address_lookup_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_address_lookup_forms_spec.rb
@@ -11,6 +11,7 @@ module WasteExemptionsEngine
     include_examples "go back", :site_address_lookup_form, "/site-address-lookup/back"
     include_examples "POST form", :site_address_lookup_form, "/site-address-lookup" do
       let(:form_data) { { temp_address: "340116" } }
+      let(:invalid_form_data) { [{ temp_address: nil }] }
     end
 
     include_examples "skip to manual address",

--- a/spec/requests/waste_exemptions_engine/site_address_manual_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_address_manual_forms_spec.rb
@@ -19,6 +19,18 @@ module WasteExemptionsEngine
           postcode: "BS1 5AH"
         }
       end
+
+      let(:invalid_form_data) do
+        [
+          {
+            premises: nil,
+            street_address: nil,
+            locality: nil,
+            city: nil,
+            postcode: nil
+          }
+        ]
+      end
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/site_grid_reference_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_grid_reference_forms_spec.rb
@@ -13,6 +13,15 @@ module WasteExemptionsEngine
           description: "The waste is stored in an out-building next to the barn."
         }
       end
+
+      let(:invalid_form_data) do
+        [
+          {
+            grid_reference: nil,
+            description: nil
+          }
+        ]
+      end
     end
 
     include_examples "skip to manual address",

--- a/spec/requests/waste_exemptions_engine/site_postcode_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_postcode_forms_spec.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :site_postcode_form, "/site-postcode/back"
     include_examples "POST form", :site_postcode_form, "/site-postcode" do
       let(:form_data) { { postcode: "BS1 5AH" } }
+      let(:invalid_form_data) { [{ postcode: "BS" }, { postcode: nil }] }
     end
 
     include_examples "skip to manual address",

--- a/spec/support/shared_examples/requests/post_form.rb
+++ b/spec/support/shared_examples/requests/post_form.rb
@@ -6,6 +6,7 @@ RSpec.shared_examples "POST form" do |form_factory, path, empty_form_is_valid = 
   let(:incorrect_form) { build(incorrect_workflow_state) }
   let(:post_request_path) { "/waste_exemptions_engine#{path}" }
   let(:form_data) { { override_me: "Set :form_data in the calling spec." } }
+  let(:invalid_form_data) { { override_me: "Set :invalid_form_data in the calling spec." } }
 
   describe "POST #{form_factory}" do
     context "when the form is not valid", unless: empty_form_is_valid do
@@ -19,6 +20,21 @@ RSpec.shared_examples "POST form" do |form_factory, path, empty_form_is_valid = 
       it "responds to the POST request with a 200 status code" do
         post post_request_path, empty_form_request_body
         expect(response.code).to eq("200")
+      end
+
+      it "includes validation errors for the form data" do
+        invalid_form_data.each do |invalid_data|
+          post post_request_path, form_factory => invalid_data.merge(token: correct_form.token)
+
+          invalid_form = build(form_factory, **invalid_data)
+          invalid_form.validate
+
+          invalid_form.errors.messages.values.flatten.each do |error_message|
+            # We include error messages twice, but rspec have no built-in an include twice method yet.
+            # Hence, the scan will make sure we matche the message twice in the rendered page.
+            expect(response.body.scan(error_message).count).to be > 1
+          end
+        end
       end
     end
 

--- a/spec/support/shared_examples/requests/post_form.rb
+++ b/spec/support/shared_examples/requests/post_form.rb
@@ -30,8 +30,8 @@ RSpec.shared_examples "POST form" do |form_factory, path, empty_form_is_valid = 
           invalid_form.validate
 
           invalid_form.errors.messages.values.flatten.each do |error_message|
-            # We include error messages twice, but rspec have no built-in an include twice method yet.
-            # Hence, the scan will make sure we matche the message twice in the rendered page.
+            # We include error messages twice, but RSpec has no built-in "include twice" method yet.
+            # Hence, the scan will make sure we match the message twice in the rendered page.
             expect(response.body.scan(error_message).count).to be > 1
           end
         end


### PR DESCRIPTION
Following a refactoring of our view, we have noticed that there is no test coverage on the shown of an error message to the users. This PR adds common validation messages coverage for our request spec. 