### PR TITLE
Record referring registration when renewing

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_copy_data_from_registration.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_copy_data_from_registration.rb
@@ -20,7 +20,8 @@ module WasteExemptionsEngine
                                                   "assistance_mode",
                                                   "created_at",
                                                   "updated_at",
-                                                  "submitted_at")
+                                                  "submitted_at",
+                                                  "referring_registration_id")
 
       assign_attributes(attributes)
 

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -18,6 +18,8 @@ module WasteExemptionsEngine
       through: :registration_exemptions,
       source: :exemption
     )
+    belongs_to :referring_registration, class_name: "Registration"
+    has_one :referred_registration, class_name: "Registration", foreign_key: "referring_registration_id"
 
     after_create :apply_reference
 

--- a/app/models/waste_exemptions_engine/renewing_registration.rb
+++ b/app/models/waste_exemptions_engine/renewing_registration.rb
@@ -4,5 +4,20 @@ module WasteExemptionsEngine
   class RenewingRegistration < TransientRegistration
     include CanUseRenewingRegistrationWorkflow
     include CanCopyDataFromRegistration
+
+    def referring_registration
+      @_referring_registration ||= Registration.find_by(renew_token: token)
+    end
+
+    def referring_registration_id
+      referring_registration.id
+    end
+
+    def registration_attributes
+      registration_attributes = super
+      registration_attributes["referring_registration_id"] = referring_registration_id
+
+      registration_attributes
+    end
   end
 end

--- a/db/migrate/20190805152649_add_referring_registration_id_to_registrations.rb
+++ b/db/migrate/20190805152649_add_referring_registration_id_to_registrations.rb
@@ -1,0 +1,5 @@
+class AddReferringRegistrationIdToRegistrations < ActiveRecord::Migration
+  def change
+    add_column :registrations, :referring_registration_id, :integer, index: true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190801171410) do
+ActiveRecord::Schema.define(version: 20190805152649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,11 +96,12 @@ ActiveRecord::Schema.define(version: 20190801171410) do
     t.string   "contact_email"
     t.boolean  "on_a_farm"
     t.boolean  "is_a_farmer"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
     t.date     "submitted_at"
     t.string   "assistance_mode"
     t.string   "renew_token"
+    t.integer  "referring_registration_id"
   end
 
   add_index "registrations", ["reference"], name: "index_registrations_on_reference", unique: true, using: :btree

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -4,7 +4,9 @@ FactoryBot.define do
   factory :renewing_registration, class: WasteExemptionsEngine::RenewingRegistration do
     # Create a new registration when initializing so we can copy its data
     initialize_with do
-      new(reference: create(:registration, :complete).reference)
+      registration = create(:registration, :complete)
+
+      new(reference: registration.reference, token: registration.renew_token)
     end
 
     factory :renewing_registration_without_changes do

--- a/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
@@ -8,6 +8,13 @@ module WasteExemptionsEngine
 
     it_behaves_like "a transient_registration", :renewing_registration
 
+    describe "#registration_attributes" do
+      it "includes a regerral registration id" do
+        attributes = renewing_registration.registration_attributes
+        expect(attributes.keys).to include("referring_registration_id")
+      end
+    end
+
     it "subclasses TransientRegistration" do
       expect(described_class).to be < TransientRegistration
     end

--- a/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
@@ -9,7 +9,7 @@ module WasteExemptionsEngine
     it_behaves_like "a transient_registration", :renewing_registration
 
     describe "#registration_attributes" do
-      it "includes a regerral registration id" do
+      it "includes a referring registration id" do
         attributes = renewing_registration.registration_attributes
         expect(attributes.keys).to include("referring_registration_id")
       end

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -128,6 +128,19 @@ module WasteExemptionsEngine
             expect(ActionMailer::Base.deliveries.count).to eq(old_emails_sent_count + 1)
           end
         end
+
+        context "whne the transient registration is a renewal" do
+          let(:renewing_registration) { create(:renewing_registration) }
+
+          it "copy over data about referring registration" do
+            referring_registration = renewing_registration.referring_registration
+
+            new_registration = described_class.run(transient_registration: renewing_registration)
+
+            expect(new_registration.referring_registration).to eq(referring_registration)
+            expect(referring_registration.referred_registration).to eq(new_registration)
+          end
+        end
       end
 
       def run_service

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -129,10 +129,10 @@ module WasteExemptionsEngine
           end
         end
 
-        context "whne the transient registration is a renewal" do
+        context "when the transient registration is a renewal" do
           let(:renewing_registration) { create(:renewing_registration) }
 
-          it "copy over data about referring registration" do
+          it "copies over data about the referring registration" do
             referring_registration = renewing_registration.referring_registration
 
             new_registration = described_class.run(transient_registration: renewing_registration)

--- a/spec/support/helpers/model_properties.rb
+++ b/spec/support/helpers/model_properties.rb
@@ -68,7 +68,6 @@ module Helpers
       on_a_farm
       is_a_farmer
       submitted_at
-      referring_registration_id
     ].freeze
 
     TRANSIENT_REGISTRATION = (REGISTRATION - [:submitted_at] + %i[

--- a/spec/support/helpers/model_properties.rb
+++ b/spec/support/helpers/model_properties.rb
@@ -68,6 +68,7 @@ module Helpers
       on_a_farm
       is_a_farmer
       submitted_at
+      referring_registration_id
     ].freeze
 
     TRANSIENT_REGISTRATION = (REGISTRATION - [:submitted_at] + %i[

--- a/spec/support/shared_examples/models/transient_registration.rb
+++ b/spec/support/shared_examples/models/transient_registration.rb
@@ -23,7 +23,7 @@ RSpec.shared_examples "a transient_registration" do |model_factory|
     it "returns valid registration attributes from the transient registration" do
       attributes = transient_registration.registration_attributes
       registration_attributes = Helpers::ModelProperties::REGISTRATION.map(&:to_s) - %w[submitted_at reference]
-      expect(attributes.keys).to match_array(registration_attributes)
+      expect(attributes.keys).to include(*registration_attributes)
     end
   end
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-497

When creating a new registration from a renewal, we want to register what registration was renewed.