### PR TITLE
Fix past_renewal_window? to not drop one day

### DIFF
--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -31,7 +31,7 @@ module WasteExemptionsEngine
     end
 
     def past_renewal_window?
-      (expires_on + renewal_window_after_expiry_in_days.days) < Time.now
+      (expires_on + renewal_window_after_expiry_in_days.days) < Date.current
     end
 
     private

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -107,14 +107,6 @@ ActiveRecord::Schema.define(version: 20190805152649) do
   add_index "registrations", ["reference"], name: "index_registrations_on_reference", unique: true, using: :btree
   add_index "registrations", ["renew_token"], name: "index_registrations_on_renew_token", unique: true, using: :btree
 
-  create_table "reports_generated_reports", force: :cascade do |t|
-    t.string   "file_name"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.date     "data_from_date"
-    t.date     "data_to_date"
-  end
-
   create_table "transient_addresses", force: :cascade do |t|
     t.integer  "address_type",              default: 0
     t.integer  "mode",                      default: 0
@@ -201,33 +193,6 @@ ActiveRecord::Schema.define(version: 20190805152649) do
   end
 
   add_index "transient_registrations", ["token"], name: "index_transient_registrations_on_token", unique: true, using: :btree
-
-  create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "",   null: false
-    t.string   "encrypted_password",     default: "",   null: false
-    t.string   "invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
-    t.integer  "invitation_limit"
-    t.integer  "invited_by_id"
-    t.string   "invited_by_type"
-    t.integer  "failed_attempts",        default: 0,    null: false
-    t.string   "unlock_token"
-    t.datetime "locked_at"
-    t.string   "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.string   "session_token"
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
-    t.string   "role"
-    t.boolean  "active",                 default: true
-  end
-
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["invitation_token"], name: "index_users_on_invitation_token", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
-  add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
 
   create_table "version_archives", force: :cascade do |t|
     t.string   "item_type",  null: false

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -53,6 +53,14 @@ module WasteExemptionsEngine
           expect(registration).to be_past_renewal_window
         end
       end
+
+      context "when the registration expired exactly 30 days ago" do
+        let(:expires_on) { 30.days.ago }
+
+        it "returns false" do
+          expect(registration).not_to be_past_renewal_window
+        end
+      end
     end
 
     describe "#in_renewal_window?" do


### PR DESCRIPTION
It was spotted in testing that we were only actually providing a grace period of 29 days. Hopefully the following scenario helps explain the situation.

- We have a registration that expires on 31 Jul 2019 (24:00)
- 31 Jul 2018 plus 30 days is Aug 30
- If the current time is 14:34 on Aug 30 `past_renewal_window?` would return true
- it should not return true until 00:00 on 31 Aug

The logic prior to this change was

```ruby
def past_renewal_window?
  (expires_on + renewal_window_after_expiry_in_days.days) < Time.now
end
```

Initially we thought we could fix it by changing the comparison to `<=` however that still leads to the comparison returning `true`. The issue is actually the use of `Time` in a comparison that uses just date objects. Using this time and our example above you get `00:00 30 Aug 2019 <= 14:34 30 Aug 2019`.

Hence this change which updates the comparison to be `< Date.current`. Using the example above means the test becomes `30 Aug 2019 < 30 Aug 2019`.

<details>
<summary>Rails Console example</summary>
<img width="403" alt="Screenshot 2019-08-15 at 10 16 59" src="https://user-images.githubusercontent.com/1789650/63085634-e1981580-bf45-11e9-81c0-21eb33aecf94.png">

</details>