### PR TITLE
Complete renewal and create new registration

### DIFF
--- a/app/controllers/waste_exemptions_engine/registration_complete_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/registration_complete_forms_controller.rb
@@ -5,10 +5,7 @@ module WasteExemptionsEngine
     def new
       return unless super(RegistrationCompleteForm, "registration_complete_form")
 
-      registration_completion_service = RegistrationCompletionService.new(@transient_registration)
-
-      registration = registration_completion_service.complete
-
+      registration = RegistrationCompletionService.run(transient_registration: @transient_registration)
       @registration_complete_form.reference = registration.reference
     end
 

--- a/app/controllers/waste_exemptions_engine/renewal_complete_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/renewal_complete_forms_controller.rb
@@ -5,8 +5,7 @@ module WasteExemptionsEngine
     def new
       return unless super(RenewalCompleteForm, "renewal_complete_form")
 
-      registration_completion_service = RegistrationCompletionService.new(@transient_registration)
-      registration = registration_completion_service.complete
+      registration = RegistrationCompletionService.run(transient_registration: @transient_registration)
       @renewal_complete_form.reference = registration.reference
     end
 

--- a/app/controllers/waste_exemptions_engine/renewal_complete_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/renewal_complete_forms_controller.rb
@@ -4,6 +4,9 @@ module WasteExemptionsEngine
   class RenewalCompleteFormsController < FormsController
     def new
       return unless super(RenewalCompleteForm, "renewal_complete_form")
+
+      registration_completion_service = RegistrationCompletionService.new(@transient_registration)
+      registration_completion_service.complete
     end
 
     # Overwrite create and go_back as you shouldn't be able to submit or go back

--- a/app/controllers/waste_exemptions_engine/renewal_complete_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/renewal_complete_forms_controller.rb
@@ -6,7 +6,8 @@ module WasteExemptionsEngine
       return unless super(RenewalCompleteForm, "renewal_complete_form")
 
       registration_completion_service = RegistrationCompletionService.new(@transient_registration)
-      registration_completion_service.complete
+      registration = registration_completion_service.complete
+      @renewal_complete_form.reference = registration.reference
     end
 
     # Overwrite create and go_back as you shouldn't be able to submit or go back

--- a/app/forms/waste_exemptions_engine/renewal_complete_form.rb
+++ b/app/forms/waste_exemptions_engine/renewal_complete_form.rb
@@ -2,6 +2,13 @@
 
 module WasteExemptionsEngine
   class RenewalCompleteForm < BaseForm
+    attr_accessor :reference
+
+    def initialize(registration)
+      super
+      self.reference = @transient_registration.reference
+    end
+
     # Override BaseForm method as users shouldn't be able to submit this form
     def submit(_params)
       raise UnsubmittableForm

--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
-  class RegistrationCompletionService
-    def initialize(transient_registration)
+  class RegistrationCompletionService < BaseService
+    def run(transient_registration:)
       @transient_registration = transient_registration
-    end
-
-    def complete
       @registration = nil
 
       @transient_registration.with_lock do

--- a/app/views/waste_exemptions_engine/renewal_complete_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/renewal_complete_forms/new.html.erb
@@ -3,5 +3,6 @@
     <%= render("waste_exemptions_engine/shared/errors", object: @renewal_complete_form) %>
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
+    <p><%= t(".paragraph_1", reference: @renewal_complete_form.reference) %></p>
   <% end %>
 </div>

--- a/config/locales/forms/renewal_complete_forms/en.yml
+++ b/config/locales/forms/renewal_complete_forms/en.yml
@@ -4,6 +4,7 @@ en:
       new:
         title: "Renewal complete"
         heading: "You have renewed your exemptions for 3 years"
+        paragraph_1: "Your new registration is %{reference}"
         next_button: "Continue"
   activemodel:
     errors:

--- a/spec/requests/waste_exemptions_engine/renewal_complete_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renewal_complete_forms_spec.rb
@@ -20,7 +20,11 @@ module WasteExemptionsEngine
       end
 
       it "creates a new registration" do
-        expect { get request_path }.to change { Registration.count }.from(0).to(1)
+        initial_count = Registration.count
+
+        get request_path
+
+        expect(Registration.count).to eq(initial_count + 1)
       end
 
       it "removes the renewing_registration" do

--- a/spec/requests/waste_exemptions_engine/renewal_complete_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renewal_complete_forms_spec.rb
@@ -18,6 +18,14 @@ module WasteExemptionsEngine
         get request_path
         expect(response.code).to eq("200")
       end
+
+      it "creates a new registration" do
+        expect { get request_path }.to change { Registration.count }.from(0).to(1)
+      end
+
+      it "removes the renewing_registration" do
+        expect { get request_path }.to change { RenewingRegistration.where(token: form.token).count }.from(1).to(0)
+      end
     end
 
     describe "unable to go submit GET back" do

--- a/spec/requests/waste_exemptions_engine/renewal_complete_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renewal_complete_forms_spec.rb
@@ -26,6 +26,11 @@ module WasteExemptionsEngine
       it "removes the renewing_registration" do
         expect { get request_path }.to change { RenewingRegistration.where(token: form.token).count }.from(1).to(0)
       end
+
+      it "displays the new registration reference number" do
+        get request_path
+        expect(response.body).to include(Registration.last.reference)
+      end
     end
 
     describe "unable to go submit GET back" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-517

When a user reaches the "renewal complete" page, we should create a new registration with the data they just confirmed.

The renewing_registration record should also be deleted from the database.