### PR TITLE
Show second error message on declaration page

### DIFF
--- a/app/views/waste_exemptions_engine/declaration_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/declaration_forms/new.html.erb
@@ -13,8 +13,12 @@
       <li><%= t(".list_item_2") %></li>
     </ul>
 
-    <div class="form-group">
+    <div class="form-group <%= "form-group-error" if @declaration_form.errors[:declaration].any? %>">
       <fieldset id="declaration">
+        <% if @declaration_form.errors[:declaration].any? %>
+          <span class="error-message"><%= @declaration_form.errors[:declaration].join(", ") %></span>
+        <% end %>
+
         <div class="multiple-choice">
           <%= f.check_box :declaration %>
           <%= f.label :declaration, t(".declaration_text") %>

--- a/spec/requests/waste_exemptions_engine/declaration_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/declaration_forms_spec.rb
@@ -8,7 +8,7 @@ module WasteExemptionsEngine
     include_examples "go back", :declaration_form, "/declaration/back"
     include_examples "POST form", :declaration_form, "/declaration" do
       let(:form_data) { { declaration: 1 } }
-      let(:invalid_form_data) { [] }
+      let(:invalid_form_data) { [{ declaration: 0 }] }
     end
   end
 end


### PR DESCRIPTION
While working to add test coverage on our error messages in request specs we have noticed that the declaration page does not show the error message in line with the checkbox. After talking to our design expert we decided that should be added.

![Screenshot 2019-07-08 at 15 11 32](https://user-images.githubusercontent.com/1385397/60817461-a1e64d00-a193-11e9-8ff5-05798f8bba26.png)
