### PR TITLE
Add `#renewal?` method to registration objects

### DIFF
--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -44,6 +44,10 @@ module WasteExemptionsEngine
       referred_registration.present?
     end
 
+    def renewal?
+      referring_registration.present?
+    end
+
     private
 
     def apply_reference

--- a/app/models/waste_exemptions_engine/renewing_registration.rb
+++ b/app/models/waste_exemptions_engine/renewing_registration.rb
@@ -23,5 +23,9 @@ module WasteExemptionsEngine
     def registration_exemptions_to_copy
       registration.active_exemptions + registration.expired_exemptions
     end
+
+    def renewal?
+      true
+    end
   end
 end

--- a/app/models/waste_exemptions_engine/transient_registration.rb
+++ b/app/models/waste_exemptions_engine/transient_registration.rb
@@ -45,6 +45,10 @@ module WasteExemptionsEngine
                               updated_at
                               workflow_state].freeze
 
+    def renewal?
+      false
+    end
+
     def registration_attributes
       attributes.except(*TRANSIENT_ATTRIBUTES)
     end

--- a/spec/models/waste_exemptions_engine/edit_registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/edit_registration_spec.rb
@@ -20,6 +20,12 @@ module WasteExemptionsEngine
       end
     end
 
+    describe "#renewal?" do
+      it "returns false" do
+        expect(edit_registration).to_not be_a_renewal
+      end
+    end
+
     describe "#initialize" do
       context "when it is initialized with a registration" do
         let(:registration) { create(:registration, :complete) }

--- a/spec/models/waste_exemptions_engine/new_registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_spec.rb
@@ -19,5 +19,11 @@ module WasteExemptionsEngine
         end
       end
     end
+
+    describe "#renewal?" do
+      it "returns false" do
+        expect(new_registration).to_not be_a_renewal
+      end
+    end
   end
 end

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -16,6 +16,26 @@ module WasteExemptionsEngine
 
     it_behaves_like "an owner of registration attributes", :registration, :address
 
+    describe "#renewal?" do
+      subject(:registration) { create(:registration) }
+
+      context "when a referring registration is present" do
+        before do
+          create(:registration, referred_registration: registration)
+        end
+
+        it "returns true" do
+          expect(registration).to be_a_renewal
+        end
+      end
+
+      context "when a referring registration is not present" do
+        it "returns false" do
+          expect(registration).to_not be_a_renewal
+        end
+      end
+    end
+
     describe "#already_renewed?" do
       subject(:registration) { create(:registration) }
 

--- a/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_spec.rb
@@ -27,6 +27,12 @@ module WasteExemptionsEngine
       end
     end
 
+    describe "#renewal?" do
+      it "returns true" do
+        expect(renewing_registration).to be_a_renewal
+      end
+    end
+
     describe "#initialize" do
       context "when it is initialized with a registration" do
         let(:registration) { create(:registration, :complete) }


### PR DESCRIPTION
Part of: https://eaflood.atlassian.net/browse/RUBY-506

This adds a common interface method on the registration classes.
A `Registration` is a `renewal` if it refers to another registration that exists.
A `TransientRegistration` is by default *not* a renewal, while a `RenewingRegistration` is by default a renwal.

This code is added to the engine in order to be reused in the backoffice (https://github.com/DEFRA/waste-exemptions-back-office-ta/pull/356) 