### PR TITLE
Create a new transient registration for WEX renewals

### DIFF
--- a/app/controllers/waste_exemptions_engine/renews_controller.rb
+++ b/app/controllers/waste_exemptions_engine/renews_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Temporary controller for testing RUBY-491
+module WasteExemptionsEngine
+  class RenewsController < ApplicationController
+    def new
+      @renewal = RenewalStartService.run
+    end
+  end
+end

--- a/app/models/waste_exemptions_engine/renewing_registration.rb
+++ b/app/models/waste_exemptions_engine/renewing_registration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RenewingRegistration < TransientRegistration
+    include CanUseNewRegistrationWorkflow
+  end
+end

--- a/app/services/waste_exemptions_engine/renewal_start_service.rb
+++ b/app/services/waste_exemptions_engine/renewal_start_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RenewalStartService < BaseService
+    def run
+      RenewingRegistration.create
+    end
+  end
+end

--- a/app/views/waste_exemptions_engine/renews/new.html.erb
+++ b/app/views/waste_exemptions_engine/renews/new.html.erb
@@ -1,0 +1,7 @@
+<div class="text">
+  <h1 class="heading-large">Renewal created</h1>
+  <p>A new renewal was created:</p>
+  <pre><%= JSON.pretty_generate(@renewal.attributes) %></pre>
+  <hr>
+  <p>This is a very temporary page for testing RUBY-491 only.</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -476,6 +476,11 @@ WasteExemptionsEngine::Engine.routes.draw do
       constraints: { status: /\d{3}/ },
       as: "error"
 
+  # Temporary route for testing RUBY-491
+  get "/renew",
+      to: "renews#new",
+      as: "renew"
+
   # Static pages with HighVoltage
   resources :pages, only: [:show], controller: "pages"
 end

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :renewing_registration, class: WasteExemptionsEngine::RenewingRegistration do
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    subject(:renewing_registration) { create(:renewing_registration) }
+
+    it_behaves_like "a transient_registration", :renewing_registration
+
+    it "subclasses TransientRegistration" do
+      expect(described_class).to be < TransientRegistration
+    end
+
+    describe "public interface" do
+      Helpers::ModelProperties::TRANSIENT_REGISTRATION.each do |property|
+        it "responds to property" do
+          expect(renewing_registration).to respond_to(property)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_exemptions_engine/renew_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renew_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe "Renew", type: :request do
+    describe "GET start_form" do
+      let(:registration) { build(:registration) }
+      let(:request_path) { "/waste_exemptions_engine/renew/" }
+
+      it "renders the appropriate template" do
+        get request_path
+        expect(response).to render_template("waste_exemptions_engine/renews/new")
+      end
+
+      it "creates a new RenewingRegistration" do
+        expect { get request_path }.to change { RenewingRegistration.count }.by(1)
+      end
+
+      it "responds to the GET request with a 200 status code" do
+        get request_path
+        expect(response.code).to eq("200")
+      end
+    end
+  end
+end

--- a/spec/requests/waste_exemptions_engine/start_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/start_forms_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-module WasteCarriersEngine
+module WasteExemptionsEngine
   RSpec.describe "Start Forms", type: :request do
     let(:form) { build(:start_form) }
 

--- a/spec/services/waste_exemptions_engine/renewal_start_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/renewal_start_service_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewalStartService do
+    describe "run" do
+      let(:service) { RenewalStartService.run }
+
+      it "creates a new RenewingRegistration" do
+        expect { service }.to change { RenewingRegistration.count }.by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-491

When a user starts the WEX renewal process, we need to create a new database record to store their in-progress renewal.

As a start, we need to create a new RenewingRegistration subtype of TransientRegistration.