### PR TITLE
Add `already_renewed?` method to Registration

### DIFF
--- a/app/controllers/waste_exemptions_engine/renews_controller.rb
+++ b/app/controllers/waste_exemptions_engine/renews_controller.rb
@@ -17,7 +17,7 @@ module WasteExemptionsEngine
     def validate_renew_token
       return render(:invalid_magic_link, status: 404) unless registration.present?
 
-      return render(:already_renewed) if registration.referred_registration.present?
+      return render(:already_renewed) if registration.already_renewed?
       return render(:past_renewal_window) if registration.past_renewal_window?
     end
 

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -40,6 +40,10 @@ module WasteExemptionsEngine
       (expires_on + renewal_window_after_expiry_in_days.days) < Date.current
     end
 
+    def already_renewed?
+      referred_registration.present?
+    end
+
     private
 
     def apply_reference

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -16,6 +16,26 @@ module WasteExemptionsEngine
 
     it_behaves_like "an owner of registration attributes", :registration, :address
 
+    describe "#already_renewed?" do
+      subject(:registration) { create(:registration) }
+
+      context "when a referring registration is present" do
+        before do
+          create(:registration, referring_registration_id: registration.id)
+        end
+
+        it "returns true" do
+          expect(registration).to be_already_renewed
+        end
+      end
+
+      context "when a referring registration is not present" do
+        it "returns false" do
+          expect(registration).to_not be_already_renewed
+        end
+      end
+    end
+
     describe "#active_exemptions" do
       subject(:registration) { create(:registration, :with_active_exemptions) }
 


### PR DESCRIPTION
Part of: https://eaflood.atlassian.net/browse/RUBY-602

Since we already check for the `already_renewed` concept in the engine, this refactor makes it a method that we can reuse on the backoffice for RUBY-602.