### PR TITLE
Fixes registration number appearing after the declaration page

### DIFF
--- a/app/controllers/waste_exemptions_engine/registration_complete_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/registration_complete_forms_controller.rb
@@ -6,7 +6,10 @@ module WasteExemptionsEngine
       return unless super(RegistrationCompleteForm, "registration_complete_form")
 
       registration_completion_service = RegistrationCompletionService.new(@transient_registration)
-      registration_completion_service.complete
+
+      registration = registration_completion_service.complete
+
+      @registration_complete_form.reference = registration.reference
     end
 
     # Overwrite create and go_back as you shouldn't be able to submit or go back

--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -7,6 +7,8 @@ module WasteExemptionsEngine
     end
 
     def complete
+      @registration = nil
+
       ActiveRecord::Base.transaction do
         activate_exemptions
 
@@ -20,6 +22,8 @@ module WasteExemptionsEngine
         @transient_registration.destroy
       end
       send_confirmation_email
+
+      @registration
     rescue StandardError => e
       Airbrake.notify(e, reference: @registration.reference) if defined?(Airbrake)
       Rails.logger.error "Completing registration error: #{e}"


### PR DESCRIPTION
Since forms are created using transient_registrations, we have the need to copy over the reference from the created registration in the confirmation form page.