### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+addons:
+  postgresql: 9.6
+
 env:
   global:
     - CC_TEST_REPORTER_ID=40a6febb0a056fa9236dec7ffab8afc58cf5fd5973cad5f047fc14f32484203e


### PR DESCRIPTION
Starting from yesterday morning, Travis stopped working on this repo complaining of not being able to connect to the postgres instance.
Adding Postgres as an addon fixed it. This is also consistent with the travis configuration in our other repos.