### PR TITLE
Add test coverage on edit and renewal transient registrations

### DIFF
--- a/spec/factories/edit_registration.rb
+++ b/spec/factories/edit_registration.rb
@@ -7,6 +7,12 @@ FactoryBot.define do
       new(reference: create(:registration, :complete).reference)
     end
 
+    trait :with_manual_site_address do
+      initialize_with do
+        new(reference: create(:registration, :complete, :with_manual_site_address).reference)
+      end
+    end
+
     trait :modified do
       after(:build) do |edit_registration|
         registration = edit_registration.registration

--- a/spec/factories/forms/applicant_email_form.rb
+++ b/spec/factories/forms/applicant_email_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "applicant_email_form"))
     end
   end
+
+  factory :edit_applicant_email_form, class: WasteExemptionsEngine::ApplicantEmailForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "applicant_email_form"))
+    end
+  end
+
+  factory :renew_applicant_email_form, class: WasteExemptionsEngine::ApplicantEmailForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "applicant_email_form"))
+    end
+  end
 end

--- a/spec/factories/forms/applicant_name_form.rb
+++ b/spec/factories/forms/applicant_name_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "applicant_name_form"))
     end
   end
+
+  factory :edit_applicant_name_form, class: WasteExemptionsEngine::ApplicantNameForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "applicant_name_form"))
+    end
+  end
+
+  factory :renew_applicant_name_form, class: WasteExemptionsEngine::ApplicantNameForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "applicant_name_form"))
+    end
+  end
 end

--- a/spec/factories/forms/applicant_phone_form.rb
+++ b/spec/factories/forms/applicant_phone_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "applicant_phone_form"))
     end
   end
+
+  factory :edit_applicant_phone_form, class: WasteExemptionsEngine::ApplicantPhoneForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "applicant_phone_form"))
+    end
+  end
+
+  factory :renew_applicant_phone_form, class: WasteExemptionsEngine::ApplicantPhoneForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "applicant_phone_form"))
+    end
+  end
 end

--- a/spec/factories/forms/business_type_form.rb
+++ b/spec/factories/forms/business_type_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "business_type_form"))
     end
   end
+
+  factory :edit_business_type_form, class: WasteExemptionsEngine::BusinessTypeForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "business_type_form"))
+    end
+  end
+
+  factory :renew_business_type_form, class: WasteExemptionsEngine::BusinessTypeForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "business_type_form"))
+    end
+  end
 end

--- a/spec/factories/forms/contact_email_form.rb
+++ b/spec/factories/forms/contact_email_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "contact_email_form"))
     end
   end
+
+  factory :edit_contact_email_form, class: WasteExemptionsEngine::ContactEmailForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "contact_email_form"))
+    end
+  end
+
+  factory :renew_contact_email_form, class: WasteExemptionsEngine::ContactEmailForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "contact_email_form"))
+    end
+  end
 end

--- a/spec/factories/forms/contact_name_form.rb
+++ b/spec/factories/forms/contact_name_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "contact_name_form"))
     end
   end
+
+  factory :edit_contact_name_form, class: WasteExemptionsEngine::ContactNameForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "contact_name_form"))
+    end
+  end
+
+  factory :renew_contact_name_form, class: WasteExemptionsEngine::ContactNameForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "contact_name_form"))
+    end
+  end
 end

--- a/spec/factories/forms/contact_phone_form.rb
+++ b/spec/factories/forms/contact_phone_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "contact_phone_form"))
     end
   end
+
+  factory :edit_contact_phone_form, class: WasteExemptionsEngine::ContactPhoneForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "contact_phone_form"))
+    end
+  end
+
+  factory :renew_contact_phone_form, class: WasteExemptionsEngine::ContactPhoneForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "contact_phone_form"))
+    end
+  end
 end

--- a/spec/factories/forms/contact_position_form.rb
+++ b/spec/factories/forms/contact_position_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "contact_position_form"))
     end
   end
+
+  factory :edit_contact_position_form, class: WasteExemptionsEngine::ContactPositionForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "contact_position_form"))
+    end
+  end
+
+  factory :renew_contact_position_form, class: WasteExemptionsEngine::ContactPositionForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "contact_position_form"))
+    end
+  end
 end

