### PR TITLE
Remove second token setting on forms

### DIFF
--- a/app/forms/waste_exemptions_engine/address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/address_lookup_form.rb
@@ -25,7 +25,7 @@ module WasteExemptionsEngine
         transient_addresses: add_or_replace_address(new_address, @transient_registration.transient_addresses)
       }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :temp_address, "waste_exemptions_engine/address": true

--- a/app/forms/waste_exemptions_engine/address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/address_manual_form.rb
@@ -30,7 +30,7 @@ module WasteExemptionsEngine
         transient_addresses: add_or_replace_address(new_address, @transient_registration.transient_addresses)
       }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates_with ManualAddressValidator

--- a/app/forms/waste_exemptions_engine/applicant_email_form.rb
+++ b/app/forms/waste_exemptions_engine/applicant_email_form.rb
@@ -18,7 +18,7 @@ module WasteExemptionsEngine
 
       attributes = { applicant_email: applicant_email }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :applicant_email, :confirmed_email, "waste_exemptions_engine/email": true

--- a/app/forms/waste_exemptions_engine/applicant_name_form.rb
+++ b/app/forms/waste_exemptions_engine/applicant_name_form.rb
@@ -20,7 +20,7 @@ module WasteExemptionsEngine
         applicant_last_name: last_name
       }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :first_name, :last_name, "waste_exemptions_engine/person_name": true

--- a/app/forms/waste_exemptions_engine/applicant_phone_form.rb
+++ b/app/forms/waste_exemptions_engine/applicant_phone_form.rb
@@ -15,7 +15,7 @@ module WasteExemptionsEngine
       self.phone_number = params[:phone_number]
       attributes = { applicant_phone: phone_number }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :phone_number, "waste_exemptions_engine/phone_number": true

--- a/app/forms/waste_exemptions_engine/base_form.rb
+++ b/app/forms/waste_exemptions_engine/base_form.rb
@@ -25,10 +25,7 @@ module WasteExemptionsEngine
       self.token = @transient_registration.token
     end
 
-    def submit(attributes, token)
-      # Additional attributes are set in individual form subclasses
-      self.token = token
-
+    def submit(attributes)
       attributes = strip_whitespace(attributes)
 
       # Update the registration with params from the registration if valid

--- a/app/forms/waste_exemptions_engine/business_type_form.rb
+++ b/app/forms/waste_exemptions_engine/business_type_form.rb
@@ -15,7 +15,7 @@ module WasteExemptionsEngine
       self.business_type = params[:business_type]
       attributes = { business_type: business_type }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :business_type, "waste_exemptions_engine/business_type": true

--- a/app/forms/waste_exemptions_engine/check_your_answers_form.rb
+++ b/app/forms/waste_exemptions_engine/check_your_answers_form.rb
@@ -11,7 +11,7 @@ module WasteExemptionsEngine
     end
 
     def submit(params)
-      super({}, params[:token])
+      super({})
     end
 
     validates :location, "waste_exemptions_engine/location": true

--- a/app/forms/waste_exemptions_engine/check_your_answers_form.rb
+++ b/app/forms/waste_exemptions_engine/check_your_answers_form.rb
@@ -10,7 +10,7 @@ module WasteExemptionsEngine
       valid?
     end
 
-    def submit(params)
+    def submit(_params)
       super({})
     end
 

--- a/app/forms/waste_exemptions_engine/confirm_edit_cancelled_form.rb
+++ b/app/forms/waste_exemptions_engine/confirm_edit_cancelled_form.rb
@@ -7,7 +7,7 @@ module WasteExemptionsEngine
     end
 
     def submit(params)
-      super({}, params[:token])
+      super({})
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/confirm_edit_cancelled_form.rb
+++ b/app/forms/waste_exemptions_engine/confirm_edit_cancelled_form.rb
@@ -6,7 +6,7 @@ module WasteExemptionsEngine
       super
     end
 
-    def submit(params)
+    def submit(_params)
       super({})
     end
   end

