### PR TITLE
Add existing forms to renewals workflow

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
+# We believe in the case of the different states and transitions for the
+# renewal journey, it's better to see them all in one place. However this
+# does mean the module length breaks Rubocop's rules, hence the exception.
+# rubocop:disable Metrics/ModuleLength
 module WasteExemptionsEngine
   module CanUseRenewingRegistrationWorkflow
     extend ActiveSupport::Concern
 
+    # We believe in the case of the different states and transitions for the
+    # renewal journey, it's better to see them all in one place. However this
+    # does mean the block length breaks Rubocop's rules, hence the exception.
+    # rubocop:disable Metrics/BlockLength
     included do
       include AASM
 
@@ -11,6 +19,51 @@ module WasteExemptionsEngine
         # States / forms
         state :renewal_start_form, initial: true
         state :renew_with_changes_form
+
+        # Location
+        state :location_form
+        state :register_in_northern_ireland_form
+        state :register_in_scotland_form
+        state :register_in_wales_form
+
+        # Applicant details
+        state :applicant_name_form
+        state :applicant_phone_form
+        state :applicant_email_form
+
+        # Operator details
+        state :business_type_form
+        state :main_people_form
+        state :registration_number_form
+        state :operator_name_form
+        state :operator_postcode_form
+        state :operator_address_lookup_form
+        state :operator_address_manual_form
+
+        # Contact details
+        state :contact_name_form
+        state :contact_position_form
+        state :contact_phone_form
+        state :contact_email_form
+        state :contact_postcode_form
+        state :contact_address_lookup_form
+        state :contact_address_manual_form
+
+        # Farm questions
+        state :on_a_farm_form
+        state :is_a_farmer_form
+
+        # Site questions
+        state :site_grid_reference_form
+        state :site_postcode_form
+        state :site_address_lookup_form
+        state :site_address_manual_form
+
+        state :exemptions_form
+
+        # End pages
+        state :check_your_answers_form
+        state :declaration_form
         state :renewal_complete_form
 
         # Transitions
@@ -19,14 +72,350 @@ module WasteExemptionsEngine
                       to: :renew_with_changes_form
 
           transitions from: :renew_with_changes_form,
+                      to: :location_form
+
+          # Location
+          transitions from: :location_form,
+                      to: :register_in_northern_ireland_form,
+                      if: :should_register_in_northern_ireland?
+
+          transitions from: :location_form,
+                      to: :register_in_scotland_form,
+                      if: :should_register_in_scotland?
+
+          transitions from: :location_form,
+                      to: :register_in_wales_form,
+                      if: :should_register_in_wales?
+
+          transitions from: :location_form,
+                      to: :exemptions_form
+
+          # Exemptions
+          transitions from: :exemptions_form,
+                      to: :applicant_name_form
+
+          # Applicant details
+          transitions from: :applicant_name_form,
+                      to: :applicant_phone_form
+
+          transitions from: :applicant_phone_form,
+                      to: :applicant_email_form
+
+          transitions from: :applicant_email_form,
+                      to: :business_type_form
+
+          # Operator details
+          transitions from: :business_type_form,
+                      to: :main_people_form,
+                      if: :partnership?
+
+          transitions from: :business_type_form,
+                      to: :operator_name_form,
+                      if: :skip_registration_number?
+
+          transitions from: :business_type_form,
+                      to: :registration_number_form
+
+          transitions from: :main_people_form,
+                      to: :operator_name_form
+
+          transitions from: :registration_number_form,
+                      to: :operator_name_form
+
+          transitions from: :operator_name_form,
+                      to: :operator_postcode_form
+
+          transitions from: :operator_postcode_form,
+                      to: :operator_address_manual_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :operator_postcode_form,
+                      to: :operator_address_lookup_form
+
+          transitions from: :operator_address_lookup_form,
+                      to: :operator_address_manual_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :operator_address_lookup_form,
+                      to: :contact_name_form
+
+          transitions from: :operator_address_manual_form,
+                      to: :contact_name_form
+
+          # Contact details
+          transitions from: :contact_name_form,
+                      to: :contact_position_form
+
+          transitions from: :contact_position_form,
+                      to: :contact_phone_form
+
+          transitions from: :contact_phone_form,
+                      to: :contact_email_form
+
+          transitions from: :contact_email_form,
+                      to: :contact_postcode_form
+
+          transitions from: :contact_postcode_form,
+                      to: :contact_address_manual_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :contact_postcode_form,
+                      to: :contact_address_lookup_form
+
+          transitions from: :contact_address_lookup_form,
+                      to: :contact_address_manual_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :contact_address_lookup_form,
+                      to: :on_a_farm_form
+
+          transitions from: :contact_address_manual_form,
+                      to: :on_a_farm_form
+
+          # Farm questions
+          transitions from: :on_a_farm_form,
+                      to: :is_a_farmer_form
+
+          # Site questions
+          transitions from: :is_a_farmer_form,
+                      to: :site_grid_reference_form
+
+          transitions from: :site_grid_reference_form,
+                      to: :site_postcode_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :site_grid_reference_form,
+                      to: :check_your_answers_form
+
+          transitions from: :site_postcode_form,
+                      to: :site_address_manual_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :site_postcode_form,
+                      to: :site_address_lookup_form
+
+          transitions from: :site_address_lookup_form,
+                      to: :site_address_manual_form,
+                      if: :skip_to_manual_address?
+
+          transitions from: :site_address_lookup_form,
+                      to: :check_your_answers_form
+
+          transitions from: :site_address_manual_form,
+                      to: :check_your_answers_form
+
+          transitions from: :check_your_answers_form,
+                      to: :declaration_form
+
+          transitions from: :declaration_form,
                       to: :renewal_complete_form
         end
 
         event :back do
           transitions from: :renew_with_changes_form,
                       to: :renewal_start_form
