### PR TITLE
Forms refactoring - Move validations to the top

### DIFF
--- a/app/forms/waste_exemptions_engine/address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/address_lookup_form.rb
@@ -7,6 +7,8 @@ module WasteExemptionsEngine
     attr_accessor :temp_addresses
     attr_accessor :temp_address
 
+    validates :temp_address, "waste_exemptions_engine/address": true
+
     def initialize(registration)
       super
 
@@ -27,8 +29,6 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :temp_address, "waste_exemptions_engine/address": true
 
     private
 

--- a/app/forms/waste_exemptions_engine/address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/address_manual_form.rb
@@ -7,6 +7,8 @@ module WasteExemptionsEngine
     attr_accessor :address_finder_error
     attr_accessor :premises, :street_address, :locality, :city, :postcode
 
+    validates_with ManualAddressValidator
+
     def initialize(registration)
       super
 
@@ -32,8 +34,6 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates_with ManualAddressValidator
 
     private
 

--- a/app/forms/waste_exemptions_engine/applicant_email_form.rb
+++ b/app/forms/waste_exemptions_engine/applicant_email_form.rb
@@ -2,8 +2,10 @@
 
 module WasteExemptionsEngine
   class ApplicantEmailForm < BaseForm
-
     attr_accessor :applicant_email, :confirmed_email
+
+    validates :applicant_email, :confirmed_email, "defra_ruby/validators/email": true
+    validates :confirmed_email, "waste_exemptions_engine/matching_email": { compare_to: :applicant_email }
 
     def initialize(registration)
       super
@@ -20,8 +22,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :applicant_email, :confirmed_email, "defra_ruby/validators/email": true
-    validates :confirmed_email, "waste_exemptions_engine/matching_email": { compare_to: :applicant_email }
   end
 end

--- a/app/forms/waste_exemptions_engine/applicant_name_form.rb
+++ b/app/forms/waste_exemptions_engine/applicant_name_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class ApplicantNameForm < BaseForm
-
     attr_accessor :first_name, :last_name
+
+    validates :first_name, :last_name, "waste_exemptions_engine/person_name": true
 
     def initialize(registration)
       super
@@ -22,7 +23,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :first_name, :last_name, "waste_exemptions_engine/person_name": true
   end
 end

--- a/app/forms/waste_exemptions_engine/applicant_phone_form.rb
+++ b/app/forms/waste_exemptions_engine/applicant_phone_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class ApplicantPhoneForm < BaseForm
-
     attr_accessor :phone_number
+
+    validates :phone_number, "defra_ruby/validators/phone_number": true
 
     def initialize(registration)
       super
@@ -17,7 +18,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :phone_number, "defra_ruby/validators/phone_number": true
   end
 end

--- a/app/forms/waste_exemptions_engine/base_form.rb
+++ b/app/forms/waste_exemptions_engine/base_form.rb
@@ -19,6 +19,11 @@ module WasteExemptionsEngine
 
     attr_accessor :token, :transient_registration
 
+    # If the record is new, and not yet persisted (which it is when the start
+    # page is first submitted) then we have nothing to validate hence the check
+    validates :token, "defra_ruby/validators/token": true if @transient_registration&.persisted?
+    validate :registration_valid?
+
     def initialize(registration)
       # Get values from registration so form will be pre-filled
       @transient_registration = registration
@@ -37,11 +42,6 @@ module WasteExemptionsEngine
         false
       end
     end
-
-    # If the record is new, and not yet persisted (which it is when the start
-    # page is first submitted) then we have nothing to validate hence the check
-    validates :token, "defra_ruby/validators/token": true if @transient_registration&.persisted?
-    validate :registration_valid?
 
     private
 

--- a/app/forms/waste_exemptions_engine/business_type_form.rb
+++ b/app/forms/waste_exemptions_engine/business_type_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class BusinessTypeForm < BaseForm
-
     attr_accessor :business_type
+
+    validates :business_type, "defra_ruby/validators/business_type": true
 
     def initialize(registration)
       super
@@ -17,7 +18,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :business_type, "defra_ruby/validators/business_type": true
   end
 end

--- a/app/forms/waste_exemptions_engine/check_your_answers_form.rb
+++ b/app/forms/waste_exemptions_engine/check_your_answers_form.rb
@@ -4,16 +4,6 @@ module WasteExemptionsEngine
   class CheckYourAnswersForm < BaseForm
     include DataOverviewForm
 
