### PR TITLE
Use DB Pessimistic locking to prevent race conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+addons:
+  postgresql: 9.6
+
 env:
   global:
     - CC_TEST_REPORTER_ID=40a6febb0a056fa9236dec7ffab8afc58cf5fd5973cad5f047fc14f32484203e

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
         expect(WasteExemptionsEngine::Registration.count).to eq(0)
         RegistrationCompletionService.new(new_registration).complete
 
-        expect { RegistrationCompletionService.new(new_registration).complete }.to raise_error
+        expect { RegistrationCompletionService.new(new_registration).complete }.to raise_error(StandardError)
 
         expect(WasteExemptionsEngine::Registration.count).to eq(1)
       end

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -20,6 +20,7 @@ module WasteExemptionsEngine
       end
 
       context "when a race condition calls the service twice" do
+        # rubocop:disable Lint/HandleExceptions
         it "generates only one record and fail to execute subsequent calls" do
           expect(WasteExemptionsEngine::Registration.count).to eq(0)
           expect(ActiveRecord::Base.connection.pool.size).to be > 3
@@ -28,9 +29,9 @@ module WasteExemptionsEngine
           concurrency_level = 4
 
           begin
-            threads = Array.new(concurrency_level) do |i|
+            threads = Array.new(concurrency_level) do
               Thread.new do
-                while should_wait do
+                while should_wait
                   # Do nothing, just wait
                 end
 
@@ -55,7 +56,9 @@ module WasteExemptionsEngine
           WasteExemptionsEngine::RegistrationExemption.delete_all
           WasteExemptionsEngine::Registration.delete_all
         end
+        # rubocop:enable Lint/HandleExceptions
       end
+
       context "when the registration can be completed" do
         it "copies attributes from the new_registration to the registration" do
           new_registration_attribute = new_registration.operator_name

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -10,6 +10,52 @@ module WasteExemptionsEngine
     let(:registration_completion_service) { RegistrationCompletionService.new(new_registration) }
 
     describe "#complete" do
+      it "is idempotent" do
+        expect(WasteExemptionsEngine::Registration.count).to eq(0)
+        RegistrationCompletionService.new(new_registration).complete
+
+        expect { RegistrationCompletionService.new(new_registration).complete }.to raise_error
+
+        expect(WasteExemptionsEngine::Registration.count).to eq(1)
+      end
+
+      context "when a race condition calls the service twice" do
+        it "generates only one record and fail to execute subsequent calls" do
+          expect(WasteExemptionsEngine::Registration.count).to eq(0)
+          expect(ActiveRecord::Base.connection.pool.size).to be > 3
+
+          should_wait = true
+          concurrency_level = 4
+
+          begin
+            threads = Array.new(concurrency_level) do |i|
+              Thread.new do
+                while should_wait do
+                  # Do nothing, just wait
+                end
+
+                begin
+                  registration_completion_service.complete
+                rescue StandardError
+                end
+              end
+            end
+          ensure
+            ActiveRecord::Base.connection_pool.disconnect!
+          end
+
+          should_wait = false
+          threads.each(&:join)
+
+          expect(WasteExemptionsEngine::Registration.count).to eq(1)
+
+          # Clean up after the threads have executed
+          WasteExemptionsEngine::Address.delete_all
+          WasteExemptionsEngine::Person.delete_all
+          WasteExemptionsEngine::RegistrationExemption.delete_all
+          WasteExemptionsEngine::Registration.delete_all
+        end
+      end
       context "when the registration can be completed" do
         it "copies attributes from the new_registration to the registration" do
           new_registration_attribute = new_registration.operator_name


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-523

In order to avoid race conditions creating broken registration records, this PR adds a test coverage which take advantage of Ruby Threads to recreate the race condition.
To fix the race condition, we have decided to use the `transient_registration` workflow_state to run an update on the object which will make it possible to take advantage of the https://api.rubyonrails.org/classes/ActiveRecord/Locking/Pessimistic.html.