--- a/spec/factories/forms/contact_postcodes_form.rb
+++ b/spec/factories/forms/contact_postcodes_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "contact_postcode_form"))
     end
   end
+
+  factory :edit_contact_postcode_form, class: WasteExemptionsEngine::ContactPostcodeForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "contact_postcode_form"))
+    end
+  end
+
+  factory :renew_contact_postcode_form, class: WasteExemptionsEngine::ContactPostcodeForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "contact_postcode_form"))
+    end
+  end
 end

--- a/spec/factories/forms/operator_name_form.rb
+++ b/spec/factories/forms/operator_name_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, :sole_trader, workflow_state: "operator_name_form"))
     end
   end
+
+  factory :edit_operator_name_form, class: WasteExemptionsEngine::OperatorNameForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "operator_name_form"))
+    end
+  end
+
+  factory :renew_operator_name_form, class: WasteExemptionsEngine::OperatorNameForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "operator_name_form"))
+    end
+  end
 end

--- a/spec/factories/forms/operator_postcodes_form.rb
+++ b/spec/factories/forms/operator_postcodes_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "operator_postcode_form"))
     end
   end
+
+  factory :edit_operator_postcode_form, class: WasteExemptionsEngine::OperatorPostcodeForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "operator_postcode_form"))
+    end
+  end
+
+  factory :renew_operator_postcode_form, class: WasteExemptionsEngine::OperatorPostcodeForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "operator_postcode_form"))
+    end
+  end
 end

--- a/spec/factories/forms/site_grid_reference_form.rb
+++ b/spec/factories/forms/site_grid_reference_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "site_grid_reference_form"))
     end
   end
+
+  factory :edit_site_grid_reference_form, class: WasteExemptionsEngine::SiteGridReferenceForm do
+    initialize_with do
+      new(create(:edit_registration, workflow_state: "site_grid_reference_form"))
+    end
+  end
+
+  factory :renew_site_grid_reference_form, class: WasteExemptionsEngine::SiteGridReferenceForm do
+    initialize_with do
+      new(create(:renewing_registration, workflow_state: "site_grid_reference_form"))
+    end
+  end
 end

--- a/spec/factories/forms/site_postcodes_form.rb
+++ b/spec/factories/forms/site_postcodes_form.rb
@@ -6,4 +6,16 @@ FactoryBot.define do
       new(create(:new_registration, workflow_state: "site_postcode_form"))
     end
   end
+
+  factory :edit_site_postcode_form, class: WasteExemptionsEngine::SitePostcodeForm do
+    initialize_with do
+      new(create(:edit_registration, :with_manual_site_address, workflow_state: "site_postcode_form"))
+    end
+  end
+
+  factory :renew_site_postcode_form, class: WasteExemptionsEngine::SitePostcodeForm do
+    initialize_with do
+      new(create(:renewing_registration, :with_manual_site_address, workflow_state: "site_postcode_form"))
+    end
+  end
 end

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -9,6 +9,12 @@ FactoryBot.define do
       new(reference: registration.reference, token: registration.renew_token)
     end
 
+    trait :with_manual_site_address do
+      initialize_with do
+        new(reference: create(:registration, :complete, :with_manual_site_address).reference)
+      end
+    end
+
     factory :renewing_registration_without_changes do
       temp_renew_without_changes { true }
     end

--- a/spec/requests/waste_exemptions_engine/applicant_email_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/applicant_email_forms_spec.rb
@@ -16,5 +16,25 @@ module WasteExemptionsEngine
         ]
       end
     end
+
+    context "when editing an existing registration" do
+      let(:edit_applicant_email_form) { build(:edit_applicant_email_form) }
+
+      it "prefils applicant email information" do
+        get "/waste_exemptions_engine/applicant-email/#{edit_applicant_email_form.token}"
+
+        expect(response.body).to include(edit_applicant_email_form.applicant_email)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_applicant_email_form) { build(:renew_applicant_email_form) }
+
+      it "prefils applicant email information" do
+        get "/waste_exemptions_engine/applicant-email/#{renew_applicant_email_form.token}"
+
+        expect(response.body).to include(renew_applicant_email_form.applicant_email)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/applicant_email_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/applicant_email_forms_spec.rb
@@ -20,7 +20,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_applicant_email_form) { build(:edit_applicant_email_form) }
 