-    def initialize(registration)
-      super
-      assign_attributes_to_display
-      valid?
-    end
-
-    def submit(_params)
-      super({})
-    end
-
     validates :location, "defra_ruby/validators/location": true
     validates :applicant_first_name, :applicant_last_name, "waste_exemptions_engine/person_name": true
     validates :applicant_phone, "defra_ruby/validators/phone_number": true
@@ -37,6 +27,16 @@ module WasteExemptionsEngine
     validates :grid_reference, "defra_ruby/validators/grid_reference": true, if: :uses_site_location?
     validates :site_description, "waste_exemptions_engine/site_description": true, if: :uses_site_location?
     validates :site_address, "waste_exemptions_engine/address": true, unless: :uses_site_location?
+
+    def initialize(registration)
+      super
+      assign_attributes_to_display
+      valid?
+    end
+
+    def submit(_params)
+      super({})
+    end
 
     private
 

--- a/app/forms/waste_exemptions_engine/contact_email_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_email_form.rb
@@ -2,8 +2,10 @@
 
 module WasteExemptionsEngine
   class ContactEmailForm < BaseForm
-
     attr_accessor :contact_email, :confirmed_email
+
+    validates :contact_email, :confirmed_email, "defra_ruby/validators/email": true
+    validates :confirmed_email, "waste_exemptions_engine/matching_email": { compare_to: :contact_email }
 
     def initialize(registration)
       super
@@ -20,8 +22,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :contact_email, :confirmed_email, "defra_ruby/validators/email": true
-    validates :confirmed_email, "waste_exemptions_engine/matching_email": { compare_to: :contact_email }
   end
 end

--- a/app/forms/waste_exemptions_engine/contact_name_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_name_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class ContactNameForm < BaseForm
-
     attr_accessor :first_name, :last_name
+
+    validates :first_name, :last_name, "waste_exemptions_engine/person_name": true
 
     def initialize(registration)
       super
@@ -22,7 +23,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :first_name, :last_name, "waste_exemptions_engine/person_name": true
   end
 end

--- a/app/forms/waste_exemptions_engine/contact_phone_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_phone_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class ContactPhoneForm < BaseForm
-
     attr_accessor :phone_number
+
+    validates :phone_number, "defra_ruby/validators/phone_number": true
 
     def initialize(registration)
       super
@@ -17,7 +18,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :phone_number, "defra_ruby/validators/phone_number": true
   end
 end

--- a/app/forms/waste_exemptions_engine/contact_position_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_position_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class ContactPositionForm < BaseForm
-
     attr_accessor :position
+
+    validates :position, "defra_ruby/validators/position": true
 
     def initialize(registration)
       super
@@ -17,7 +18,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :position, "defra_ruby/validators/position": true
   end
 end

--- a/app/forms/waste_exemptions_engine/declaration_form.rb
+++ b/app/forms/waste_exemptions_engine/declaration_form.rb
@@ -4,6 +4,8 @@ module WasteExemptionsEngine
   class DeclarationForm < BaseForm
     attr_accessor :declaration
 
+    validates :declaration, inclusion: { in: [1] }
+
     def self.can_navigate_flexibly?
       false
     end
@@ -20,7 +22,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :declaration, inclusion: { in: [1] }
   end
 end

--- a/app/forms/waste_exemptions_engine/exemptions_form.rb
+++ b/app/forms/waste_exemptions_engine/exemptions_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class ExemptionsForm < BaseForm
-
     attr_accessor :exemptions, :matched_exemptions, :matched_exemption_ids
+
+    validates :matched_exemptions, "waste_exemptions_engine/exemptions": true
 
     def initialize(registration)
       super
@@ -23,8 +24,6 @@ module WasteExemptionsEngine
 
       super(exemptions: matched_exemptions)
     end
-
-    validates :matched_exemptions, "waste_exemptions_engine/exemptions": true
 
     private
 

--- a/app/forms/waste_exemptions_engine/is_a_farmer_form.rb
+++ b/app/forms/waste_exemptions_engine/is_a_farmer_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class IsAFarmerForm < BaseForm
-
     attr_accessor :is_a_farmer
