### PR TITLE
Make it possible to jump directly into the declaration page at renewal

### DIFF
--- a/app/controllers/waste_exemptions_engine/renew_without_changes_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/renew_without_changes_forms_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RenewWithoutChangesFormsController < FormsController
+    def new
+      super(RenewWithoutChangesForm, "renew_without_changes_form")
+    end
+
+    def create
+      super(RenewWithoutChangesForm, "renew_without_changes_form")
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/renew_without_changes_form.rb
+++ b/app/forms/waste_exemptions_engine/renew_without_changes_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RenewWithoutChangesForm < BaseForm
+    def submit(params)
+      super({}, params[:token])
+    end
+  end
+end

--- a/app/views/waste_exemptions_engine/renew_without_changes_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/renew_without_changes_forms/new.html.erb
@@ -1,0 +1,14 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_renew_without_changes_forms_path(@renew_without_changes_form.token)) %>
+
+<div class="text">
+  <%= form_for(@renew_without_changes_form) do |f| %>
+    <%= render("waste_exemptions_engine/shared/errors", object: @renew_without_changes_form) %>
+
+    <h1 class="heading-large"><%= t(".heading") %></h1>
+
+    <%= f.hidden_field :token, value: @renew_without_changes_form.token %>
+    <div class="form-group">
+      <%= f.submit t(".next_button"), class: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/forms/renew_without_changes_forms/en.yml
+++ b/config/locales/forms/renew_without_changes_forms/en.yml
@@ -1,0 +1,7 @@
+en:
+  waste_exemptions_engine:
+    renew_without_changes_forms:
+      new:
+        title: "Renewing without changes"
+        heading: "Renewing without changes"
+        next_button: "Continue"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -480,6 +480,16 @@ WasteExemptionsEngine::Engine.routes.draw do
                   on: :collection
             end
 
+  resources :renew_without_changes_forms,
+            only: %i[new create],
+            path: "renew-without-changes",
+            path_names: { new: "/:token" } do
+              get "back/:token",
+                  to: "renew_without_changes_forms#go_back",
+                  as: "back",
+                  on: :collection
+            end
+
   resources :renewal_complete_forms,
             only: %i[new create],
             path: "renewal-complete",

