### PR TITLE
Change position of the Exemptions form

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_new_registration_workflow.rb
@@ -92,6 +92,10 @@ module WasteExemptionsEngine
                       if: :should_register_in_wales?
 
           transitions from: :location_form,
+                      to: :exemptions_form
+
+          # Exemptions
+          transitions from: :exemptions_form,
                       to: :applicant_name_form
 
           # Applicant details
@@ -185,7 +189,7 @@ module WasteExemptionsEngine
                       if: :skip_to_manual_address?
 
           transitions from: :site_grid_reference_form,
-                      to: :exemptions_form
+                      to: :check_your_answers_form
 
           transitions from: :site_postcode_form,
                       to: :site_address_manual_form,
@@ -199,12 +203,9 @@ module WasteExemptionsEngine
                       if: :skip_to_manual_address?
 
           transitions from: :site_address_lookup_form,
-                      to: :exemptions_form
+                      to: :check_your_answers_form
 
           transitions from: :site_address_manual_form,
-                      to: :exemptions_form
-
-          transitions from: :exemptions_form,
                       to: :check_your_answers_form
 
           transitions from: :check_your_answers_form,
@@ -233,8 +234,12 @@ module WasteExemptionsEngine
                       to: :location_form
 
           # Applicant details
-          transitions from: :applicant_name_form,
+          transitions from: :exemptions_form,
                       to: :location_form
+
+          # Applicant details
+          transitions from: :applicant_name_form,
+                      to: :exemptions_form
 
           transitions from: :applicant_phone_form,
                       to: :applicant_name_form
@@ -322,21 +327,17 @@ module WasteExemptionsEngine
           transitions from: :site_address_manual_form,
                       to: :site_postcode_form
 
-          # Exemptions questions
-          transitions from: :exemptions_form,
+          # End pages
+          transitions from: :check_your_answers_form,
                       to: :site_address_manual_form,
                       if: :site_address_was_manually_entered?
 
-          transitions from: :exemptions_form,
+          transitions from: :check_your_answers_form,
                       to: :site_address_lookup_form,
                       if: :site_address_was_entered?
 
-          transitions from: :exemptions_form,
-                      to: :site_grid_reference_form
-
-          # End pages
           transitions from: :check_your_answers_form,
-                      to: :exemptions_form
+                      to: :site_grid_reference_form
 
           transitions from: :declaration_form,
                       to: :check_your_answers_form

--- a/app/models/concerns/waste_exemptions_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_new_registration_workflow.rb
@@ -233,7 +233,7 @@ module WasteExemptionsEngine
           transitions from: :register_in_wales_form,
                       to: :location_form
 
-          # Applicant details
+          # Exemptions
           transitions from: :exemptions_form,
                       to: :location_form
 

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/applicant_name_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/applicant_name_form_spec.rb
@@ -6,7 +6,7 @@ module WasteExemptionsEngine
   RSpec.describe NewRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :location_form,
+                      previous_state: :exemptions_form,
                       current_state: :applicant_name_form,
                       next_state: :applicant_phone_form,
                       factory: :new_registration

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/check_your_answers_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/check_your_answers_form_spec.rb
@@ -6,10 +6,51 @@ module WasteExemptionsEngine
   RSpec.describe NewRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :exemptions_form,
+                      previous_state: :site_grid_reference_form,
                       current_state: :check_your_answers_form,
                       next_state: :declaration_form,
                       factory: :new_registration