+
+          # Location
+          transitions from: :location_form,
+                      to: :renew_with_changes_form
+
+          transitions from: :register_in_northern_ireland_form,
+                      to: :location_form
+
+          transitions from: :register_in_scotland_form,
+                      to: :location_form
+
+          transitions from: :register_in_wales_form,
+                      to: :location_form
+
+          # Exemptions
+          transitions from: :exemptions_form,
+                      to: :location_form
+
+          # Applicant details
+          transitions from: :applicant_name_form,
+                      to: :exemptions_form
+
+          transitions from: :applicant_phone_form,
+                      to: :applicant_name_form
+
+          transitions from: :applicant_email_form,
+                      to: :applicant_phone_form
+
+          transitions from: :business_type_form,
+                      to: :applicant_email_form
+
+          # Operator details
+          transitions from: :main_people_form,
+                      to: :business_type_form
+
+          transitions from: :registration_number_form,
+                      to: :business_type_form
+
+          transitions from: :operator_name_form,
+                      to: :main_people_form,
+                      if: :partnership?
+
+          transitions from: :operator_name_form,
+                      to: :business_type_form,
+                      if: :skip_registration_number?
+
+          transitions from: :operator_name_form,
+                      to: :registration_number_form
+
+          transitions from: :operator_postcode_form,
+                      to: :operator_name_form
+
+          transitions from: :operator_address_lookup_form,
+                      to: :operator_postcode_form
+
+          transitions from: :operator_address_manual_form,
+                      to: :operator_postcode_form
+
+          # Contact details
+          transitions from: :contact_name_form,
+                      to: :operator_address_manual_form,
+                      if: :operator_address_was_manually_entered?
+
+          transitions from: :contact_name_form,
+                      to: :operator_address_lookup_form
+
+          transitions from: :contact_position_form,
+                      to: :contact_name_form
+
+          transitions from: :contact_phone_form,
+                      to: :contact_position_form
+
+          transitions from: :contact_email_form,
+                      to: :contact_phone_form
+
+          transitions from: :contact_postcode_form,
+                      to: :contact_email_form
+
+          transitions from: :contact_address_lookup_form,
+                      to: :contact_postcode_form
+
+          transitions from: :contact_address_manual_form,
+                      to: :contact_postcode_form
+
+          # Farm questions
+          transitions from: :on_a_farm_form,
+                      to: :contact_address_manual_form,
+                      if: :contact_address_was_manually_entered?
+
+          transitions from: :on_a_farm_form,
+                      to: :contact_address_lookup_form
+
+          transitions from: :is_a_farmer_form,
+                      to: :on_a_farm_form
+
+          # Site questions
+          transitions from: :site_grid_reference_form,
+                      to: :is_a_farmer_form
+
+          transitions from: :site_postcode_form,
+                      to: :site_grid_reference_form
+
+          transitions from: :site_address_lookup_form,
+                      to: :site_postcode_form
+
+          transitions from: :site_address_manual_form,
+                      to: :site_postcode_form
+
+          # End pages
+          transitions from: :check_your_answers_form,
+                      to: :site_address_manual_form,
+                      if: :site_address_was_manually_entered?
+
+          transitions from: :check_your_answers_form,
+                      to: :site_address_lookup_form,
+                      if: :site_address_was_entered?
+
+          transitions from: :check_your_answers_form,
+                      to: :site_grid_reference_form
+
+          transitions from: :declaration_form,
+                      to: :check_your_answers_form
+        end
+
+        event :skip_to_manual_address do
+          transitions from: :operator_postcode_form,
+                      to: :operator_address_manual_form
+
+          transitions from: :operator_address_lookup_form,
+                      to: :operator_address_manual_form
+
+          transitions from: :contact_postcode_form,
+                      to: :contact_address_manual_form
+
+          transitions from: :contact_address_lookup_form,
+                      to: :contact_address_manual_form
+
+          transitions from: :site_postcode_form,
+                      to: :site_address_manual_form
+
+          transitions from: :site_address_lookup_form,
+                      to: :site_address_manual_form
+        end
+
+        event :skip_to_address do
+          transitions from: :site_grid_reference_form,
+                      to: :site_postcode_form
         end
       end
     end