-      it "prefils applicant email information" do
+      it "pre-fills applicant email information" do
         get "/waste_exemptions_engine/applicant-email/#{edit_applicant_email_form.token}"
 
         expect(response.body).to include(edit_applicant_email_form.applicant_email)
@@ -30,7 +30,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_applicant_email_form) { build(:renew_applicant_email_form) }
 
-      it "prefils applicant email information" do
+      it "pre-fills applicant email information" do
         get "/waste_exemptions_engine/applicant-email/#{renew_applicant_email_form.token}"
 
         expect(response.body).to include(renew_applicant_email_form.applicant_email)

--- a/spec/requests/waste_exemptions_engine/applicant_name_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/applicant_name_forms_spec.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_applicant_name_form) { build(:edit_applicant_name_form) }
 
-      it "prefils applicant name information" do
+      it "pre-fills applicant name information" do
         get "/waste_exemptions_engine/applicant-name/#{edit_applicant_name_form.token}"
 
         expect(response.body).to include(edit_applicant_name_form.first_name)
@@ -25,7 +25,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_applicant_name_form) { build(:renew_applicant_name_form) }
 
-      it "prefils applicant name information" do
+      it "pre-fills applicant name information" do
         get "/waste_exemptions_engine/applicant-name/#{renew_applicant_name_form.token}"
 
         expect(response.body).to include(renew_applicant_name_form.first_name)

--- a/spec/requests/waste_exemptions_engine/applicant_name_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/applicant_name_forms_spec.rb
@@ -10,5 +10,27 @@ module WasteExemptionsEngine
       let(:form_data) { { first_name: "Joe", last_name: "Bloggs" } }
       let(:invalid_form_data) { [{ first_name: nil, last_name: nil }] }
     end
+
+    context "when editing an existing registration" do
+      let(:edit_applicant_name_form) { build(:edit_applicant_name_form) }
+
+      it "prefils applicant name information" do
+        get "/waste_exemptions_engine/applicant-name/#{edit_applicant_name_form.token}"
+
+        expect(response.body).to include(edit_applicant_name_form.first_name)
+        expect(response.body).to include(edit_applicant_name_form.last_name)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_applicant_name_form) { build(:renew_applicant_name_form) }
+
+      it "prefils applicant name information" do
+        get "/waste_exemptions_engine/applicant-name/#{renew_applicant_name_form.token}"
+
+        expect(response.body).to include(renew_applicant_name_form.first_name)
+        expect(response.body).to include(renew_applicant_name_form.last_name)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/applicant_phone_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/applicant_phone_forms_spec.rb
@@ -10,5 +10,25 @@ module WasteExemptionsEngine
       let(:form_data) { { phone_number: "01234567890" } }
       let(:invalid_form_data) { [{ phone_number: nil }, { phone_number: "1234" }] }
     end
+
+    context "when editing an existing registration" do
+      let(:edit_applicant_phone_form) { build(:edit_applicant_phone_form) }
+
+      it "prefils applicant phone information" do
+        get "/waste_exemptions_engine/applicant-phone/#{edit_applicant_phone_form.token}"
+
+        expect(response.body).to include(edit_applicant_phone_form.phone_number)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_applicant_phone_form) { build(:renew_applicant_phone_form) }
+
+      it "prefils applicant phone information" do
+        get "/waste_exemptions_engine/applicant-phone/#{renew_applicant_phone_form.token}"
+
+        expect(response.body).to include(renew_applicant_phone_form.phone_number)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/applicant_phone_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/applicant_phone_forms_spec.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_applicant_phone_form) { build(:edit_applicant_phone_form) }
 
-      it "prefils applicant phone information" do
+      it "pre-fills applicant phone information" do
         get "/waste_exemptions_engine/applicant-phone/#{edit_applicant_phone_form.token}"
 
         expect(response.body).to include(edit_applicant_phone_form.phone_number)