+
+      next_state = :declaration_form
+      current_state = :check_your_answers_form
+      let(:site_address) { build(:transient_address, :site_address) }
+      subject(:new_registration) do
+        create(:new_registration, workflow_state: current_state, addresses: [site_address])
+      end
+
+      context "when new_registration.site_address_was_manually_entered? is true" do
+        previous_state = :site_address_manual_form
+
+        before(:each) { new_registration.site_address.manual! }
+
+        it "can only transition to either #{previous_state} or #{next_state}" do
+          permitted_states = Helpers::WorkflowStates.permitted_states(new_registration)
+          expect(permitted_states).to match_array([previous_state, next_state])
+        end
+
+        it "changes to #{previous_state} after the 'back' event" do
+          expect(new_registration.send(:site_address_was_manually_entered?)).to eq(true)
+          expect(new_registration.send(:site_address_was_entered?)).to eq(false)
+          expect(new_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+        end
+      end
+
+      context "when new_registration.site_address_was_entered? is true" do
+        previous_state = :site_address_lookup_form
+
+        before(:each) { new_registration.site_address.lookup! }
+
+        it "can only transition to either #{previous_state} or #{next_state}" do
+          permitted_states = Helpers::WorkflowStates.permitted_states(new_registration)
+          expect(permitted_states).to match_array([previous_state, next_state])
+        end
+
+        it "changes to #{previous_state} after the 'back' event" do
+          expect(new_registration.send(:site_address_was_manually_entered?)).to eq(false)
+          expect(new_registration.send(:site_address_was_entered?)).to eq(true)
+          expect(new_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+        end
+      end
     end
   end
 end

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/exemptions_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/exemptions_form_spec.rb
@@ -5,68 +5,11 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe NewRegistration, type: :model do
     describe "#workflow_state" do
-      next_state = :check_your_answers_form
-      current_state = :exemptions_form
-      let(:site_address) { build(:transient_address, :site_address) }
-      subject(:new_registration) do
-        create(:new_registration, workflow_state: current_state, addresses: [site_address])
-      end
-
-      context "when a NewRegistration's state is #{current_state}" do
-        it "changes to #{next_state} after the 'next' event" do
-          expect(new_registration).to transition_from(current_state).to(next_state).on_event(:next)
-        end
-
-        context "when neither new_registration.site_address_was_manually_entered? nor " \
-        "new_registration.site_address_was_entered? are true" do
-          previous_state = :site_grid_reference_form
-
-          it "can only transition to either #{previous_state} or #{next_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(new_registration)
-            expect(permitted_states).to match_array([previous_state, next_state])
-          end
-
-          it "changes to #{previous_state} after the 'back' event" do
-            expect(new_registration.send(:site_address_was_manually_entered?)).to eq(false)
-            expect(new_registration.send(:site_address_was_entered?)).to eq(false)
-            expect(new_registration).to transition_from(current_state).to(previous_state).on_event(:back)
-          end
-        end
-
-        context "when new_registration.site_address_was_manually_entered? is true" do
-          previous_state = :site_address_manual_form
-
-          before(:each) { new_registration.site_address.manual! }
-
-          it "can only transition to either #{previous_state} or #{next_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(new_registration)
-            expect(permitted_states).to match_array([previous_state, next_state])
-          end
-
-          it "changes to #{previous_state} after the 'back' event" do
-            expect(new_registration.send(:site_address_was_manually_entered?)).to eq(true)
-            expect(new_registration.send(:site_address_was_entered?)).to eq(false)
-            expect(new_registration).to transition_from(current_state).to(previous_state).on_event(:back)
-          end
-        end
-
-        context "when new_registration.site_address_was_entered? is true" do
-          previous_state = :site_address_lookup_form
-
-          before(:each) { new_registration.site_address.lookup! }
-
-          it "can only transition to either #{previous_state} or #{next_state}" do
-            permitted_states = Helpers::WorkflowStates.permitted_states(new_registration)
-            expect(permitted_states).to match_array([previous_state, next_state])
-          end
-
-          it "changes to #{previous_state} after the 'back' event" do
-            expect(new_registration.send(:site_address_was_manually_entered?)).to eq(false)
-            expect(new_registration.send(:site_address_was_entered?)).to eq(true)
-            expect(new_registration).to transition_from(current_state).to(previous_state).on_event(:back)
-          end
-        end
-      end
+      it_behaves_like "a simple bidirectional transition",
+                      previous_state: :location_form,
+                      current_state: :exemptions_form,
+                      next_state: :applicant_name_form,
+                      factory: :new_registration
     end
   end
 end

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/location_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/location_form_spec.rb
@@ -11,7 +11,7 @@ module WasteExemptionsEngine
 
       context "when a NewRegistration's state is #{current_state}" do
         context "when none of the should register in location conditions are true" do
-          next_state = :applicant_name_form
+          next_state = :exemptions_form
 
           before(:each) { new_registration.location = "england" }
 

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/site_address_lookup_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/site_address_lookup_form_spec.rb
@@ -6,7 +6,7 @@ module WasteExemptionsEngine
   RSpec.describe NewRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "an address lookup transition",
-                      next_state_if_not_skipping_to_manual: :exemptions_form,
+                      next_state_if_not_skipping_to_manual: :check_your_answers_form,
                       address_type: "site",
                       factory: :new_registration
     end

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/site_address_manual_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/site_address_manual_form_spec.rb
@@ -8,7 +8,7 @@ module WasteExemptionsEngine
       it_behaves_like "a simple bidirectional transition",
                       previous_state: :site_postcode_form,
                       current_state: :site_address_manual_form,
-                      next_state: :exemptions_form,
+                      next_state: :check_your_answers_form,
                       factory: :new_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/site_grid_reference_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/site_grid_reference_form_spec.rb
@@ -11,7 +11,7 @@ module WasteExemptionsEngine
 
       context "when a NewRegistration's state is #{current_state}" do
         context "when new_registration.skip_to_manual_address? is false" do
-          next_state = :exemptions_form
+          next_state = :check_your_answers_form
           alt_state = :site_postcode_form
 
           before(:each) { new_registration.address_finder_error = false }

--- a/spec/support/helpers/workflow_states.rb
+++ b/spec/support/helpers/workflow_states.rb
@@ -7,9 +7,11 @@ module Helpers
     end
 
     def self.can_navigate_flexibly_to_state?(state)
+      return false unless state_can_navigate_flexibly?(state)
+
       previous_state = previous_state(WasteExemptionsEngine::NewRegistration.new(workflow_state: state))
 
-      previous_state && state_can_navigate_flexibly?(previous_state) && state_can_navigate_flexibly?(state)
+      previous_state && state_can_navigate_flexibly?(previous_state)
     end
 
     def self.state_can_navigate_flexibly?(state)
@@ -17,21 +19,30 @@ module Helpers
       form_class.can_navigate_flexibly?
     end
 
+    # The purpose of this method is to dynamically find a valid previous state for a given transient registration's state.
+    # In order to do that, we get the data of the state machine of the transient registration class, and we search in all
+    # back event which handles moving from a transient registration's current state to a previous valid state.
     def self.previous_state(transient_registration)
       state_machine = transient_registration.class.aasm
 
       state_machine.events.each do |event|
+        # We are only interested in :back events. Those are the only that define a valid previous state for a
+        # transient registration
         next unless event.name == :back
 
         previous_state_transition = event.transitions.find do |transition|
+          # Once we find a valid transition, we have to make sure such transition can be run in the current object.
+          # Some transitions have extra `:if:` and `:unless:` rules that define on which object they are valid to run,
+          # the `#allowed?` method will run those checks on the give object for the given transaction
           transition.allowed?(transient_registration) && transition.from == transient_registration.aasm.current_state
         end
 
+        # We exit the method and return the first valid result
         return previous_state_transition.to if previous_state_transition
       end
 
-      return if transient_registration.registration_complete_form?
-
+      # If no result is found, then there is something logically wrong. One reason might be that the current state is not a
+      # flexibly navigatable one.
       raise(StandardError, "No previous state found for #{transient_registration.aasm.current_state}")
     end
   end

--- a/spec/support/helpers/workflow_states.rb
+++ b/spec/support/helpers/workflow_states.rb
@@ -19,9 +19,10 @@ module Helpers
       form_class.can_navigate_flexibly?
     end
 
-    # The purpose of this method is to dynamically find a valid previous state for a given transient registration's state.
-    # In order to do that, we get the data of the state machine of the transient registration class, and we search in all
-    # back event which handles moving from a transient registration's current state to a previous valid state.
+    # The purpose of this method is to dynamically find a valid previous state for a given transient registration's
+    # state.
+    # In order to do that, we get the data of the state machine of the transient registration class, and we search in
+    # all back event which handles moving from a transient registration's current state to a previous valid state.
     def self.previous_state(transient_registration)
       state_machine = transient_registration.class.aasm
 
@@ -41,8 +42,8 @@ module Helpers
         return previous_state_transition.to if previous_state_transition
       end
 
-      # If no result is found, then there is something logically wrong. One reason might be that the current state is not a
-      # flexibly navigatable one.
+      # If no result is found, then there is something logically wrong. One reason might be that the current state is
+      # not a flexibly navigatable one.
       raise(StandardError, "No previous state found for #{transient_registration.aasm.current_state}")
     end
   end

--- a/spec/support/helpers/workflow_states.rb
+++ b/spec/support/helpers/workflow_states.rb
@@ -30,7 +30,6 @@ module Helpers
         return previous_state_transition.to if previous_state_transition
       end
 
-
       unless transient_registration.registration_complete_form?
         raise(StandardError, "No previous state found for #{transient_registration.aasm.current_state}")
       end

--- a/spec/support/helpers/workflow_states.rb
+++ b/spec/support/helpers/workflow_states.rb
@@ -43,7 +43,7 @@ module Helpers
       end
 
       # If no result is found, then there is something logically wrong. One reason might be that the current state is
-      # not a flexibly navigatable one.
+      #  the start of the user journey, or an inescapable end point.
       raise(StandardError, "No previous state found for #{transient_registration.aasm.current_state}")
     end
   end

--- a/spec/support/helpers/workflow_states.rb
+++ b/spec/support/helpers/workflow_states.rb
@@ -30,7 +30,7 @@ module Helpers
         return previous_state_transition.to if previous_state_transition
       end
 
-      return unless transient_registration.registration_complete_form?
+      return if transient_registration.registration_complete_form?
 
       raise(StandardError, "No previous state found for #{transient_registration.aasm.current_state}")
     end

--- a/spec/support/helpers/workflow_states.rb
+++ b/spec/support/helpers/workflow_states.rb
@@ -30,9 +30,9 @@ module Helpers
         return previous_state_transition.to if previous_state_transition
       end
 
-      unless transient_registration.registration_complete_form?
-        raise(StandardError, "No previous state found for #{transient_registration.aasm.current_state}")
-      end
+      return unless transient_registration.registration_complete_form?
+
+      raise(StandardError, "No previous state found for #{transient_registration.aasm.current_state}")
     end
   end
 end

--- a/spec/support/helpers/workflow_states.rb
+++ b/spec/support/helpers/workflow_states.rb
@@ -43,7 +43,7 @@ module Helpers
       end
 
       # If no result is found, then there is something logically wrong. One reason might be that the current state is
-      #  the start of the user journey, or an inescapable end point.
+      # the start of the user journey, or an inescapable end point.
       raise(StandardError, "No previous state found for #{transient_registration.aasm.current_state}")
     end
   end

--- a/spec/support/helpers/workflow_states.rb
+++ b/spec/support/helpers/workflow_states.rb
@@ -30,7 +30,6 @@ module Helpers
         return previous_state_transition.to if previous_state_transition
       end
 
-      :start_form
 
       unless transient_registration.registration_complete_form?
         raise(StandardError, "No previous state found for #{transient_registration.aasm.current_state}")

--- a/spec/support/shared_examples/requests/get_form.rb
+++ b/spec/support/shared_examples/requests/get_form.rb
@@ -54,6 +54,7 @@ RSpec.shared_examples "GET form" do |form_factory, path|
 
       context "and the form can not navigate flexibly", unless: flexible_navigation_allowed do
         status_code = WasteExemptionsEngine::ApplicationController::UNSUCCESSFUL_REDIRECTION_CODE
+        let(:incorrect_form) { build(:start_form) }
 
         it "responds to the GET request with a #{status_code} status code" do
           get bad_request_path

--- a/spec/support/shared_examples/requests/get_form.rb
+++ b/spec/support/shared_examples/requests/get_form.rb
@@ -2,8 +2,6 @@
 
 RSpec.shared_examples "GET form" do |form_factory, path|
   let(:correct_form) { build(form_factory) }
-  let!(:incorrect_workflow_state) { Helpers::WorkflowStates.previous_state(correct_form.transient_registration) }
-  let(:incorrect_form) { build(incorrect_workflow_state) }
 
   describe "GET #{form_factory}" do
     context "when the registration is in the correct state" do
@@ -32,6 +30,9 @@ RSpec.shared_examples "GET form" do |form_factory, path|
       flexible_navigation_allowed = Helpers::WorkflowStates.can_navigate_flexibly_to_state?(form_factory)
 
       context "and the form can navigate flexibly", if: flexible_navigation_allowed do
+        let!(:incorrect_workflow_state) { Helpers::WorkflowStates.previous_state(correct_form.transient_registration) }
+        let(:incorrect_form) { build(incorrect_workflow_state) }
+
         it "renders the appropriate template" do
           get bad_request_path
           expect(response).to render_template("waste_exemptions_engine/#{form_factory}s/new")

--- a/spec/support/shared_examples/requests/post_form.rb
+++ b/spec/support/shared_examples/requests/post_form.rb
@@ -2,8 +2,6 @@
 
 RSpec.shared_examples "POST form" do |form_factory, path, empty_form_is_valid = false|
   let(:correct_form) { build(form_factory) }
-  let(:incorrect_workflow_state) { Helpers::WorkflowStates.previous_state(correct_form.transient_registration) }
-  let(:incorrect_form) { build(incorrect_workflow_state) }
   let(:post_request_path) { "/waste_exemptions_engine#{path}" }
   let(:form_data) { { override_me: "Set :form_data in the calling spec." } }
   let(:invalid_form_data) { { override_me: "Set :invalid_form_data in the calling spec." } }
@@ -68,6 +66,10 @@ RSpec.shared_examples "POST form" do |form_factory, path, empty_form_is_valid = 
     end
 
     context "when the registration is not in the correct state" do
+      # Use a form which cannot be posted and so won't be using this shared example
+      let(:incorrect_workflow_state) { :register_in_wales_form }
+      let(:incorrect_form) { build(incorrect_workflow_state) }
+
       let(:bad_request_body) { { form_factory => form_data.merge(token: incorrect_form.token) } }
       let(:bad_request_redirection_path) do
         workflow_path = "new_#{incorrect_form.transient_registration.workflow_state}_path".to_sym


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-457

Change the state machine and fix tests so that the exemptions screen will now appear just after the location screens.

Other fixes were necessary on the test suite for all this to run. First thing that went wrong with them, is that removing the exemptions form between the site address and check your answers screen was generating an issue with the helper we use to fetch the correct `previous state` of a form. The code that was there was doing very little on fetching the correct previous status, was not accounting for multiple options, like is the case when dealing with the site_address, and was using "next" AASM events rather than "back" ones, so it was actually working just by chances rather than correct logic.
Once that was fixed to return the correct previous state, it was now breaking the logic for "flexibly navigatable" tests in the "get form" share examples. This is becase we rely on the get_previous_state to return a result for forms that should not have any previous state, like is the case for not flexibly navigatable forms, hence the fixes there.