### PR TITLE
For discussion on Thursday

### DIFF
--- a/app/forms/waste_exemptions_engine/base_form.rb
+++ b/app/forms/waste_exemptions_engine/base_form.rb
@@ -5,6 +5,15 @@ module WasteExemptionsEngine
     include ActiveModel::Model
     include CanStripWhitespace
 
+    attr_reader :transient_registration
+
+    delegate :token, to: :transient_registration
+
+    # If the record is new, and not yet persisted (which it is when the start
+    # page is first submitted) then we have nothing to validate hence the check
+    validates :token, "defra_ruby/validators/token": true if transient_registration&.persisted?
+    validate :registration_valid?
+
     # The standard behaviour for loading a form is to check whether the requested form matches the workflow_state for
     # the registration, and redirect to the saved workflow_state if it doesn't.
     # But if the workflow state is 'flexible', we skip the check and load the requested form instead of the saved one.
@@ -17,38 +26,35 @@ module WasteExemptionsEngine
       true
     end
 
-    attr_accessor :token, :transient_registration
-
-    def initialize(registration)
-      # Get values from registration so form will be pre-filled
-      @transient_registration = registration
-      self.token = @transient_registration.token
+    def initialize(transient_registration)
+      # Get values from transient_registration so form will be pre-filled
+      @transient_registration = transient_registration
     end
 
-    def submit(attributes)
+    def submit(params)
+      attributes = transient_registration_attributes(params)
       attributes = strip_whitespace(attributes)
 
-      # Update the registration with params from the registration if valid
-      if valid?
-        @transient_registration.update_attributes(attributes)
-        @transient_registration.save!
-        true
-      else
-        false
+      attributes.each do |key, value|
+        transient_registration.public_send("#{key}=", value)
       end
-    end
 
-    # If the record is new, and not yet persisted (which it is when the start
-    # page is first submitted) then we have nothing to validate hence the check
-    validates :token, "defra_ruby/validators/token": true if @transient_registration&.persisted?
-    validate :registration_valid?
+      return transient_registration.save! if valid?
+
+      false
+    end
 
     private
 
-    def registration_valid?
-      return if @transient_registration.valid?
+    def transient_registration_attributes(_params)
+      # Default behaviour. Subclasses to override.
+      {}
+    end
 
-      @transient_registration.errors.each do |_attribute, message|
+    def registration_valid?
+      return if transient_registration.valid?
+
+      transient_registration.errors.each do |_attribute, message|
         errors[:base] << message
       end
     end

--- a/app/forms/waste_exemptions_engine/business_type_form.rb
+++ b/app/forms/waste_exemptions_engine/business_type_form.rb
@@ -2,22 +2,16 @@
 
 module WasteExemptionsEngine
   class BusinessTypeForm < BaseForm
-
-    attr_accessor :business_type
-
-    def initialize(registration)
-      super
-      self.business_type = @transient_registration.business_type
-    end
-
-    def submit(params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      self.business_type = params[:business_type]
-      attributes = { business_type: business_type }
-
-      super(attributes)
-    end
+    delegate :business_type, to: :transient_registration
 
     validates :business_type, "defra_ruby/validators/business_type": true
+
+    private
+
+    def transient_registration_attributes(params)
+      {
+        business_type: params[:business_type]
+      }
+    end
   end
 end

--- a/app/forms/waste_exemptions_engine/edit_form.rb
+++ b/app/forms/waste_exemptions_engine/edit_form.rb
@@ -2,63 +2,16 @@
 
 module WasteExemptionsEngine
   class EditForm < BaseForm
-    attr_accessor :applicant_email
-    attr_accessor :applicant_name
-    attr_accessor :applicant_phone
-    attr_accessor :business_type
-    attr_accessor :company_no
-    attr_accessor :contact_address
-    attr_accessor :contact_email
-    attr_accessor :contact_name
-    attr_accessor :contact_phone
-    attr_accessor :is_a_farmer
-    attr_accessor :location
-    attr_accessor :on_a_farm
-    attr_accessor :operator_name
-    attr_accessor :operator_address
-    attr_accessor :people
-    attr_accessor :reference
-    attr_accessor :registration_exemptions
-    attr_accessor :site_address
+    delegate :applicant_email, :applicant_phone, :business_type, :company_no, to: :transient_registration
+    delegate :contact_phone, :contact_email, :is_a_farmer, :location, :on_a_farm, to: :transient_registration
+    delegate :operator_name, :operator_address, :people, :reference, to: :transient_registration
+    delegate :contact_address, :registration_exemptions, :site_address, :applicant_name, to: :transient_registration
+    delegate :contact_name, to: :transient_registration
 
-    # This form has a lot of attributes, so we have to disable the length cop.
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     def initialize(registration)
       registration.save! unless registration.persisted?
 
       super
-
-      self.applicant_email          = @transient_registration.applicant_email
-      self.applicant_phone          = @transient_registration.applicant_phone
-      self.business_type            = @transient_registration.business_type
-      self.company_no               = @transient_registration.company_no
-      self.contact_address          = @transient_registration.contact_address
-      self.contact_email            = @transient_registration.contact_email
-      self.contact_phone            = @transient_registration.contact_phone
-      self.is_a_farmer              = @transient_registration.is_a_farmer
-      self.location                 = @transient_registration.location
-      self.on_a_farm                = @transient_registration.on_a_farm
-      self.operator_name            = @transient_registration.operator_name
-      self.operator_address         = @transient_registration.operator_address
-      self.people                   = @transient_registration.people
-      self.reference                = @transient_registration.reference
-      self.registration_exemptions  = @transient_registration.registration_exemptions
-      self.site_address             = @transient_registration.site_address
-
-      self.applicant_name           = full_name(@transient_registration.applicant_first_name,
-                                                @transient_registration.applicant_last_name)
-      self.contact_name             = full_name(@transient_registration.contact_first_name,
-                                                @transient_registration.contact_last_name)
-    end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
-
-    def submit(_params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      attributes = {}
-
-      super(attributes)
     end
 
     private


### PR DESCRIPTION
This is a `template` of the fixes I was thinking to introduce.
Basically, we are keeping the `form` pattern main methods in the Parent classes, and the children define the rest of specific things but without the re-write of the main methods. 
Instead, the parent class offers a `default` simple behaviour that works on the simplest cases and the children will deal with the parameters complications. 
A `delegate` is used instead of assigning instance variable on the form object, and at validation time, we assign values to the registration itself before validating, as we would do with a controller. If valid we save, otherwise, we don't. 
I think this narrows down the form's responsibilities which right now are too many. 