+    # rubocop:enable Metrics/BlockLength
+
+    private
+
+    def operator_address_was_manually_entered?
+      return unless operator_address
+
+      # We use the mode field to record whether the address was manually entered
+      # and because it correlates to an enum, Activerecord magic gives us
+      # my_address.manual?
+      operator_address.manual?
+    end
+
+    def contact_address_was_manually_entered?
+      return unless contact_address
+
+      contact_address.manual?
+    end
+
+    def site_address_was_manually_entered?
+      return unless site_address
+
+      site_address.manual?
+    end
+
+    def site_address_was_entered?
+      return unless site_address
+
+      site_address.lookup?
+    end
+
+    def should_register_in_northern_ireland?
+      location == "northern_ireland"
+    end
+
+    def should_register_in_scotland?
+      location == "scotland"
+    end
+
+    def should_register_in_wales?
+      location == "wales"
+    end
+
+    def skip_registration_number?
+      return false if company_no_required?
+
+      true
+    end
+
+    def skip_to_manual_address?
+      address_finder_error
+    end
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/applicant_email_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/applicant_email_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :applicant_phone_form,
+                      current_state: :applicant_email_form,
+                      next_state: :business_type_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/applicant_name_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/applicant_name_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :exemptions_form,
+                      current_state: :applicant_name_form,
+                      next_state: :applicant_phone_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/applicant_phone_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/applicant_phone_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :applicant_name_form,
+                      current_state: :applicant_phone_form,
+                      next_state: :applicant_email_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/business_type_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/business_type_form_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      previous_state = :applicant_email_form
+      current_state = :business_type_form
+      subject(:renewing_registration) { create(:renewing_registration, workflow_state: current_state) }
+
+      context "when a RenewingRegistration's state is #{current_state}" do
+        context "when neither renewing_registration.partnership? nor " \
+        "renewing_registration.skip_registration_number? are true" do
+          next_state = :registration_number_form
+
+          [TransientRegistration::BUSINESS_TYPES[:limited_company],
+           TransientRegistration::BUSINESS_TYPES[:limited_liability_partnership]].each do |business_type|
+            before(:each) { renewing_registration.business_type = business_type }
+
+            context "and the business type is #{business_type}" do
+              it "can only transition to either #{previous_state} or #{next_state}" do
+                permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+                expect(permitted_states).to match_array([previous_state, next_state])
+              end
+
+              it "changes to #{next_state} after the 'next' event" do
+                expect(renewing_registration.send(:partnership?)).to eq(false)
+                expect(renewing_registration.send(:skip_registration_number?)).to eq(false)
+                expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+              end
+            end
+          end
+        end
+
+        context "when renewing_registration.partnership? is true" do
+          next_state = :main_people_form
+
+          [TransientRegistration::BUSINESS_TYPES[:partnership]].each do |business_type|
+            before(:each) { renewing_registration.business_type = business_type }
+
+            context "and the business type is #{business_type}" do
+              it "can only transition to either #{previous_state} or #{next_state}" do
+                permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+                expect(permitted_states).to match_array([previous_state, next_state])
+              end
+
+              it "changes to #{next_state} after the 'next' event" do
+                expect(renewing_registration.send(:partnership?)).to eq(true)
+                expect(renewing_registration.send(:skip_registration_number?)).to eq(true)
+                expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+              end
+            end
+          end
+        end
+
+        context "when renewing_registration.skip_registration_number? is true" do
+          next_state = :operator_name_form
+
+          [TransientRegistration::BUSINESS_TYPES[:charity],
+           TransientRegistration::BUSINESS_TYPES[:local_authority],
+           TransientRegistration::BUSINESS_TYPES[:sole_trader]].each do |business_type|
+            before(:each) { renewing_registration.business_type = business_type }
+
+            context "and the business type is #{business_type}" do
+              it "can only transition to either #{previous_state} or #{next_state}" do
+                permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+                expect(permitted_states).to match_array([previous_state, next_state])
+              end
+
+              it "changes to #{next_state} after the 'next' event" do
+                expect(renewing_registration.send(:partnership?)).to eq(false)
+                expect(renewing_registration.send(:skip_registration_number?)).to eq(true)
+                expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+              end
+            end
+          end
+        end
+
+        it "changes to #{previous_state} after the 'back' event" do
+          expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/check_your_answers_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/check_your_answers_form_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      it_behaves_like "a simple bidirectional transition",
+                      previous_state: :site_grid_reference_form,
+                      current_state: :check_your_answers_form,
+                      next_state: :declaration_form,
+                      factory: :renewing_registration
+
+      next_state = :declaration_form
+      current_state = :check_your_answers_form
+      let(:site_address) { build(:transient_address, :site_address) }
+      subject(:renewing_registration) do
+        create(:renewing_registration, workflow_state: current_state, addresses: [site_address])
+      end
+
+      context "when renewing_registration.site_address_was_manually_entered? is true" do
+        previous_state = :site_address_manual_form
+
+        before(:each) { renewing_registration.site_address.manual! }
+
+        it "can only transition to either #{previous_state} or #{next_state}" do
+          permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+          expect(permitted_states).to match_array([previous_state, next_state])
+        end
+
+        it "changes to #{previous_state} after the 'back' event" do
+          expect(renewing_registration.send(:site_address_was_manually_entered?)).to eq(true)
+          expect(renewing_registration.send(:site_address_was_entered?)).to eq(false)
+          expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+        end
+      end
+
+      context "when renewing_registration.site_address_was_entered? is true" do
+        previous_state = :site_address_lookup_form
+
+        before(:each) { renewing_registration.site_address.lookup! }
+
+        it "can only transition to either #{previous_state} or #{next_state}" do
+          permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+          expect(permitted_states).to match_array([previous_state, next_state])
+        end
+
+        it "changes to #{previous_state} after the 'back' event" do
+          expect(renewing_registration.send(:site_address_was_manually_entered?)).to eq(false)
+          expect(renewing_registration.send(:site_address_was_entered?)).to eq(true)
+          expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_address_lookup_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_address_lookup_form_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+      it_behaves_like "an address lookup transition",
+                      next_state_if_not_skipping_to_manual: :on_a_farm_form,
+                      address_type: "contact",
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_address_manual_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_address_manual_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :contact_postcode_form,
+                      current_state: :contact_address_manual_form,
+                      next_state: :on_a_farm_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_email_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_email_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :contact_phone_form,
+                      current_state: :contact_email_form,
+                      next_state: :contact_postcode_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_name_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_name_form_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      next_state = :contact_position_form
+      current_state = :contact_name_form
+      let(:operator_address) { build(:transient_address, :operator_address) }
+      subject(:renewing_registration) do
+        create(:renewing_registration, workflow_state: current_state, addresses: [operator_address])
+      end
+
+      context "when a RenewingRegistration's state is #{current_state}" do
+        it "changes to #{next_state} after the 'next' event" do
+          expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+        end
+
+        context "when renewing_registration.operator_address_was_manually_entered? is true" do
+          previous_state = :operator_address_manual_form
+
+          before(:each) { renewing_registration.operator_address.manual! }
+
+          it "can only transition to either #{previous_state} or #{next_state}" do
+            permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+            expect(permitted_states).to match_array([previous_state, next_state])
+          end
+
+          it "changes to #{previous_state} after the 'back' event" do
+            expect(renewing_registration.send(:operator_address_was_manually_entered?)).to eq(true)
+            expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+          end
+        end
+
+        context "when renewing_registration.operator_address_was_manually_entered? is false" do
+          previous_state = :operator_address_lookup_form
+
+          it "can only transition to either #{previous_state} or #{next_state}" do
+            permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+            expect(permitted_states).to match_array([previous_state, next_state])
+          end
+
+          it "changes to #{previous_state} after the 'back' event" do
+            expect(renewing_registration.send(:operator_address_was_manually_entered?)).to eq(false)
+            expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_phone_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_phone_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :contact_position_form,
+                      current_state: :contact_phone_form,
+                      next_state: :contact_email_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_position_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_position_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :contact_name_form,
+                      current_state: :contact_position_form,
+                      next_state: :contact_phone_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_postcode_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/contact_postcode_form_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+      it_behaves_like "a postcode transition",
+                      previous_state: :contact_email_form,
+                      address_type: "contact",
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/declaration_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/declaration_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :check_your_answers_form,
+                      current_state: :declaration_form,
+                      next_state: :renewal_complete_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/exemptions_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/exemptions_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :location_form,
+                      current_state: :exemptions_form,
+                      next_state: :applicant_name_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/is_a_farmer_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/is_a_farmer_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :on_a_farm_form,
+                      current_state: :is_a_farmer_form,
+                      next_state: :site_grid_reference_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/location_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/location_form_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      previous_state = :renew_with_changes_form
+      current_state = :location_form
+      subject(:renewing_registration) { create(:renewing_registration, workflow_state: current_state) }
+
+      context "when a RenewingRegistration's state is #{current_state}" do
+        context "when none of the should register in location conditions are true" do
+          next_state = :exemptions_form
+
+          before(:each) { renewing_registration.location = "england" }
+
+          it "can only transition to either #{previous_state} or #{next_state}" do
+            permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+            expect(permitted_states).to match_array([previous_state, next_state])
+          end
+
+          it "changes to #{next_state} after the 'next' event" do
+            expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+          end
+        end
+
+        context "when renewing_registration.should_register_in_northern_ireland? is true" do
+          next_state = :register_in_northern_ireland_form
+
+          before(:each) { renewing_registration.location = "northern_ireland" }
+
+          it "can only transition to either #{previous_state} or #{next_state}" do
+            permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+            expect(permitted_states).to match_array([previous_state, next_state])
+          end
+
+          it "changes to #{next_state} after the 'next' event" do
+            expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+          end
+        end
+
+        context "when renewing_registration.should_register_in_scotland? is true" do
+          next_state = :register_in_scotland_form
+
+          before(:each) { renewing_registration.location = "scotland" }
+
+          it "can only transition to either #{previous_state} or #{next_state}" do
+            permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+            expect(permitted_states).to match_array([previous_state, next_state])
+          end
+
+          it "changes to #{next_state} after the 'next' event" do
+            expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+          end
+        end
+
+        context "when renewing_registration.should_register_in_wales? is true" do
+          next_state = :register_in_wales_form
+
+          before(:each) { renewing_registration.location = "wales" }
+
+          it "can only transition to either #{previous_state} or #{next_state}" do
+            permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+            expect(permitted_states).to match_array([previous_state, next_state])
+          end
+
+          it "changes to #{next_state} after the 'next' event" do
+            expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+          end
+        end
+
+        it "changes to #{previous_state} after the 'back' event" do
+          expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/main_people_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/main_people_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :business_type_form,
+                      current_state: :main_people_form,
+                      next_state: :operator_name_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/on_a_farm_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/on_a_farm_form_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      next_state = :is_a_farmer_form
+      current_state = :on_a_farm_form
+      let(:contact_address) { build(:transient_address, :contact_address) }
+      subject(:renewing_registration) do
+        create(:renewing_registration, workflow_state: current_state, addresses: [contact_address])
+      end
+
+      context "when a RenewingRegistration's state is #{current_state}" do
+        it "changes to #{next_state} after the 'next' event" do
+          expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+        end
+
+        context "when renewing_registration.contact_address_was_manually_entered? is true" do
+          previous_state = :contact_address_manual_form
+
+          before(:each) { renewing_registration.contact_address.manual! }
+
+          it "can only transition to either #{previous_state} or #{next_state}" do
+            permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+            expect(permitted_states).to match_array([previous_state, next_state])
+          end
+
+          it "changes to #{previous_state} after the 'back' event" do
+            expect(renewing_registration.send(:contact_address_was_manually_entered?)).to eq(true)
+            expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+          end
+        end
+
+        context "when renewing_registration.contact_address_was_manually_entered? is false" do
+          previous_state = :contact_address_lookup_form
+
+          it "can only transition to either #{previous_state} or #{next_state}" do
+            permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+            expect(permitted_states).to match_array([previous_state, next_state])
+          end
+
+          it "changes to #{previous_state} after the 'back' event" do
+            expect(renewing_registration.send(:contact_address_was_manually_entered?)).to eq(false)
+            expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/operator_address_lookup_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/operator_address_lookup_form_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+      it_behaves_like "an address lookup transition",
+                      next_state_if_not_skipping_to_manual: :contact_name_form,
+                      address_type: "operator",
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/operator_address_manual_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/operator_address_manual_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :operator_postcode_form,
+                      current_state: :operator_address_manual_form,
+                      next_state: :contact_name_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/operator_name_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/operator_name_form_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      next_state = :operator_postcode_form
+      current_state = :operator_name_form
+      subject(:renewing_registration) { create(:renewing_registration, workflow_state: current_state) }
+
+      context "when a RenewingRegistration's state is #{current_state}" do
+        it "changes to #{next_state} after the 'next' event" do
+          expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+        end
+
+        context "when neither renewing_registration.partnership? nor " \
+        "renewing_registration.skip_registration_number? are true" do
+          previous_state = :registration_number_form
+
+          [TransientRegistration::BUSINESS_TYPES[:limited_company],
+           TransientRegistration::BUSINESS_TYPES[:limited_liability_partnership]].each do |business_type|
+            before(:each) { renewing_registration.business_type = business_type }
+
+            context "and the business type is #{business_type}" do
+              it "can only transition to either #{previous_state} or #{next_state}" do
+                permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+                expect(permitted_states).to match_array([previous_state, next_state])
+              end
+
+              it "changes to #{previous_state} after the 'back' event" do
+                expect(renewing_registration.send(:partnership?)).to eq(false)
+                expect(renewing_registration.send(:skip_registration_number?)).to eq(false)
+                expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+              end
+            end
+          end
+        end
+
+        context "when renewing_registration.partnership? is true" do
+          previous_state = :main_people_form
+
+          [TransientRegistration::BUSINESS_TYPES[:partnership]].each do |business_type|
+            before(:each) { renewing_registration.business_type = business_type }
+
+            context "and the business type is #{business_type}" do
+              it "can only transition to either #{previous_state} or #{next_state}" do
+                permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+                expect(permitted_states).to match_array([previous_state, next_state])
+              end
+
+              it "changes to #{previous_state} after the 'back' event" do
+                expect(renewing_registration.send(:partnership?)).to eq(true)
+                expect(renewing_registration.send(:skip_registration_number?)).to eq(true)
+                expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+              end
+            end
+          end
+        end
+
+        context "when renewing_registration.skip_registration_number? is true" do
+          previous_state = :business_type_form
+
+          [TransientRegistration::BUSINESS_TYPES[:charity],
+           TransientRegistration::BUSINESS_TYPES[:local_authority],
+           TransientRegistration::BUSINESS_TYPES[:sole_trader]].each do |business_type|
+            before(:each) { renewing_registration.business_type = business_type }
+
+            context "and the business type is #{business_type}" do
+              it "can only transition to either #{previous_state} or #{next_state}" do
+                permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+                expect(permitted_states).to match_array([previous_state, next_state])
+              end
+
+              it "changes to #{previous_state} after the 'back' event" do
+                expect(renewing_registration.send(:partnership?)).to eq(false)
+                expect(renewing_registration.send(:skip_registration_number?)).to eq(true)
+                expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/operator_postcode_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/operator_postcode_form_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+      it_behaves_like "a postcode transition",
+                      previous_state: :operator_name_form,
+                      address_type: "operator",
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/register_in_northern_ireland_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/register_in_northern_ireland_form_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+      it_behaves_like "a final state",
+                      previous_state: :location_form,
+                      current_state: :register_in_northern_ireland_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/register_in_scotland_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/register_in_scotland_form_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+      it_behaves_like "a final state",
+                      previous_state: :location_form,
+                      current_state: :register_in_scotland_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/register_in_wales_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/register_in_wales_form_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+      it_behaves_like "a final state",
+                      previous_state: :location_form,
+                      current_state: :register_in_wales_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/registration_number_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/registration_number_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :business_type_form,
+                      current_state: :registration_number_form,
+                      next_state: :operator_name_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renewal_start_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renewal_start_form_spec.rb
@@ -5,19 +5,19 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      subject(:new_registration) { create(:renewing_registration, workflow_state: :renewal_start_form) }
+      subject(:renewing_registration) { create(:renewing_registration, workflow_state: :renewal_start_form) }
 
       it "can only transition to :renew_with_changes_form" do
