### PR TITLE
Remove unnecessary data after business type change

### DIFF
--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -12,7 +12,7 @@ module WasteExemptionsEngine
 
         activate_exemptions
 
-        @registration = Registration.new(@transient_registration.registration_attributes)
+        @registration = Registration.new(copyable_attributes)
         copy_addresses
         copy_exemptions
         copy_people
@@ -38,6 +38,14 @@ module WasteExemptionsEngine
 
     def activate_exemptions
       @transient_registration.transient_registration_exemptions.each(&:activate)
+    end
+
+    def copyable_attributes
+      if @transient_registration.company_no_required?
+        @transient_registration.registration_attributes
+      else
+        @transient_registration.registration_attributes.except("company_no")
+      end
     end
 
     def copy_addresses
@@ -66,7 +74,7 @@ module WasteExemptionsEngine
     end
 
     def include_people?
-      %w[partnership].include?(@transient_registration.business_type)
+      [TransientRegistration::BUSINESS_TYPES[:partnership]].include?(@transient_registration.business_type)
     end
 
     def send_confirmation_email

--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -61,7 +61,7 @@ module WasteExemptionsEngine
     end
 
     def copy_people
-      return unless include_people?
+      return unless @transient_registration.partnership?
 
       @transient_registration.transient_people.each do |trans_person|
         @registration.people << Person.new(trans_person.person_attributes)
@@ -71,10 +71,6 @@ module WasteExemptionsEngine
     def add_metadata
       @registration.assistance_mode = WasteExemptionsEngine.configuration.default_assistance_mode
       @registration.submitted_at = Date.today
-    end
-
-    def include_people?
-      [TransientRegistration::BUSINESS_TYPES[:partnership]].include?(@transient_registration.business_type)
     end
 
     def send_confirmation_email

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
       contact_email { applicant_email }
     end
 
+    trait :has_people do
+      people { build_list(:transient_person, 2) }
+    end
+
     trait :complete do
       limited_company
 

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -34,6 +34,10 @@ FactoryBot.define do
       people { build_list(:transient_person, 2) }
     end
 
+    trait :has_company_no do
+      company_no { "09360070" }
+    end
+
     trait :complete do
       limited_company
 

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -141,6 +141,30 @@ module WasteExemptionsEngine
             expect(referring_registration.referred_registration).to eq(new_registration)
           end
         end
+
+        context "when the transient_registration has people" do
+          context "when the organisation is a partnership" do
+            let(:new_registration) { create(:new_registration, :complete, :has_people, :partnership) }
+
+            it "copies the people" do
+              people_count = new_registration.people.count
+
+              registration = described_class.run(transient_registration: new_registration)
+
+              expect(registration.people.count).to eq(people_count)
+            end
+          end
+
+          context "when the organisation is not a partnership" do
+            let(:new_registration) { create(:new_registration, :complete, :has_people, :sole_trader) }
+
+            it "does not copy the people" do
+              registration = described_class.run(transient_registration: new_registration)
+
+              expect(registration.people.count).to eq(0)
+            end
+          end
+        end
       end
 
       def run_service

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -165,6 +165,30 @@ module WasteExemptionsEngine
             end
           end
         end
+
+        context "when the transient_registration has a company_no" do
+          context "when the organisation type uses a company_no" do
+            let(:new_registration) { create(:new_registration, :complete, :has_company_no, :limited_company) }
+
+            it "copies the company_no" do
+              company_no = new_registration.company_no
+
+              registration = described_class.run(transient_registration: new_registration)
+
+              expect(registration.company_no).to eq(company_no)
+            end
+          end
+
+          context "when the organisation type does not use a company_no" do
+            let(:new_registration) { create(:new_registration, :complete, :has_company_no, :sole_trader) }
+
+            it "does not copy the company_no" do
+              registration = described_class.run(transient_registration: new_registration)
+
+              expect(registration.company_no).to eq(nil)
+            end
+          end
+        end
       end
 
       def run_service


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-503

Some data is only required for registrations with certain business types - partnerships need partners, while limited companies and LLPs need Companies House numbers.

However, if the business type changes from one which requires this data to one which doesn't, we should remove the extra data.

This could be because the user changes the business type during renewal, but it could also happen during a new registration if they go through most of the process and then go back to change their business type.