### PR TITLE
Add options to renewal start page

### DIFF
--- a/app/forms/waste_exemptions_engine/renewal_start_form.rb
+++ b/app/forms/waste_exemptions_engine/renewal_start_form.rb
@@ -4,8 +4,19 @@ module WasteExemptionsEngine
   class RenewalStartForm < BaseForm
     attr_accessor :temp_renew_without_changes
 
-    def submit(params)
-      super({}, params[:token])
+    def initialize(registration)
+      super
+      self.temp_renew_without_changes = @transient_registration.temp_renew_without_changes
     end
+
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      self.temp_renew_without_changes = params[:temp_renew_without_changes]
+      attributes = { temp_renew_without_changes: temp_renew_without_changes }
+
+      super(attributes, params[:token])
+    end
+
+    validates :temp_renew_without_changes, "defra_ruby/validators/true_false": true
   end
 end

--- a/app/forms/waste_exemptions_engine/renewal_start_form.rb
+++ b/app/forms/waste_exemptions_engine/renewal_start_form.rb
@@ -2,6 +2,8 @@
 
 module WasteExemptionsEngine
   class RenewalStartForm < BaseForm
+    attr_accessor :temp_renew_without_changes
+
     def submit(params)
       super({}, params[:token])
     end

--- a/app/models/waste_exemptions_engine/transient_registration.rb
+++ b/app/models/waste_exemptions_engine/transient_registration.rb
@@ -36,6 +36,7 @@ module WasteExemptionsEngine
                               temp_grid_reference
                               temp_site_description
                               temp_site_postcode
+                              temp_renew_without_changes
                               token
                               transient_addresses
                               transient_registration_exemptions

--- a/app/views/waste_exemptions_engine/renewal_start_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/renewal_start_forms/new.html.erb
@@ -4,6 +4,23 @@
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
+    <div class="form-group <%= "form-group-error" if @renewal_start_form.errors[:temp_renew_without_changes].any? %>">
+      <fieldset class="inline" id="temp_renew_without_changes">
+        <% if @renewal_start_form.errors[:temp_renew_without_changes].any? %>
+          <span class="error-message"><%= @renewal_start_form.errors[:temp_renew_without_changes].join(", ") %></span>
+        <% end %>
+
+        <div class="multiple-choice">
+          <%= f.radio_button :temp_renew_without_changes, "true" %>
+          <%= f.label :temp_renew_without_changes, t(".options.yes"), value: "true" %>
+        </div>
+        <div class="multiple-choice">
+          <%= f.radio_button :temp_renew_without_changes, "false" %>
+          <%= f.label :temp_renew_without_changes, t(".options.no"), value: "false" %>
+        </div>
+      </fieldset>
+    </div>
+
     <%= f.hidden_field :token, value: @renewal_start_form.token %>
     <div class="form-group">
       <%= f.submit t(".next_button"), class: "button" %>

--- a/config/locales/forms/renewal_start_forms/en.yml
+++ b/config/locales/forms/renewal_start_forms/en.yml
@@ -4,6 +4,9 @@ en:
       new:
         title: "Start your renewal"
         heading: "Do you want to renew with these details?"
+        options:
+          "yes": "Renew with these details"
+          "no": "I need to make changes"
         next_button: "Continue"
   activemodel:
     errors:

--- a/db/migrate/20190801171410_add_temp_renew_without_changes_to_transient_registration.rb
+++ b/db/migrate/20190801171410_add_temp_renew_without_changes_to_transient_registration.rb
@@ -1,0 +1,5 @@
+class AddTempRenewWithoutChangesToTransientRegistration < ActiveRecord::Migration
+  def change
+    add_column :transient_registrations, :temp_renew_without_changes, :boolean
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190801095905) do
+ActiveRecord::Schema.define(version: 20190801171410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -192,10 +192,11 @@ ActiveRecord::Schema.define(version: 20190801095905) do
     t.string   "temp_site_postcode"
     t.string   "temp_grid_reference"
     t.text     "temp_site_description"
-    t.boolean  "address_finder_error",   default: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.string   "type",                                   null: false
+    t.boolean  "address_finder_error",       default: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
+    t.string   "type",                                       null: false
+    t.boolean  "temp_renew_without_changes"
   end
 
   add_index "transient_registrations", ["token"], name: "index_transient_registrations_on_token", unique: true, using: :btree

--- a/spec/forms/waste_exemptions_engine/renewal_start_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/renewal_start_form_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewalStartForm, type: :model do
+    subject(:form) { build(:renewal_start_form) }
+
+    it "validates the on a farm question using the YesNoValidator class" do
+      validators = form._validators
+      expect(validators.keys).to include(:temp_renew_without_changes)
+      expect(validators[:temp_renew_without_changes].first.class)
+        .to eq(DefraRuby::Validators::TrueFalseValidator)
+    end
+
+    it_behaves_like "a validated form", :renewal_start_form do
+      let(:valid_params) do
+        [
+          { token: form.token, temp_renew_without_changes: "true" },
+          { token: form.token, temp_renew_without_changes: "false" }
+        ]
+      end
+      let(:invalid_params) do
+        [
+          { token: form.token, temp_renew_without_changes: 0 },
+          { token: form.token, temp_renew_without_changes: "" }
+        ]
+      end
+    end
+
+    describe "#submit" do
+      context "when the form is valid" do
+        it "updates the transient registration with the renewal type answer" do
+          temp_renew_without_changes = %w[true false].sample
+          valid_params = { token: form.token, temp_renew_without_changes: temp_renew_without_changes }
+          transient_registration = form.transient_registration
+
+          expect(transient_registration.temp_renew_without_changes).to be_blank
+          form.submit(valid_params)
+          expect(transient_registration.temp_renew_without_changes).to eq(temp_renew_without_changes == "true")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_exemptions_engine/renewal_start_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renewal_start_forms_spec.rb
@@ -28,9 +28,8 @@ module WasteExemptionsEngine
       end
     end
 
-    empty_form_is_valid = true
-    include_examples "POST form", :renewal_start_form, "/renewal-start", empty_form_is_valid do
-      let(:form_data) { {} }
+    include_examples "POST form", :renewal_start_form, "/renewal-start" do
+      let(:form_data) { { temp_renew_without_changes: "true" } }
       let(:invalid_form_data) { [] }
     end
   end

--- a/spec/support/helpers/model_properties.rb
+++ b/spec/support/helpers/model_properties.rb
@@ -80,6 +80,7 @@ module Helpers
       temp_site_postcode
       temp_grid_reference
       temp_site_description
+      temp_renew_without_changes
       address_finder_error
     ]).freeze
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-493
https://eaflood.atlassian.net/browse/RUBY-498

These buttons will be used to route the user to the declaration or through the longer journey through the forms.