+
+    validates :is_a_farmer, "defra_ruby/validators/true_false": true
 
     def initialize(registration)
       super
@@ -17,7 +18,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :is_a_farmer, "defra_ruby/validators/true_false": true
   end
 end

--- a/app/forms/waste_exemptions_engine/location_form.rb
+++ b/app/forms/waste_exemptions_engine/location_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class LocationForm < BaseForm
-
     attr_accessor :location
+
+    validates :location, "defra_ruby/validators/location": true
 
     def initialize(registration)
       super
@@ -17,7 +18,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :location, "defra_ruby/validators/location": true
   end
 end

--- a/app/forms/waste_exemptions_engine/main_people_form.rb
+++ b/app/forms/waste_exemptions_engine/main_people_form.rb
@@ -6,6 +6,8 @@ module WasteExemptionsEngine
 
     attr_accessor :business_type
 
+    validates_with MainPersonValidator
+
     def initialize(transient_registration)
       super
       # We only use this for the correct microcopy
@@ -18,8 +20,6 @@ module WasteExemptionsEngine
     def person_type
       TransientPerson.person_types[:partner]
     end
-
-    validates_with MainPersonValidator
 
     private
 

--- a/app/forms/waste_exemptions_engine/on_a_farm_form.rb
+++ b/app/forms/waste_exemptions_engine/on_a_farm_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class OnAFarmForm < BaseForm
-
     attr_accessor :on_a_farm
+
+    validates :on_a_farm, "defra_ruby/validators/true_false": true
 
     def initialize(registration)
       super
@@ -17,7 +18,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :on_a_farm, "defra_ruby/validators/true_false": true
   end
 end

--- a/app/forms/waste_exemptions_engine/operator_address_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_form.rb
@@ -2,7 +2,6 @@
 
 module WasteExemptionsEngine
   module OperatorAddressForm
-
     attr_accessor :business_type
 
     def initialize(registration)

--- a/app/forms/waste_exemptions_engine/operator_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_lookup_form.rb
@@ -3,6 +3,5 @@
 module WasteExemptionsEngine
   class OperatorAddressLookupForm < AddressLookupForm
     include OperatorAddressForm
-
   end
 end

--- a/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
@@ -3,6 +3,5 @@
 module WasteExemptionsEngine
   class OperatorAddressManualForm < AddressManualForm
     include OperatorAddressForm
-
   end
 end

--- a/app/forms/waste_exemptions_engine/operator_name_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_name_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class OperatorNameForm < BaseForm
-
     attr_accessor :business_type, :operator_name
+
+    validates :operator_name, "waste_exemptions_engine/operator_name": true
 
     def initialize(registration)
       super
@@ -19,7 +20,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :operator_name, "waste_exemptions_engine/operator_name": true
   end
 end

--- a/app/forms/waste_exemptions_engine/operator_postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_postcode_form.rb
@@ -2,7 +2,6 @@
 
 module WasteExemptionsEngine
   class OperatorPostcodeForm < PostcodeForm
-
     attr_accessor :business_type
 
     def initialize(registration)

--- a/app/forms/waste_exemptions_engine/person_form.rb
+++ b/app/forms/waste_exemptions_engine/person_form.rb
@@ -2,7 +2,6 @@
 
 module WasteExemptionsEngine
   class PersonForm < BaseForm
-
     attr_accessor :first_name, :last_name
 
     def initialize(transient_registration)

--- a/app/forms/waste_exemptions_engine/postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/postcode_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class PostcodeForm < BaseForm
-
     attr_accessor :postcode
+
+    validates :postcode, "waste_exemptions_engine/postcode": true
 
     def initialize(registration)
       super
@@ -25,8 +26,6 @@ module WasteExemptionsEngine
       # update on the registration itself
       super({})
     end
-
-    validates :postcode, "waste_exemptions_engine/postcode": true
 
     def address_finder_error(error_occurred)
       transient_registration.address_finder_error = error_occurred

--- a/app/forms/waste_exemptions_engine/register_in_northern_ireland_form.rb
+++ b/app/forms/waste_exemptions_engine/register_in_northern_ireland_form.rb
@@ -2,7 +2,6 @@
 
 module WasteExemptionsEngine
   class RegisterInNorthernIrelandForm < BaseForm
