### PR TITLE
Fix bug on renewal creation

### DIFF
--- a/app/models/waste_exemptions_engine/renewing_registration.rb
+++ b/app/models/waste_exemptions_engine/renewing_registration.rb
@@ -6,7 +6,7 @@ module WasteExemptionsEngine
     include CanCopyDataFromRegistration
 
     def referring_registration
-      @_referring_registration ||= Registration.find_by(renew_token: token)
+      @_referring_registration ||= Registration.find_by(reference: reference)
     end
 
     def referring_registration_id

--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -28,7 +28,7 @@ module WasteExemptionsEngine
 
       @registration
     rescue StandardError => e
-      Airbrake.notify(e, reference: @registration.reference) if defined?(Airbrake)
+      Airbrake.notify(e, reference: @registration&.reference) if defined?(Airbrake)
       Rails.logger.error "Completing registration error: #{e}"
 
       raise e


### PR DESCRIPTION
Two fixes were necessary:
The first is about adding a `&` on the Airbrake error reporting code for when an error is thrown before the `@registration` object is initialized.
The second fix is the actual problem. I was using the `token` from the Transient Registration to populate a referring registration, but that is incorrect as the 2 tokens are not going to match. What is going to match is instead the `reference`, and hence I have changed the code to use that in order to fetch the correct referring registration.