-        permitted_states = Helpers::WorkflowStates.permitted_states(new_registration)
+        permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
         expect(permitted_states).to eq([:renew_with_changes_form])
       end
 
       it "changes to :renew_with_changes_form after the 'next' event" do
-        expect(new_registration).to transition_from(:renewal_start_form).to(:renew_with_changes_form).on_event(:next)
+        expect(renewing_registration).to transition_from(:renewal_start_form).to(:renew_with_changes_form).on_event(:next)
       end
 
       it "is unable to transition when the 'back' event is issued" do
-        expect { new_registration.back }.to raise_error(AASM::InvalidTransition)
+        expect { renewing_registration.back }.to raise_error(AASM::InvalidTransition)
       end
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_address_lookup_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_address_lookup_form_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+      it_behaves_like "an address lookup transition",
+                      next_state_if_not_skipping_to_manual: :check_your_answers_form,
+                      address_type: "site",
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_address_manual_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_address_manual_form_spec.rb
@@ -6,9 +6,9 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+                      previous_state: :site_postcode_form,
+                      current_state: :site_address_manual_form,
+                      next_state: :check_your_answers_form,
                       factory: :renewing_registration
     end
   end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_grid_reference_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_grid_reference_form_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      previous_state = :is_a_farmer_form
+      current_state = :site_grid_reference_form
+      subject(:renewing_registration) { create(:renewing_registration, workflow_state: current_state) }
+
+      context "when a RenewingRegistration's state is #{current_state}" do
+        context "when renewing_registration.skip_to_manual_address? is false" do
+          next_state = :check_your_answers_form
+          alt_state = :site_postcode_form
+
+          before(:each) { renewing_registration.address_finder_error = false }
+
+          it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
+            permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+            expect(permitted_states).to match_array([previous_state, next_state, alt_state])
+          end
+
+          it "changes to #{next_state} after the 'next' event" do
+            expect(renewing_registration.send(:skip_to_manual_address?)).to eq(false)
+            expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+          end
+
+          it "changes to #{alt_state} after the 'skip_to_address' event" do
+            expect(renewing_registration.send(:skip_to_manual_address?)).to eq(false)
+            expect(renewing_registration)
+              .to transition_from(current_state)
+              .to(alt_state)
+              .on_event(:skip_to_address)
+          end
+        end
+
+        context "when renewing_registration.skip_to_manual_address? is true" do
+          next_state = :site_postcode_form
+
+          before(:each) { renewing_registration.address_finder_error = true }
+
+          it "can only transition to either #{previous_state} or #{next_state}" do
+            permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
+            expect(permitted_states).to match_array([previous_state, next_state])
+          end
+
+          it "changes to #{next_state} after the 'next' event" do
+            expect(renewing_registration.send(:skip_to_manual_address?)).to eq(true)
+            expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+          end
+        end
+
+        it "changes to #{previous_state} after the 'back' event" do
+          expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_postcode_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_postcode_form_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      it_behaves_like "a simple bidirectional transition",
-                      previous_state: :renewal_start_form,
-                      current_state: :renew_with_changes_form,
-                      next_state: :location_form,
+      it_behaves_like "a postcode transition",
+                      previous_state: :site_grid_reference_form,
+                      address_type: "site",
                       factory: :renewing_registration
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-516

If a user is making changes, they will go through a very similar workflow to the new registration journey, with minor differences at the start and end.

This PR adds those existing forms to the state machine for the renewals workflow.