--- a/spec/cassettes/w3c_valid_content/renew_without_changes_forms_spec.yml
+++ b/spec/cassettes/w3c_valid_content/renew_without_changes_forms_spec.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://validator.w3.org/nu/?out=json&parser=html&showsource=yes
+    body:
+      encoding: UTF-8
+      string: "<!DOCTYPE html>\n<html>\n<head>\n  <title>Dummy</title>\n  <link rel=\"stylesheet\"
+        media=\"all\" href=\"/stylesheets/application.css\" data-turbolinks-track=\"true\"
+        />\n  <script src=\"/javascripts/application.js\" data-turbolinks-track=\"true\"></script>\n
+        \ \n</head>\n<body>\n\n<a class=\"link-back\" href=\"/waste_exemptions_engine/renew-without-changes/back/jwrL9y2uqFMJmAtfCnFndDVr\">Back</a>\n\n\n<div
+        class=\"text\">\n  <form class=\"new_renew_without_changes_form\" id=\"new_renew_without_changes_form\"
+        action=\"/waste_exemptions_engine/renew-without-changes\" accept-charset=\"UTF-8\"
+        method=\"post\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" />\n
+        \   \n\n    <h1 class=\"heading-large\">Renewing without changes</h1>\n\n
+        \   <input value=\"jwrL9y2uqFMJmAtfCnFndDVr\" type=\"hidden\" name=\"renew_without_changes_form[token]\"
+        id=\"renew_without_changes_form_token\" />\n    <div class=\"form-group\">\n
+        \     <input type=\"submit\" name=\"commit\" value=\"Continue\" class=\"button\"
+        />\n    </div>\n</form></div>\n\n\n</body>\n</html>\n"
+    headers:
+      Content-Type:
+      - text/html; charset=utf-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 02 Aug 2019 14:55:29 GMT
+      Accept-Encoding:
+      - gzip
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - content-type
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json;charset=utf-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.4.z-SNAPSHOT)
+      Strict-Transport-Security:
+      - max-age=15552015; preload
+      Public-Key-Pins:
+      - pin-sha256="cN0QSpPIkuwpT6iP2YjEo1bEwGpH/yiUn6yhdy+HNto="; pin-sha256="WGJkyYjx1QMdMe0UqlyOKXtydPDVrk7sl2fV+nNm1r4=";
+        pin-sha256="LrKdTxZLRTvyHM4/atX2nquX9BeHRZMCxg3cf4rhc2I="; max-age=864000
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9zdHlsZXNoZWV0cy9hcHBsaWNhdGlvbi5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvamF2YXNjcmlwdHMvYXBwbGljYXRpb24uanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxhIGNsYXNzPVwibGluay1iYWNrXCIgaHJlZj1cIi93YXN0ZV9leGVtcHRpb25zX2VuZ2luZS9yZW5ldy13aXRob3V0LWNoYW5nZXMvYmFjay9qd3JMOXkydXFGTUptQXRmQ25GbmREVnJcIj5CYWNrPC9hPlxuXG5cbjxkaXYgY2xhc3M9XCJ0ZXh0XCI+XG4gIDxmb3JtIGNsYXNzPVwibmV3X3JlbmV3X3dpdGhvdXRfY2hhbmdlc19mb3JtXCIgaWQ9XCJuZXdfcmVuZXdfd2l0aG91dF9jaGFuZ2VzX2Zvcm1cIiBhY3Rpb249XCIvd2FzdGVfZXhlbXB0aW9uc19lbmdpbmUvcmVuZXctd2l0aG91dC1jaGFuZ2VzXCIgYWNjZXB0LWNoYXJzZXQ9XCJVVEYtOFwiIG1ldGhvZD1cInBvc3RcIj48aW5wdXQgbmFtZT1cInV0ZjhcIiB0eXBlPVwiaGlkZGVuXCIgdmFsdWU9XCImI3gyNzEzO1wiIC8+XG4gICAgXG5cbiAgICA8aDEgY2xhc3M9XCJoZWFkaW5nLWxhcmdlXCI+UmVuZXdpbmcgd2l0aG91dCBjaGFuZ2VzPC9oMT5cblxuICAgIDxpbnB1dCB2YWx1ZT1cImp3ckw5eTJ1cUZNSm1BdGZDbkZuZERWclwiIHR5cGU9XCJoaWRkZW5cIiBuYW1lPVwicmVuZXdfd2l0aG91dF9jaGFuZ2VzX2Zvcm1bdG9rZW5dXCIgaWQ9XCJyZW5ld193aXRob3V0X2NoYW5nZXNfZm9ybV90b2tlblwiIC8+XG4gICAgPGRpdiBjbGFzcz1cImZvcm0tZ3JvdXBcIj5cbiAgICAgIDxpbnB1dCB0eXBlPVwic3VibWl0XCIgbmFtZT1cImNvbW1pdFwiIHZhbHVlPVwiQ29udGludWVcIiBjbGFzcz1cImJ1dHRvblwiIC8+XG4gICAgPC9kaXY+XG48L2Zvcm0+PC9kaXY+XG5cblxuPC9ib2R5PlxuPC9odG1sPiJ9fQo=
+    http_version: 
+  recorded_at: Fri, 02 Aug 2019 14:55:29 GMT
+recorded_with: VCR 5.0.0

--- a/spec/factories/forms/renewal_without_changes_form.rb
+++ b/spec/factories/forms/renewal_without_changes_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :renew_without_changes_form, class: WasteExemptionsEngine::RenewWithoutChangesForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "renew_without_changes_form"))
+    end
+  end
+end

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     initialize_with do
       new(reference: create(:registration, :complete).reference)
     end
