### PR TITLE
Add default ordering to registration exemptions

### DIFF
--- a/app/models/waste_exemptions_engine/registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/registration_exemption.rb
@@ -8,5 +8,7 @@ module WasteExemptionsEngine
     belongs_to :exemption
 
     scope :active, -> { where(state: :active) }
+
+    default_scope { order(exemption_id: :asc) }
   end
 end

--- a/app/models/waste_exemptions_engine/transient_registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/transient_registration_exemption.rb
@@ -9,6 +9,8 @@ module WasteExemptionsEngine
     belongs_to :transient_registration
     belongs_to :exemption
 
+    default_scope { order(exemption_id: :asc) }
+
     def exemption_attributes
       attributes.except("id", "transient_registration_id", "created_at", "updated_at")
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-520

This change sorts the exemptions by the `exemption_id` value, so they should be listed in the order they appear on the form.