-
     # Override BaseForm method as users shouldn't be able to submit this form
     def submit(_params)
       raise UnsubmittableForm

--- a/app/forms/waste_exemptions_engine/register_in_scotland_form.rb
+++ b/app/forms/waste_exemptions_engine/register_in_scotland_form.rb
@@ -2,7 +2,6 @@
 
 module WasteExemptionsEngine
   class RegisterInScotlandForm < BaseForm
-
     # Override BaseForm method as users shouldn't be able to submit this form
     def submit(_params)
       raise UnsubmittableForm

--- a/app/forms/waste_exemptions_engine/register_in_wales_form.rb
+++ b/app/forms/waste_exemptions_engine/register_in_wales_form.rb
@@ -2,7 +2,6 @@
 
 module WasteExemptionsEngine
   class RegisterInWalesForm < BaseForm
-
     # Override BaseForm method as users shouldn't be able to submit this form
     def submit(_params)
       raise UnsubmittableForm

--- a/app/forms/waste_exemptions_engine/registration_complete_form.rb
+++ b/app/forms/waste_exemptions_engine/registration_complete_form.rb
@@ -2,7 +2,6 @@
 
 module WasteExemptionsEngine
   class RegistrationCompleteForm < BaseForm
-
     attr_accessor :reference, :exemptions_plural, :applicant_email, :contact_email, :emails_plural
 
     def initialize(registration)

--- a/app/forms/waste_exemptions_engine/registration_number_form.rb
+++ b/app/forms/waste_exemptions_engine/registration_number_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class RegistrationNumberForm < BaseForm
-
     attr_accessor :company_no, :business_type
+
+    validates :company_no, "defra_ruby/validators/companies_house_number": true
 
     def initialize(registration)
       super
@@ -21,8 +22,6 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :company_no, "defra_ruby/validators/companies_house_number": true
 
     private
 

--- a/app/forms/waste_exemptions_engine/renewal_start_form.rb
+++ b/app/forms/waste_exemptions_engine/renewal_start_form.rb
@@ -6,6 +6,14 @@ module WasteExemptionsEngine
 
     attr_accessor :temp_renew_without_changes
 
+    validates :temp_renew_without_changes,
+              "defra_ruby/validators/true_false": {
+                messages: {
+                  inclusion: I18n.t("activemodel.errors.models.waste_exemptions_engine/renewal_start_form"\
+                                    ".attributes.temp_renew_without_changes.inclusion")
+                }
+              }
+
     def initialize(registration)
       super
       assign_attributes_to_display
@@ -19,13 +27,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :temp_renew_without_changes,
-              "defra_ruby/validators/true_false": {
-                messages: {
-                  inclusion: I18n.t("activemodel.errors.models.waste_exemptions_engine/renewal_start_form"\
-                                    ".attributes.temp_renew_without_changes.inclusion")
-                }
-              }
   end
 end

--- a/app/forms/waste_exemptions_engine/site_grid_reference_form.rb
+++ b/app/forms/waste_exemptions_engine/site_grid_reference_form.rb
@@ -2,8 +2,10 @@
 
 module WasteExemptionsEngine
   class SiteGridReferenceForm < BaseForm
-
     attr_accessor :grid_reference, :description
+
+    validates :grid_reference, "defra_ruby/validators/grid_reference": true
+    validates :description, "waste_exemptions_engine/site_description": true
 
     def initialize(registration)
       super
@@ -29,9 +31,6 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :grid_reference, "defra_ruby/validators/grid_reference": true
-    validates :description, "waste_exemptions_engine/site_description": true
 
     private
 

--- a/app/forms/waste_exemptions_engine/start_form.rb
+++ b/app/forms/waste_exemptions_engine/start_form.rb
@@ -2,8 +2,9 @@
 
 module WasteExemptionsEngine
   class StartForm < BaseForm
-
     attr_accessor :start
+
+    validates :start, "waste_exemptions_engine/start": true
 
     def initialize(registration)
       super
@@ -17,7 +18,5 @@ module WasteExemptionsEngine
 
       super(attributes)
     end
-
-    validates :start, "waste_exemptions_engine/start": true
   end
 end


### PR DESCRIPTION
As agreed by the devs, we have decided to move all validations to the top of the class, just before the initialize method.