--- a/app/forms/waste_exemptions_engine/contact_email_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_email_form.rb
@@ -18,7 +18,7 @@ module WasteExemptionsEngine
 
       attributes = { contact_email: contact_email }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :contact_email, :confirmed_email, "waste_exemptions_engine/email": true

--- a/app/forms/waste_exemptions_engine/contact_name_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_name_form.rb
@@ -20,7 +20,7 @@ module WasteExemptionsEngine
         contact_last_name: last_name
       }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :first_name, :last_name, "waste_exemptions_engine/person_name": true

--- a/app/forms/waste_exemptions_engine/contact_phone_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_phone_form.rb
@@ -15,7 +15,7 @@ module WasteExemptionsEngine
       self.phone_number = params[:phone_number]
       attributes = { contact_phone: phone_number }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :phone_number, "waste_exemptions_engine/phone_number": true

--- a/app/forms/waste_exemptions_engine/contact_position_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_position_form.rb
@@ -15,7 +15,7 @@ module WasteExemptionsEngine
       self.position = params[:position]
       attributes = { contact_position: position }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :position, "waste_exemptions_engine/position": true

--- a/app/forms/waste_exemptions_engine/declaration_form.rb
+++ b/app/forms/waste_exemptions_engine/declaration_form.rb
@@ -18,7 +18,7 @@ module WasteExemptionsEngine
 
       attributes = { declaration: declaration }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :declaration, inclusion: { in: [1] }

--- a/app/forms/waste_exemptions_engine/edit_form.rb
+++ b/app/forms/waste_exemptions_engine/edit_form.rb
@@ -58,7 +58,7 @@ module WasteExemptionsEngine
       # Assign the params for validation and pass them to the BaseForm method for updating
       attributes = {}
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     private

--- a/app/forms/waste_exemptions_engine/edit_form.rb
+++ b/app/forms/waste_exemptions_engine/edit_form.rb
@@ -54,7 +54,7 @@ module WasteExemptionsEngine
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
 
-    def submit(params)
+    def submit(_params)
       # Assign the params for validation and pass them to the BaseForm method for updating
       attributes = {}
 

--- a/app/forms/waste_exemptions_engine/exemptions_form.rb
+++ b/app/forms/waste_exemptions_engine/exemptions_form.rb
@@ -21,7 +21,7 @@ module WasteExemptionsEngine
     def submit(params)
       self.matched_exemptions = determine_matched_exemptions(params)
 
-      super({ exemptions: matched_exemptions }, params[:token])
+      super(exemptions: matched_exemptions)
     end
 
     validates :matched_exemptions, "waste_exemptions_engine/exemptions": true

--- a/app/forms/waste_exemptions_engine/is_a_farmer_form.rb
+++ b/app/forms/waste_exemptions_engine/is_a_farmer_form.rb
@@ -15,7 +15,7 @@ module WasteExemptionsEngine
       self.is_a_farmer = params[:is_a_farmer]
       attributes = { is_a_farmer: is_a_farmer }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :is_a_farmer, "defra_ruby/validators/true_false": true

--- a/app/forms/waste_exemptions_engine/location_form.rb
+++ b/app/forms/waste_exemptions_engine/location_form.rb
@@ -15,7 +15,7 @@ module WasteExemptionsEngine
       self.location = params[:location]
       attributes = { location: location }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :location, "waste_exemptions_engine/location": true

--- a/app/forms/waste_exemptions_engine/on_a_farm_form.rb
+++ b/app/forms/waste_exemptions_engine/on_a_farm_form.rb
@@ -15,7 +15,7 @@ module WasteExemptionsEngine
       self.on_a_farm = params[:on_a_farm]
       attributes = { on_a_farm: on_a_farm }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :on_a_farm, "defra_ruby/validators/true_false": true

--- a/app/forms/waste_exemptions_engine/operator_name_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_name_form.rb
@@ -17,7 +17,7 @@ module WasteExemptionsEngine
       self.operator_name = params[:operator_name]
       attributes = { operator_name: operator_name }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :operator_name, "waste_exemptions_engine/operator_name": true

