### PR TITLE
Redirect to correct site address form on Renewing

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
@@ -184,7 +184,12 @@ module WasteExemptionsEngine
 
           # Site questions
           transitions from: :is_a_farmer_form,
-                      to: :site_grid_reference_form
+                      to: :site_grid_reference_form,
+                      if: :located_by_grid_reference?
+
+          transitions from: :is_a_farmer_form,
+                      to: :site_postcode_form,
+                      unless: :located_by_grid_reference?
 
           transitions from: :site_grid_reference_form,
                       to: :site_postcode_form,
@@ -433,6 +438,10 @@ module WasteExemptionsEngine
       return false if company_no_required?
 
       true
+    end
+
+    def located_by_grid_reference?
+      site_address.located_by_grid_reference?
     end
 
     def skip_to_manual_address?

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -12,5 +12,13 @@ FactoryBot.define do
     factory :renewing_registration_without_changes do
       temp_renew_without_changes { true }
     end
+
+    factory :renewing_registration_with_manual_site_address do
+      initialize_with do
+        registration = create(:registration, :complete, :with_manual_site_address)
+
+        new(reference: registration.reference, token: registration.renew_token)
+      end
+    end
   end
 end

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/is_a_farmer_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/is_a_farmer_form_spec.rb
@@ -10,6 +10,12 @@ module WasteExemptionsEngine
                       current_state: :is_a_farmer_form,
                       next_state: :site_grid_reference_form,
                       factory: :renewing_registration
+
+      it_behaves_like "a simple bidirectional transition",
+                      previous_state: :on_a_farm_form,
+                      current_state: :is_a_farmer_form,
+                      next_state: :site_postcode_form,
+                      factory: :renewing_registration_with_manual_site_address
     end
   end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-502

Twick the renewals state machine and make sure to redirect the user to the correct site form (grid reference VS postal address) when renewing.