### PR TITLE
Fix bug on site address workflow for renewal

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
@@ -332,7 +332,12 @@ module WasteExemptionsEngine
                       to: :is_a_farmer_form
 
           transitions from: :site_postcode_form,
-                      to: :site_grid_reference_form
+                      to: :site_grid_reference_form,
+                      if: :located_by_grid_reference?
+
+          transitions from: :site_postcode_form,
+                      to: :is_a_farmer_form,
+                      unless: :located_by_grid_reference?
 
           transitions from: :site_address_lookup_form,
                       to: :site_postcode_form
@@ -350,7 +355,12 @@ module WasteExemptionsEngine
                       if: :site_address_was_entered?
 
           transitions from: :check_your_answers_form,
-                      to: :site_grid_reference_form
+                      to: :site_grid_reference_form,
+                      if: :located_by_grid_reference?
+
+          transitions from: :check_your_answers_form,
+                      to: :site_postcode_form,
+                      unless: :located_by_grid_reference?
 
           transitions from: :declaration_form,
                       to: :check_your_answers_form,

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/check_your_answers_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/check_your_answers_form_spec.rb
@@ -11,6 +11,12 @@ module WasteExemptionsEngine
                       next_state: :declaration_form,
                       factory: :renewing_registration
 
+      it_behaves_like "a simple bidirectional transition",
+                      previous_state: :site_address_manual_form,
+                      current_state: :check_your_answers_form,
+                      next_state: :declaration_form,
+                      factory: :renewing_registration_with_manual_site_address
+
       next_state = :declaration_form
       current_state = :check_your_answers_form
       let(:site_address) { build(:transient_address, :site_address) }

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_postcode_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_postcode_form_spec.rb
@@ -9,6 +9,11 @@ module WasteExemptionsEngine
                       previous_state: :site_grid_reference_form,
                       address_type: "site",
                       factory: :renewing_registration
+
+      it_behaves_like "a postcode transition",
+                      previous_state: :is_a_farmer_form,
+                      address_type: "site",
+                      factory: :renewing_registration_with_manual_site_address
     end
   end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-502

This adds back events checks on the site address workflow to redirect to the correct site address screen