@@ -24,7 +24,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_applicant_phone_form) { build(:renew_applicant_phone_form) }
 
-      it "prefils applicant phone information" do
+      it "pre-fills applicant phone information" do
         get "/waste_exemptions_engine/applicant-phone/#{renew_applicant_phone_form.token}"
 
         expect(response.body).to include(renew_applicant_phone_form.phone_number)

--- a/spec/requests/waste_exemptions_engine/contact_email_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_email_forms_spec.rb
@@ -16,5 +16,25 @@ module WasteExemptionsEngine
         ]
       end
     end
+
+    context "when editing an existing registration" do
+      let(:edit_contact_email_form) { build(:edit_contact_email_form) }
+
+      it "prefils contact email information" do
+        get "/waste_exemptions_engine/contact-email/#{edit_contact_email_form.token}"
+
+        expect(response.body).to include(edit_contact_email_form.contact_email)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_contact_email_form) { build(:renew_contact_email_form) }
+
+      it "prefils contact email information" do
+        get "/waste_exemptions_engine/contact-email/#{renew_contact_email_form.token}"
+
+        expect(response.body).to include(renew_contact_email_form.contact_email)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/contact_email_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_email_forms_spec.rb
@@ -20,7 +20,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_contact_email_form) { build(:edit_contact_email_form) }
 
-      it "prefils contact email information" do
+      it "pre-fills contact email information" do
         get "/waste_exemptions_engine/contact-email/#{edit_contact_email_form.token}"
 
         expect(response.body).to include(edit_contact_email_form.contact_email)
@@ -30,7 +30,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_contact_email_form) { build(:renew_contact_email_form) }
 
-      it "prefils contact email information" do
+      it "pre-fills contact email information" do
         get "/waste_exemptions_engine/contact-email/#{renew_contact_email_form.token}"
 
         expect(response.body).to include(renew_contact_email_form.contact_email)

--- a/spec/requests/waste_exemptions_engine/contact_name_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_name_forms_spec.rb
@@ -10,5 +10,27 @@ module WasteExemptionsEngine
       let(:form_data) { { first_name: "Joe", last_name: "Bloggs" } }
       let(:invalid_form_data) { [{ first_name: nil, last_name: nil }] }
     end
+
+    context "when editing an existing registration" do
+      let(:edit_contact_name_form) { build(:edit_contact_name_form) }
+
+      it "prefils contact name information" do
+        get "/waste_exemptions_engine/contact-name/#{edit_contact_name_form.token}"
+
+        expect(response.body).to include(edit_contact_name_form.first_name)
+        expect(response.body).to include(edit_contact_name_form.last_name)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_contact_name_form) { build(:renew_contact_name_form) }
+
+      it "prefils contact name information" do
+        get "/waste_exemptions_engine/contact-name/#{renew_contact_name_form.token}"
+
+        expect(response.body).to include(renew_contact_name_form.first_name)
+        expect(response.body).to include(renew_contact_name_form.last_name)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/contact_name_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_name_forms_spec.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_contact_name_form) { build(:edit_contact_name_form) }
 
-      it "prefils contact name information" do
+      it "pre-fills contact name information" do
         get "/waste_exemptions_engine/contact-name/#{edit_contact_name_form.token}"
 
         expect(response.body).to include(edit_contact_name_form.first_name)
@@ -25,7 +25,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_contact_name_form) { build(:renew_contact_name_form) }
 
-      it "prefils contact name information" do
+      it "pre-fills contact name information" do
         get "/waste_exemptions_engine/contact-name/#{renew_contact_name_form.token}"
 
         expect(response.body).to include(renew_contact_name_form.first_name)

--- a/spec/requests/waste_exemptions_engine/contact_phone_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_phone_forms_spec.rb
@@ -10,5 +10,25 @@ module WasteExemptionsEngine
       let(:form_data) { { phone_number: "01234567890" } }
       let(:invalid_form_data) { [{ phone_number: "123" }, { phone_number: nil }] }
     end
