### PR TITLE
Create new state machine for renewals

### DIFF
--- a/app/controllers/waste_exemptions_engine/renew_with_changes_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/renew_with_changes_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RenewWithChangesFormsController < FormsController
+    def new
+      super(RenewWithChangesForm, "renew_with_changes_form")
+    end
+
+    def create
+      super(RenewWithChangesForm, "renew_with_changes_form")
+    end
+  end
+end

--- a/app/controllers/waste_exemptions_engine/renewal_complete_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/renewal_complete_forms_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RenewalCompleteFormsController < FormsController
+    def new
+      return unless super(RenewalCompleteForm, "renewal_complete_form")
+    end
+
+    # Overwrite create and go_back as you shouldn't be able to submit or go back
+    def create; end
+
+    def go_back; end
+  end
+end

--- a/app/controllers/waste_exemptions_engine/renewal_start_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/renewal_start_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RenewalStartFormsController < FormsController
+    def new
+      super(RenewalStartForm, "renewal_start_form")
+    end
+
+    def create
+      super(RenewalStartForm, "renewal_start_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/renew_with_changes_form.rb
+++ b/app/forms/waste_exemptions_engine/renew_with_changes_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RenewWithChangesForm < BaseForm
+    def submit(params)
+      super({}, params[:token])
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/renewal_complete_form.rb
+++ b/app/forms/waste_exemptions_engine/renewal_complete_form.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RenewalCompleteForm < BaseForm
+    # Override BaseForm method as users shouldn't be able to submit this form
+    def submit(_params)
+      raise UnsubmittableForm
+    end
+
+    def self.can_navigate_flexibly?
+      false
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/renewal_start_form.rb
+++ b/app/forms/waste_exemptions_engine/renewal_start_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RenewalStartForm < BaseForm
+    def submit(params)
+      super({}, params[:token])
+    end
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module CanUseRenewingRegistrationWorkflow
+    extend ActiveSupport::Concern
+
+    included do
+      include AASM
+
+      aasm column: :workflow_state do
+        # States / forms
+
+        state :renewal_start_form, initial: true
+        state :renew_with_changes_form
+        state :renewal_complete_form
+
+        # Transitions
+        event :next do
+          transitions from: :renewal_start_form,
+                      to: :renew_with_changes_form
+
+          transitions from: :renew_with_changes_form,
+                      to: :renewal_complete_form
+        end
+
+        event :back do
+          transitions from: :renew_with_changes_form,
+                      to: :renewal_start_form
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
@@ -9,7 +9,6 @@ module WasteExemptionsEngine
 
       aasm column: :workflow_state do
         # States / forms
-
         state :renewal_start_form, initial: true
         state :renew_with_changes_form
         state :renewal_complete_form

--- a/app/models/waste_exemptions_engine/renewing_registration.rb
+++ b/app/models/waste_exemptions_engine/renewing_registration.rb
@@ -2,6 +2,6 @@
 
 module WasteExemptionsEngine
   class RenewingRegistration < TransientRegistration
-    include CanUseNewRegistrationWorkflow
+    include CanUseRenewingRegistrationWorkflow
   end
 end

--- a/app/views/waste_exemptions_engine/renew_with_changes_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/renew_with_changes_forms/new.html.erb
@@ -1,0 +1,14 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_renew_with_changes_forms_path(@renew_with_changes_form.token)) %>
+
+<div class="text">
+  <%= form_for(@renew_with_changes_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @renew_with_changes_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= f.hidden_field :token, value: @renew_with_changes_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/waste_exemptions_engine/renewal_complete_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/renewal_complete_forms/new.html.erb
@@ -1,0 +1,7 @@
+<div class="text">
+  <%= form_for(@renewal_complete_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @renewal_complete_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+  <% end %>
+</div>

--- a/app/views/waste_exemptions_engine/renewal_start_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/renewal_start_forms/new.html.erb
@@ -1,0 +1,12 @@
+<div class="text">
+  <%= form_for(@renewal_start_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @renewal_start_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= f.hidden_field :token, value: @renewal_start_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/waste_exemptions_engine/renews/new.html.erb
+++ b/app/views/waste_exemptions_engine/renews/new.html.erb
@@ -4,4 +4,7 @@
   <pre><%= JSON.pretty_generate(@renewal.attributes) %></pre>
   <hr>
   <p>This is a very temporary page for testing RUBY-491 only.</p>
+  <div class="form-group">
+    <%= link_to "Continue to workflow", new_renewal_start_form_path(@renewal.token), class: "button" %>
+  </div>
 </div>

--- a/config/locales/forms/renew_with_changes_forms/en.yml
+++ b/config/locales/forms/renew_with_changes_forms/en.yml
@@ -1,0 +1,15 @@
+en:
+  waste_exemptions_engine:
+    renew_with_changes_forms:
+      new:
+        title: "Renewing with changes"
+        heading: "We'll fill in the form with your current registration details"
+        next_button: "Continue"
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/renew_with_changes_form:
+          attributes:
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/locales/forms/renewal_complete_forms/en.yml
+++ b/config/locales/forms/renewal_complete_forms/en.yml
@@ -1,0 +1,15 @@
+en:
+  waste_exemptions_engine:
+    renewal_complete_forms:
+      new:
+        title: "Renewal complete"
+        heading: "You have renewed your exemptions for 3 years"
+        next_button: "Continue"
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/renewal_complete_form:
+          attributes:
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/locales/forms/renewal_start_forms/en.yml
+++ b/config/locales/forms/renewal_start_forms/en.yml
@@ -1,0 +1,15 @@
+en:
+  waste_exemptions_engine:
+    renewal_start_forms:
+      new:
+        title: "Start your renewal"
+        heading: "Do you want to renew with these details?"
+        next_button: "Continue"
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/renewal_start_form:
+          attributes:
+            token:
+              invalid_format: "The token is not valid"
+              missing: "The token is missing"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -464,6 +464,27 @@ WasteExemptionsEngine::Engine.routes.draw do
             path: "edit-cancelled",
             path_names: { new: "/:token" }
 
+  # Renewing
+  resources :renewal_start_forms,
+            only: %i[new create],
+            path: "renewal-start",
+            path_names: { new: "/:token" }
+
+  resources :renew_with_changes_forms,
+            only: %i[new create],
+            path: "renew-with-changes",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+                  to: "renew_with_changes_forms#go_back",
+                  as: "back",
+                  on: :collection
+            end
+
+  resources :renewal_complete_forms,
+            only: %i[new create],
+            path: "renewal-complete",
+            path_names: { new: "/:token" }
+
   # Expose the data stored by the LastEmailCacheService
   get "/last-email",
       to: "last_email#show",

--- a/spec/factories/forms/renewal_complete_form.rb
+++ b/spec/factories/forms/renewal_complete_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :renewal_complete_form, class: WasteExemptionsEngine::RenewalCompleteForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "renewal_complete_form"))
+    end
+  end
+end

--- a/spec/factories/forms/renewal_start_form.rb
+++ b/spec/factories/forms/renewal_start_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :renewal_start_form, class: WasteExemptionsEngine::RenewalStartForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "renewal_start_form"))
+    end
+  end
+end

