### PR TITLE
Create reference using the registration id 

### DIFF
--- a/app/models/waste_exemptions_engine/new_registration.rb
+++ b/app/models/waste_exemptions_engine/new_registration.rb
@@ -3,14 +3,5 @@
 module WasteExemptionsEngine
   class NewRegistration < TransientRegistration
     include CanUseNewRegistrationWorkflow
-
-    # after_create :apply_reference
-
-    private
-
-    def apply_reference
-      self.reference = format("WEX%06d", id)
-      save!
-    end
   end
 end

--- a/app/models/waste_exemptions_engine/new_registration.rb
+++ b/app/models/waste_exemptions_engine/new_registration.rb
@@ -4,7 +4,7 @@ module WasteExemptionsEngine
   class NewRegistration < TransientRegistration
     include CanUseNewRegistrationWorkflow
 
-    after_create :apply_reference
+    # after_create :apply_reference
 
     private
 

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -19,7 +19,14 @@ module WasteExemptionsEngine
       source: :exemption
     )
 
+    after_create :apply_reference
+
     private
+
+    def apply_reference
+      self.reference = format("WEX%06d", id)
+      save!
+    end
 
     def json_for_version
       to_json(include: %i[addresses

--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -17,6 +17,8 @@ module WasteExemptionsEngine
 
         add_metadata
         @registration.save!
+        @registration.reference = format("WEX%06d", @registration.id)
+        @registration.save!
         @transient_registration.destroy
       end
       send_confirmation_email

--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -17,8 +17,7 @@ module WasteExemptionsEngine
 
         add_metadata
         @registration.save!
-        @registration.reference = format("WEX%06d", @registration.id)
-        @registration.save!
+
         @transient_registration.destroy
       end
       send_confirmation_email

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RegistrationCompletionService do
     let(:new_registration) { create(:new_registration, :complete, workflow_state: "registration_complete_form") }
-    let(:registration) { Registration.where(reference: new_registration.reference).first }
+    let(:registration) { Registration.last }
 
     let(:registration_completion_service) { RegistrationCompletionService.new(new_registration) }
 


### PR DESCRIPTION
In order to avoid skipping registration numbers and to keep them sequential, we want to move the creation of the reference in the Registration object creation rather than the Transient registration. 
By doing this before going live there is no downtime involved in the change. 