+
+    context "when editing an existing registration" do
+      let(:edit_contact_phone_form) { build(:edit_contact_phone_form) }
+
+      it "prefils contact phone information" do
+        get "/waste_exemptions_engine/contact-phone/#{edit_contact_phone_form.token}"
+
+        expect(response.body).to include(edit_contact_phone_form.phone_number)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_contact_phone_form) { build(:renew_contact_phone_form) }
+
+      it "prefils contact phone information" do
+        get "/waste_exemptions_engine/contact-phone/#{renew_contact_phone_form.token}"
+
+        expect(response.body).to include(renew_contact_phone_form.phone_number)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/contact_phone_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_phone_forms_spec.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_contact_phone_form) { build(:edit_contact_phone_form) }
 
-      it "prefils contact phone information" do
+      it "pre-fills contact phone information" do
         get "/waste_exemptions_engine/contact-phone/#{edit_contact_phone_form.token}"
 
         expect(response.body).to include(edit_contact_phone_form.phone_number)
@@ -24,7 +24,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_contact_phone_form) { build(:renew_contact_phone_form) }
 
-      it "prefils contact phone information" do
+      it "pre-fills contact phone information" do
         get "/waste_exemptions_engine/contact-phone/#{renew_contact_phone_form.token}"
 
         expect(response.body).to include(renew_contact_phone_form.phone_number)

--- a/spec/requests/waste_exemptions_engine/contact_position_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_position_forms_spec.rb
@@ -12,5 +12,25 @@ module WasteExemptionsEngine
       let(:form_data) { { position: "Chief Waste Carrier" } }
       let(:invalid_form_data) { [] }
     end
+
+    context "when editing an existing registration" do
+      let(:edit_contact_position_form) { build(:edit_contact_position_form) }
+
+      it "prefils contact position information" do
+        get "/waste_exemptions_engine/contact-position/#{edit_contact_position_form.token}"
+
+        expect(response.body).to include(edit_contact_position_form.position)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_contact_position_form) { build(:renew_contact_position_form) }
+
+      it "prefils contact position information" do
+        get "/waste_exemptions_engine/contact-position/#{renew_contact_position_form.token}"
+
+        expect(response.body).to include(renew_contact_position_form.position)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/contact_position_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_position_forms_spec.rb
@@ -16,7 +16,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_contact_position_form) { build(:edit_contact_position_form) }
 
-      it "prefils contact position information" do
+      it "pre-fills contact position information" do
         get "/waste_exemptions_engine/contact-position/#{edit_contact_position_form.token}"
 
         expect(response.body).to include(edit_contact_position_form.position)
@@ -26,7 +26,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_contact_position_form) { build(:renew_contact_position_form) }
 
-      it "prefils contact position information" do
+      it "pre-fills contact position information" do
         get "/waste_exemptions_engine/contact-position/#{renew_contact_position_form.token}"
 
         expect(response.body).to include(renew_contact_position_form.position)

--- a/spec/requests/waste_exemptions_engine/contact_postcode_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_postcode_forms_spec.rb
@@ -19,7 +19,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_contact_postcode_form) { build(:edit_contact_postcode_form) }
 
-      it "prefils contact postcode information" do
+      it "pre-fills contact postcode information" do
         get "/waste_exemptions_engine/contact-postcode/#{edit_contact_postcode_form.token}"
 
         expect(response.body).to include(edit_contact_postcode_form.postcode)
@@ -29,7 +29,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_contact_postcode_form) { build(:renew_contact_postcode_form) }
 
-      it "prefils contact postcode information" do
+      it "pre-fills contact postcode information" do
         get "/waste_exemptions_engine/contact-postcode/#{renew_contact_postcode_form.token}"
 
         expect(response.body).to include(renew_contact_postcode_form.postcode)

--- a/spec/requests/waste_exemptions_engine/contact_postcode_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_postcode_forms_spec.rb
@@ -15,5 +15,25 @@ module WasteExemptionsEngine
                      :contact_postcode_form,
                      request_path: "/contact-postcode/skip_to_manual_address",
                      result_path: "/contact-address-manual"