--- a/app/forms/waste_exemptions_engine/person_form.rb
+++ b/app/forms/waste_exemptions_engine/person_form.rb
@@ -16,7 +16,7 @@ module WasteExemptionsEngine
 
       set_up_new_person if fields_have_content?
 
-      super({}, params[:token])
+      super({})
     end
 
     # Used to switch on usage of the :position attribute for validation and form-filling

--- a/app/forms/waste_exemptions_engine/postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/postcode_form.rb
@@ -23,7 +23,7 @@ module WasteExemptionsEngine
 
       # We pass through an empty hash for the attributes, as there is nothing to
       # update on the registration itself
-      super({}, params[:token])
+      super({})
     end
 
     validates :postcode, "waste_exemptions_engine/postcode": true

--- a/app/forms/waste_exemptions_engine/registration_number_form.rb
+++ b/app/forms/waste_exemptions_engine/registration_number_form.rb
@@ -19,7 +19,7 @@ module WasteExemptionsEngine
       self.company_no = process_company_no(company_no) if company_no.present?
       attributes = { company_no: company_no }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :company_no, "defra_ruby/validators/companies_house_number": true

--- a/app/forms/waste_exemptions_engine/renew_with_changes_form.rb
+++ b/app/forms/waste_exemptions_engine/renew_with_changes_form.rb
@@ -2,7 +2,7 @@
 
 module WasteExemptionsEngine
   class RenewWithChangesForm < BaseForm
-    def submit(params)
+    def submit(_params)
       super({})
     end
   end

--- a/app/forms/waste_exemptions_engine/renew_with_changes_form.rb
+++ b/app/forms/waste_exemptions_engine/renew_with_changes_form.rb
@@ -3,7 +3,7 @@
 module WasteExemptionsEngine
   class RenewWithChangesForm < BaseForm
     def submit(params)
-      super({}, params[:token])
+      super({})
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/renew_without_changes_form.rb
+++ b/app/forms/waste_exemptions_engine/renew_without_changes_form.rb
@@ -3,7 +3,7 @@
 module WasteExemptionsEngine
   class RenewWithoutChangesForm < BaseForm
     def submit(params)
-      super({}, params[:token])
+      super({})
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/renew_without_changes_form.rb
+++ b/app/forms/waste_exemptions_engine/renew_without_changes_form.rb
@@ -2,7 +2,7 @@
 
 module WasteExemptionsEngine
   class RenewWithoutChangesForm < BaseForm
-    def submit(params)
+    def submit(_params)
       super({})
     end
   end

--- a/app/forms/waste_exemptions_engine/renewal_start_form.rb
+++ b/app/forms/waste_exemptions_engine/renewal_start_form.rb
@@ -17,7 +17,7 @@ module WasteExemptionsEngine
       self.temp_renew_without_changes = params[:temp_renew_without_changes]
       attributes = { temp_renew_without_changes: temp_renew_without_changes }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :temp_renew_without_changes,

--- a/app/forms/waste_exemptions_engine/site_grid_reference_form.rb
+++ b/app/forms/waste_exemptions_engine/site_grid_reference_form.rb
@@ -27,7 +27,7 @@ module WasteExemptionsEngine
         )
       }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :grid_reference, "waste_exemptions_engine/grid_reference": true

--- a/app/forms/waste_exemptions_engine/start_form.rb
+++ b/app/forms/waste_exemptions_engine/start_form.rb
@@ -15,7 +15,7 @@ module WasteExemptionsEngine
       self.start = params[:start]
       attributes = { start_option: start }
 
-      super(attributes, params[:token])
+      super(attributes)
     end
 
     validates :start, "waste_exemptions_engine/start": true


### PR DESCRIPTION
Since the advent of the edit functionality, we now se the form token in the `initialize` method, taking it from the transient_registration.
Hence, it is not any more needed for the `submit` to set the correct token.

Next step will be to make the `attributes` a method in the children classes that define which attributes from the form have to be updated in the transient registration. 