### PR TITLE
Copy expired registrations to RenewingRegistration

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_copy_data_from_registration.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_copy_data_from_registration.rb
@@ -60,7 +60,11 @@ module WasteExemptionsEngine
     end
 
     def copy_exemptions_from_registration
-      self.exemptions = registration.active_exemptions
+      self.exemptions = if respond_to?(:registration_exemptions_to_copy)
+                          registration_exemptions_to_copy
+                        else
+                          registration.active_exemptions
+                        end
     end
   end
 end

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -18,6 +18,12 @@ module WasteExemptionsEngine
       through: :registration_exemptions,
       source: :exemption
     )
+    has_many(
+      :expired_exemptions,
+      -> { WasteExemptionsEngine::RegistrationExemption.expired },
+      through: :registration_exemptions,
+      source: :exemption
+    )
     belongs_to :referring_registration, class_name: "Registration"
     has_one :referred_registration, class_name: "Registration", foreign_key: "referring_registration_id"
 

--- a/app/models/waste_exemptions_engine/registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/registration_exemption.rb
@@ -8,6 +8,7 @@ module WasteExemptionsEngine
     belongs_to :exemption
 
     scope :active, -> { where(state: :active) }
+    scope :expired, -> { where(state: :expired) }
     scope :order_by_exemption, -> { order(exemption_id: :asc) }
   end
 end

--- a/app/models/waste_exemptions_engine/renewing_registration.rb
+++ b/app/models/waste_exemptions_engine/renewing_registration.rb
@@ -19,5 +19,9 @@ module WasteExemptionsEngine
 
       registration_attributes
     end
+
+    def registration_exemptions_to_copy
+      registration.active_exemptions + registration.expired_exemptions
+    end
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
       registration_exemptions { build_list(:registration_exemption, 5, state: :active) }
     end
 
+    trait :with_expired_exemptions do
+      registration_exemptions { build_list(:registration_exemption, 5, state: :expired) }
+    end
+
     trait :limited_company do
       business_type { WasteExemptionsEngine::Registration::BUSINESS_TYPES[:limited_company] }
     end

--- a/spec/models/waste_exemptions_engine/edit_registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/edit_registration_spec.rb
@@ -60,9 +60,47 @@ module WasteExemptionsEngine
           end
         end
 
-        it "copies the exemptions from the registration" do
+        it "copies the active exemptions from the registration" do
+          registration.registration_exemptions.each do |re|
+            re.state = :active
+            re.save
+          end
+
           registration.exemptions.each do |exemption|
             expect(edit_registration.exemptions).to include(exemption)
+          end
+        end
+
+        it "does not copy the expired exemptions from the registration" do
+          registration.registration_exemptions.each do |re|
+            re.state = :expired
+            re.save
+          end
+
+          registration.exemptions.each do |exemption|
+            expect(edit_registration.exemptions).to_not include(exemption)
+          end
+        end
+
+        it "does not copy revoked exemptions from the registration" do
+          registration.registration_exemptions.each do |re|
+            re.state = :revoked
+            re.save
+          end
+
+          registration.exemptions.each do |exemption|
+            expect(edit_registration.exemptions).to_not include(exemption)
+          end
+        end
+
+        it "does not copy ceased exemptions from the registration" do
+          registration.registration_exemptions.each do |re|
+            re.state = :ceased
+            re.save
+          end
+
+          registration.exemptions.each do |exemption|
+            expect(edit_registration.exemptions).to_not include(exemption)
           end
         end
       end

--- a/spec/models/waste_exemptions_engine/edit_registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/edit_registration_spec.rb
@@ -22,7 +22,7 @@ module WasteExemptionsEngine
 
     describe "#initialize" do
       context "when it is initialized with a registration" do