+
+    context "when editing an existing registration" do
+      let(:edit_contact_postcode_form) { build(:edit_contact_postcode_form) }
+
+      it "prefils contact postcode information" do
+        get "/waste_exemptions_engine/contact-postcode/#{edit_contact_postcode_form.token}"
+
+        expect(response.body).to include(edit_contact_postcode_form.postcode)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_contact_postcode_form) { build(:renew_contact_postcode_form) }
+
+      it "prefils contact postcode information" do
+        get "/waste_exemptions_engine/contact-postcode/#{renew_contact_postcode_form.token}"
+
+        expect(response.body).to include(renew_contact_postcode_form.postcode)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/operator_name_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/operator_name_forms_spec.rb
@@ -10,5 +10,25 @@ module WasteExemptionsEngine
       let(:form_data) { { operator_name: "Acme Waste Carriers" } }
       let(:invalid_form_data) { [{ operator_name: nil }] }
     end
+
+    context "when editing an existing registration" do
+      let(:edit_operator_name_form) { build(:edit_operator_name_form) }
+
+      it "prefils operator name information" do
+        get "/waste_exemptions_engine/operator-name/#{edit_operator_name_form.token}"
+
+        expect(response.body).to include(edit_operator_name_form.operator_name)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_operator_name_form) { build(:renew_operator_name_form) }
+
+      it "prefils operator name information" do
+        get "/waste_exemptions_engine/operator-name/#{renew_operator_name_form.token}"
+
+        expect(response.body).to include(renew_operator_name_form.operator_name)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/operator_name_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/operator_name_forms_spec.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_operator_name_form) { build(:edit_operator_name_form) }
 
-      it "prefils operator name information" do
+      it "pre-fills operator name information" do
         get "/waste_exemptions_engine/operator-name/#{edit_operator_name_form.token}"
 
         expect(response.body).to include(edit_operator_name_form.operator_name)
@@ -24,7 +24,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_operator_name_form) { build(:renew_operator_name_form) }
 
-      it "prefils operator name information" do
+      it "pre-fills operator name information" do
         get "/waste_exemptions_engine/operator-name/#{renew_operator_name_form.token}"
 
         expect(response.body).to include(renew_operator_name_form.operator_name)

--- a/spec/requests/waste_exemptions_engine/operator_postcode_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/operator_postcode_forms_spec.rb
@@ -15,5 +15,26 @@ module WasteExemptionsEngine
                      :operator_postcode_form,
                      request_path: "/operator-postcode/skip_to_manual_address",
                      result_path: "/operator-address-manual"
+
+
+    context "when editing an existing registration" do
+      let(:edit_operator_postcode_form) { build(:edit_operator_postcode_form) }
+
+      it "prefils operator postcode information" do
+        get "/waste_exemptions_engine/operator-postcode/#{edit_operator_postcode_form.token}"
+
+        expect(response.body).to include(edit_operator_postcode_form.postcode)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_operator_postcode_form) { build(:renew_operator_postcode_form) }
+
+      it "prefils operator postcode information" do
+        get "/waste_exemptions_engine/operator-postcode/#{renew_operator_postcode_form.token}"
+
+        expect(response.body).to include(renew_operator_postcode_form.postcode)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/operator_postcode_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/operator_postcode_forms_spec.rb
@@ -16,7 +16,6 @@ module WasteExemptionsEngine
                      request_path: "/operator-postcode/skip_to_manual_address",
                      result_path: "/operator-address-manual"
 
-
     context "when editing an existing registration" do
       let(:edit_operator_postcode_form) { build(:edit_operator_postcode_form) }
 

--- a/spec/requests/waste_exemptions_engine/operator_postcode_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/operator_postcode_forms_spec.rb
@@ -19,7 +19,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_operator_postcode_form) { build(:edit_operator_postcode_form) }
 
-      it "prefils operator postcode information" do
+      it "pre-fills operator postcode information" do
         get "/waste_exemptions_engine/operator-postcode/#{edit_operator_postcode_form.token}"
 
         expect(response.body).to include(edit_operator_postcode_form.postcode)
@@ -29,7 +29,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_operator_postcode_form) { build(:renew_operator_postcode_form) }
 
-      it "prefils operator postcode information" do
+      it "pre-fills operator postcode information" do
         get "/waste_exemptions_engine/operator-postcode/#{renew_operator_postcode_form.token}"
 
         expect(response.body).to include(renew_operator_postcode_form.postcode)