--- a/spec/factories/forms/renewal_with_changes_form.rb
+++ b/spec/factories/forms/renewal_with_changes_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :renew_with_changes_form, class: WasteExemptionsEngine::RenewWithChangesForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "renew_with_changes_form"))
+    end
+  end
+end

--- a/spec/forms/waste_exemptions_engine/renewal_complete_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/renewal_complete_form_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewalCompleteForm, type: :model do
+    describe ".can_navigate_flexibly?" do
+      it "returns false" do
+        expect(described_class.can_navigate_flexibly?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renew_with_changes_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renew_with_changes_form_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      it_behaves_like "a simple bidirectional transition",
+                      previous_state: :renewal_start_form,
+                      current_state: :renew_with_changes_form,
+                      next_state: :renewal_complete_form,
+                      factory: :renewing_registration
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renewal_complete_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renewal_complete_form_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      it_behaves_like "a fixed final state",
+                      current_state: :renewal_complete_form,
+                      factory: :renewing_registration
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renewal_start_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renewal_start_form_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      subject(:new_registration) { create(:renewing_registration, workflow_state: :renewal_start_form) }
+
+      it "can only transition to :renew_with_changes_form" do
+        permitted_states = Helpers::WorkflowStates.permitted_states(new_registration)
+        expect(permitted_states).to eq([:renew_with_changes_form])
+      end
+
+      it "changes to :renew_with_changes_form after the 'next' event" do
+        expect(new_registration).to transition_from(:renewal_start_form).to(:renew_with_changes_form).on_event(:next)
+      end
+
+      it "is unable to transition when the 'back' event is issued" do
+        expect { new_registration.back }.to raise_error(AASM::InvalidTransition)
+      end
+    end
+  end
+end

--- a/spec/requests/waste_exemptions_engine/renew_with_changes_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renew_with_changes_forms_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe "Renew With Changes Forms", type: :request do
+    let(:form) { build(:renew_with_changes_form) }
+
+    describe "GET renew_with_changes_form" do
+      let(:request_path) { "/waste_exemptions_engine/renew-with-changes/#{form.token}" }
+
+      it "renders the appropriate template" do
+        get request_path
+        expect(response).to render_template("waste_exemptions_engine/renew_with_changes_forms/new")
+      end
+
+      it "responds to the GET request with a 200 status code" do
+        get request_path
+        expect(response.code).to eq("200")
+      end
+    end
+
+    empty_form_is_valid = true
+    include_examples "go back", :renew_with_changes_form, "/renew-with-changes/back"
+    include_examples "POST form", :renew_with_changes_form, "/renew-with-changes", empty_form_is_valid do
+      let(:form_data) { {} }
+      let(:invalid_form_data) { [] }
+    end
+  end
+end

--- a/spec/requests/waste_exemptions_engine/renewal_complete_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renewal_complete_forms_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe "Renewal Complete Forms", type: :request do
+    let(:form) { build(:renewal_complete_form) }
+
+    describe "GET renewal_complete_form" do
+      let(:request_path) { "/waste_exemptions_engine/renewal-complete/#{form.token}" }
+
+      it "renders the appropriate template" do
+        get request_path
+        expect(response).to render_template("waste_exemptions_engine/renewal_complete_forms/new")
+      end
+
+      it "responds to the GET request with a 200 status code" do
+        get request_path
+        expect(response.code).to eq("200")
+      end
+    end
+
+    describe "unable to go submit GET back" do
+      let(:request_path) { "/waste_exemptions_engine/renewal-complete/back/#{form.token}" }
+
+      it "raises an error" do
+        expect { get request_path }.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    include_examples "unable to POST form", :renewal_complete_form, "/renewal-complete"
+  end
+end

--- a/spec/requests/waste_exemptions_engine/renewal_start_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renewal_start_forms_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe "Renewal Start Forms", type: :request do
+    let(:form) { build(:renewal_start_form) }
+
+    describe "GET renewal_start_form" do
+      let(:request_path) { "/waste_exemptions_engine/renewal-start/#{form.token}" }
+
+      it "renders the appropriate template" do
+        get request_path
+        expect(response).to render_template("waste_exemptions_engine/renewal_start_forms/new")
+      end
+
+      it "responds to the GET request with a 200 status code" do
+        get request_path
+        expect(response.code).to eq("200")
+      end
+    end
+
+    describe "unable to go submit GET back" do
+      let(:request_path) { "/waste_exemptions_engine/renewal-complete/back/#{form.token}" }
+
+      it "raises an error" do
+        expect { get request_path }.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    empty_form_is_valid = true
+    include_examples "POST form", :renewal_start_form, "/renewal-start", empty_form_is_valid do
+      let(:form_data) { {} }
+      let(:invalid_form_data) { [] }
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-516

This story covers:

- creating a new state machine to handle the renewal workflow
- applying the renewal state machine to the renewals model
- creating skeleton versions of the ‘Do you want to renew with these details?', 'you are about to renew', and 'renewal complete’ pages - each page should just be a heading and a 'continue' button