+
+    factory :renewing_registration_without_changes do
+      temp_renew_without_changes { true }
+    end
   end
 end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/declaration_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/declaration_form_spec.rb
@@ -6,6 +6,12 @@ module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
+                      previous_state: :renew_without_changes_form,
+                      current_state: :declaration_form,
+                      next_state: :renewal_complete_form,
+                      factory: :renewing_registration_without_changes
+
+      it_behaves_like "a simple bidirectional transition",
                       previous_state: :check_your_answers_form,
                       current_state: :declaration_form,
                       next_state: :renewal_complete_form,

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renew_without_changes_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renew_without_changes_form_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RenewingRegistration, type: :model do
+    describe "#workflow_state" do
+      it_behaves_like "a simple bidirectional transition",
+                      previous_state: :renewal_start_form,
+                      current_state: :renew_without_changes_form,
+                      next_state: :declaration_form,
+                      factory: :renewing_registration
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renewal_start_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/renewal_start_form_spec.rb
@@ -7,13 +7,30 @@ module WasteExemptionsEngine
     describe "#workflow_state" do
       subject(:renewing_registration) { create(:renewing_registration, workflow_state: :renewal_start_form) }
 
-      it "can only transition to :renew_with_changes_form" do
-        permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
-        expect(permitted_states).to eq([:renew_with_changes_form])
+      context "when subject.should_renew_without_changes? is false" do
+        before(:each) { subject.temp_renew_without_changes = false }
+
+        it "can only transition to :renew_with_changes_form" do
+          permitted_states = Helpers::WorkflowStates.permitted_states(subject)
+          expect(permitted_states).to match_array([:renew_with_changes_form])
+        end
+
+        it "changes to :renew_with_changes_form after the 'next' event" do
+          expect(subject).to transition_from(:renewal_start_form).to(:renew_with_changes_form).on_event(:next)
+        end
       end
 
-      it "changes to :renew_with_changes_form after the 'next' event" do
-        expect(renewing_registration).to transition_from(:renewal_start_form).to(:renew_with_changes_form).on_event(:next)
+      context "when subject.should_renew_without_changes? is true" do
+        before(:each) { subject.temp_renew_without_changes = true }
+
+        it "can only transition to :renew_without_changes_form" do
+          permitted_states = Helpers::WorkflowStates.permitted_states(subject)
+          expect(permitted_states).to match_array([:renew_without_changes_form])
+        end
+
+        it "changes to :renew_without_changes_form after the 'next' event" do
+          expect(subject).to transition_from(:renewal_start_form).to(:renew_without_changes_form).on_event(:next)
+        end
       end
 
       it "is unable to transition when the 'back' event is issued" do

--- a/spec/requests/waste_exemptions_engine/renew_without_changes_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renew_without_changes_forms_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe "Renew Without Changes Forms", type: :request do
+    let(:form) { build(:renew_without_changes_form) }
+
+    describe "GET renew_without_changes_form" do
+      let(:request_path) { "/waste_exemptions_engine/renew-without-changes/#{form.token}" }
+
+      it "renders the appropriate template" do
+        get request_path
+        expect(response).to render_template("waste_exemptions_engine/renew_without_changes_forms/new")
+      end
+
+      it "responds to the GET request with a 200 status code" do
+        get request_path
+        expect(response.code).to eq("200")
+      end
+
+      it "returns W3C valid HTML content", vcr: true do
+        get request_path
+        expect(response.body).to have_valid_html
+      end
+    end
+
+    empty_form_is_valid = true
+    include_examples "go back", :renew_without_changes_form, "/renew-without-changes/back"
+    include_examples "POST form", :renew_without_changes_form, "/renew-without-changes", empty_form_is_valid do
+      let(:form_data) { {} }
+      let(:invalid_form_data) { [] }
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-498

Add transition events and state to make it possible for the user to go on a different flow to the declaration page when choosing not to make changes to a renewal