--- a/spec/requests/waste_exemptions_engine/site_grid_reference_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_grid_reference_forms_spec.rb
@@ -32,7 +32,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_site_grid_reference_form) { build(:edit_site_grid_reference_form) }
 
-      it "prefils site grid reference information" do
+      it "pre-fills site grid reference information" do
         get "/waste_exemptions_engine/site-grid-reference/#{edit_site_grid_reference_form.token}"
 
         expect(response.body).to include(edit_site_grid_reference_form.grid_reference)
@@ -43,7 +43,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_site_grid_reference_form) { build(:renew_site_grid_reference_form) }
 
-      it "prefils site grid reference information" do
+      it "pre-fills site grid reference information" do
         get "/waste_exemptions_engine/site-grid-reference/#{renew_site_grid_reference_form.token}"
 
         expect(response.body).to include(renew_site_grid_reference_form.grid_reference)

--- a/spec/requests/waste_exemptions_engine/site_grid_reference_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_grid_reference_forms_spec.rb
@@ -28,5 +28,27 @@ module WasteExemptionsEngine
                      :site_grid_reference_form,
                      request_path: "/site-grid-reference/skip_to_address",
                      result_path: "/site-postcode"
+
+    context "when editing an existing registration" do
+      let(:edit_site_grid_reference_form) { build(:edit_site_grid_reference_form) }
+
+      it "prefils site grid reference information" do
+        get "/waste_exemptions_engine/site-grid-reference/#{edit_site_grid_reference_form.token}"
+
+        expect(response.body).to include(edit_site_grid_reference_form.grid_reference)
+        expect(response.body).to include(edit_site_grid_reference_form.description)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_site_grid_reference_form) { build(:renew_site_grid_reference_form) }
+
+      it "prefils site grid reference information" do
+        get "/waste_exemptions_engine/site-grid-reference/#{renew_site_grid_reference_form.token}"
+
+        expect(response.body).to include(renew_site_grid_reference_form.grid_reference)
+        expect(response.body).to include(renew_site_grid_reference_form.description)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/site_postcode_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_postcode_forms_spec.rb
@@ -15,5 +15,25 @@ module WasteExemptionsEngine
                      :site_postcode_form,
                      request_path: "/site-postcode/skip_to_manual_address",
                      result_path: "/site-address-manual"
+
+    context "when editing an existing registration" do
+      let(:edit_site_postcode_form) { build(:edit_site_postcode_form) }
+
+      it "prefils site grid reference information" do
+        get "/waste_exemptions_engine/site-postcode/#{edit_site_postcode_form.token}"
+
+        expect(response.body).to include(edit_site_postcode_form.postcode)
+      end
+    end
+
+    context "when renewing an existing registration" do
+      let(:renew_site_postcode_form) { build(:renew_site_postcode_form) }
+
+      it "prefils site grid reference information" do
+        get "/waste_exemptions_engine/site-postcode/#{renew_site_postcode_form.token}"
+
+        expect(response.body).to include(renew_site_postcode_form.postcode)
+      end
+    end
   end
 end

--- a/spec/requests/waste_exemptions_engine/site_postcode_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_postcode_forms_spec.rb
@@ -19,7 +19,7 @@ module WasteExemptionsEngine
     context "when editing an existing registration" do
       let(:edit_site_postcode_form) { build(:edit_site_postcode_form) }
 
-      it "prefils site grid reference information" do
+      it "pre-fills site postcode information" do
         get "/waste_exemptions_engine/site-postcode/#{edit_site_postcode_form.token}"
 
         expect(response.body).to include(edit_site_postcode_form.postcode)
@@ -29,7 +29,7 @@ module WasteExemptionsEngine
     context "when renewing an existing registration" do
       let(:renew_site_postcode_form) { build(:renew_site_postcode_form) }
 
-      it "prefils site grid reference information" do
+      it "pre-fills site postcode information" do
         get "/waste_exemptions_engine/site-postcode/#{renew_site_postcode_form.token}"
 
         expect(response.body).to include(renew_site_postcode_form.postcode)


### PR DESCRIPTION
This adds request test coverage on relevant forms for edit and renew registration.
This will ensure we have at least one place that test the correct pre-fill of forms in those cases.