-        let(:registration) { create(:registration) }
+        let(:registration) { create(:registration, :complete) }
         let(:edit_registration) { described_class.new(reference: registration.reference) }
 
         copyable_properties = Helpers::ModelProperties::REGISTRATION - %i[id
@@ -38,12 +38,15 @@ module WasteExemptionsEngine
         end
 
         it "copies the addresses from the registration" do
-          registration.addresses.each_with_index do |address, index|
+          registration.addresses.each do |address|
             copyable_attributes = address.attributes.except("id",
                                                             "registration_id",
                                                             "created_at",
                                                             "updated_at")
-            expect(edit_registration.address[index].attributes).to include(copyable_attributes)
+
+            edit_address_attributes = edit_registration.public_send("#{address.address_type}_address")
+                                                       .attributes
+            expect(edit_address_attributes).to include(copyable_attributes)
           end
         end
 

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -28,6 +28,18 @@ module WasteExemptionsEngine
       end
     end
 
+    describe "#expired_exemptions" do
+      subject(:registration) { create(:registration, :with_expired_exemptions) }
+
+      it "returns a list of registrations in an expired status" do
+        pending_exemption = registration.registration_exemptions.first
+        pending_exemption.state = :pending
+        pending_exemption.save
+
+        expect(registration.expired_exemptions.count).to eq(registration.exemptions.count - 1)
+      end
+    end
+
     describe "#past_renewal_window?" do
       let(:registration_exemption) { build(:registration_exemption, expires_on: expires_on) }
 

--- a/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
@@ -67,9 +67,47 @@ module WasteExemptionsEngine
           end
         end
 
-        it "copies the exemptions from the registration" do
+        it "copies the active exemptions from the registration" do
+          registration.registration_exemptions.each do |re|
+            re.state = :active
+            re.save
+          end
+
           registration.exemptions.each do |exemption|
             expect(renewing_registration.exemptions).to include(exemption)
+          end
+        end
+
+        it "copies the expired exemptions from the registration" do
+          registration.registration_exemptions.each do |re|
+            re.state = :expired
+            re.save
+          end
+
+          registration.exemptions.each do |exemption|
+            expect(renewing_registration.exemptions).to include(exemption)
+          end
+        end
+
+        it "does not copy revoked exemptions from the registration" do
+          registration.registration_exemptions.each do |re|
+            re.state = :revoked
+            re.save
+          end
+
+          registration.exemptions.each do |exemption|
+            expect(renewing_registration.exemptions).to_not include(exemption)
+          end
+        end
+
+        it "does not copy ceased exemptions from the registration" do
+          registration.registration_exemptions.each do |re|
+            re.state = :ceased
+            re.save
+          end
+
+          registration.exemptions.each do |exemption|
+            expect(renewing_registration.exemptions).to_not include(exemption)
           end
         end
       end

--- a/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
@@ -29,7 +29,7 @@ module WasteExemptionsEngine
 
     describe "#initialize" do
       context "when it is initialized with a registration" do
-        let(:registration) { create(:registration) }
+        let(:registration) { create(:registration, :complete) }
         let(:renewing_registration) { described_class.new(reference: registration.reference) }
 
         copyable_properties = Helpers::ModelProperties::REGISTRATION - %i[id
@@ -45,12 +45,15 @@ module WasteExemptionsEngine
         end
 
         it "copies the addresses from the registration" do
-          registration.addresses.each_with_index do |address, index|
+          registration.addresses.each do |address|
             copyable_attributes = address.attributes.except("id",
                                                             "registration_id",
                                                             "created_at",
                                                             "updated_at")
-            expect(renewing_registration.address[index].attributes).to include(copyable_attributes)
+
+            renewing_address_attributes = renewing_registration.public_send("#{address.address_type}_address")
+                                                               .attributes
+            expect(renewing_address_attributes).to include(copyable_attributes)
           end
         end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-594

When we start a renewal, if the registration has already expired and is in the grace period, we want to copy over the expired exemptions so they don't have to re-select them.

This will also mean the exemptions are listed in the magic link email if it is resent after expiry.