### PR TITLE
Use applicant first and last name transient registration params

### DIFF
--- a/app/forms/waste_exemptions_engine/applicant_name_form.rb
+++ b/app/forms/waste_exemptions_engine/applicant_name_form.rb
@@ -3,26 +3,27 @@
 module WasteExemptionsEngine
   class ApplicantNameForm < BaseForm
 
-    attr_accessor :first_name, :last_name
+    attr_accessor :applicant_first_name, :applicant_last_name
 
     def initialize(registration)
       super
-      self.first_name = @transient_registration.applicant_first_name
-      self.last_name = @transient_registration.applicant_last_name
+      self.applicant_first_name = @transient_registration.applicant_first_name
+      self.applicant_last_name = @transient_registration.applicant_last_name
     end
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.first_name = params[:first_name]
-      self.last_name = params[:last_name]
+      self.applicant_first_name = params[:applicant_first_name]
+      self.applicant_last_name = params[:applicant_last_name]
+
       attributes = {
-        applicant_first_name: first_name,
-        applicant_last_name: last_name
+        applicant_first_name: applicant_first_name,
+        applicant_last_name: applicant_last_name
       }
 
       super(attributes)
     end
 
-    validates :first_name, :last_name, "waste_exemptions_engine/person_name": true
+    validates :applicant_first_name, :applicant_last_name, "waste_exemptions_engine/person_name": true
   end
 end

--- a/app/views/waste_exemptions_engine/applicant_name_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/applicant_name_forms/new.html.erb
@@ -19,14 +19,14 @@
       </fieldset>
     </div>
 
-    <div class="form-group <%= "form-group-error" if @applicant_name_form.errors[:last_name].any? %>">
-      <fieldset id="last_name">
-        <% if @applicant_name_form.errors[:last_name].any? %>
-          <span class="error-message"><%= @applicant_name_form.errors[:last_name].join(", ") %></span>
+    <div class="form-group <%= "form-group-error" if @applicant_name_form.errors[:applicant_last_name].any? %>">
+      <fieldset id="applicant_last_name">
+        <% if @applicant_name_form.errors[:applicant_last_name].any? %>
+          <span class="error-message"><%= @applicant_name_form.errors[:applicant_last_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :last_name, t(".last_name_label"), class: "form-label" %>
-        <%= f.text_field :last_name, value: @applicant_name_form.last_name, class: "form-control govuk-input--width-20" %>
+        <%= f.label :applicant_last_name, t(".last_name_label"), class: "form-label" %>
+        <%= f.text_field :applicant_last_name, value: @applicant_name_form.applicant_last_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>
 

--- a/app/views/waste_exemptions_engine/applicant_name_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/applicant_name_forms/new.html.erb
@@ -14,7 +14,7 @@
             <span class="error-message"><%= @applicant_name_form.errors[:applicant_first_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :applicant_first_name, t(".first_name_label"), class: "form-label" %>
+        <%= f.label :applicant_first_name, t(".applicant_first_name_label"), class: "form-label" %>
         <%= f.text_field :applicant_first_name, value: @applicant_name_form.applicant_first_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>
@@ -25,7 +25,7 @@
           <span class="error-message"><%= @applicant_name_form.errors[:applicant_last_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :applicant_last_name, t(".last_name_label"), class: "form-label" %>
+        <%= f.label :applicant_last_name, t(".applicant_last_name_label"), class: "form-label" %>
         <%= f.text_field :applicant_last_name, value: @applicant_name_form.applicant_last_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>

--- a/app/views/waste_exemptions_engine/applicant_name_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/applicant_name_forms/new.html.erb
@@ -8,14 +8,14 @@
 
     <p><%= t(".description") %></p>
 
-    <div class="form-group <%= "form-group-error" if @applicant_name_form.errors[:first_name].any? %>">
-      <fieldset id="first_name">
-        <% if @applicant_name_form.errors[:first_name].any? %>
-            <span class="error-message"><%= @applicant_name_form.errors[:first_name].join(", ") %></span>
+    <div class="form-group <%= "form-group-error" if @applicant_name_form.errors[:applicant_first_name].any? %>">
+      <fieldset id="applicant_first_name">
+        <% if @applicant_name_form.errors[:applicant_first_name].any? %>
+            <span class="error-message"><%= @applicant_name_form.errors[:applicant_first_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :first_name, t(".first_name_label"), class: "form-label" %>
-        <%= f.text_field :first_name, value: @applicant_name_form.first_name, class: "form-control govuk-input--width-20" %>
+        <%= f.label :applicant_first_name, t(".first_name_label"), class: "form-label" %>
+        <%= f.text_field :applicant_first_name, value: @applicant_name_form.applicant_first_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>
 

--- a/config/locales/forms/applicant_name_forms/en.yml
+++ b/config/locales/forms/applicant_name_forms/en.yml
@@ -5,8 +5,8 @@ en:
         title: Your name
         heading: Who is filling in this form?
         description: Please enter your name, even if you’re an agent, employee or other third-party
-        first_name_label: First name
-        last_name_label: Last name
+        applicant_first_name_label: First name
+        applicant_last_name_label: Last name
         error_heading: A problem to fix
         next_button: Continue
   activemodel:

--- a/spec/forms/waste_exemptions_engine/applicant_name_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/applicant_name_form_spec.rb
@@ -10,27 +10,27 @@ module WasteExemptionsEngine
       subject(:validators) { form._validators }
 
       it "validates the first name using the PersonNameValidator class" do
-        expect(validators.keys).to include(:first_name)
-        expect(validators[:first_name].first.class)
+        expect(validators.keys).to include(:applicant_first_name)
+        expect(validators[:applicant_first_name].first.class)
           .to eq(WasteExemptionsEngine::PersonNameValidator)
       end
 
       it "validates the last name using the PersonNameValidator class" do
-        expect(validators.keys).to include(:last_name)
-        expect(validators[:first_name].first.class)
+        expect(validators.keys).to include(:applicant_last_name)
+        expect(validators[:applicant_first_name].first.class)
           .to eq(WasteExemptionsEngine::PersonNameValidator)
       end
     end
 
     it_behaves_like "a validated form", :applicant_name_form do
       let(:valid_params) do
-        { token: form.token, first_name: "Joe", last_name: "Bloggs" }
+        { token: form.token, applicant_first_name: "Joe", applicant_last_name: "Bloggs" }
       end
       let(:invalid_params) do
         [
-          { token: form.token, first_name: "", last_name: "Bloggs" },
-          { token: form.token, first_name: "Joe", last_name: "" },
-          { token: form.token, first_name: "", last_name: "" }
+          { token: form.token, applicant_first_name: "", applicant_last_name: "Bloggs" },
+          { token: form.token, applicant_first_name: "Joe", applicant_last_name: "" },
+          { token: form.token, applicant_first_name: "", applicant_last_name: "" }
         ]
       end
     end
@@ -40,7 +40,7 @@ module WasteExemptionsEngine
         it "updates the transient registration with the applicant name" do
           first_name = "Joe"
           last_name = "Bloggs"
-          valid_params = { token: form.token, first_name: first_name, last_name: last_name }
+          valid_params = { token: form.token, applicant_first_name: first_name, applicant_last_name: last_name }
           transient_registration = form.transient_registration
 
           expect(transient_registration.applicant_first_name).to be_blank

--- a/spec/forms/waste_exemptions_engine/applicant_name_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/applicant_name_form_spec.rb
@@ -17,7 +17,7 @@ module WasteExemptionsEngine
 
       it "validates the last name using the PersonNameValidator class" do
         expect(validators.keys).to include(:applicant_last_name)
-        expect(validators[:applicant_first_name].first.class)
+        expect(validators[:applicant_last_name].first.class)
           .to eq(WasteExemptionsEngine::PersonNameValidator)
       end
     end

--- a/spec/requests/waste_exemptions_engine/applicant_name_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/applicant_name_forms_spec.rb
@@ -7,8 +7,8 @@ module WasteExemptionsEngine
     include_examples "GET form", :applicant_name_form, "/applicant-name"
     include_examples "go back", :applicant_name_form, "/applicant-name/back"
     include_examples "POST form", :applicant_name_form, "/applicant-name" do
-      let(:form_data) { { first_name: "Joe", last_name: "Bloggs" } }
-      let(:invalid_form_data) { [{ first_name: nil, last_name: nil }] }
+      let(:form_data) { { applicant_first_name: "Joe", applicant_last_name: "Bloggs" } }
+      let(:invalid_form_data) { [{ applicant_first_name: nil, applicant_last_name: nil }] }
     end
 
     context "when editing an existing registration" do
@@ -17,8 +17,8 @@ module WasteExemptionsEngine
       it "pre-fills applicant name information" do
         get "/waste_exemptions_engine/applicant-name/#{edit_applicant_name_form.token}"
 
-        expect(response.body).to have_html_escaped_string(edit_applicant_name_form.first_name)
-        expect(response.body).to have_html_escaped_string(edit_applicant_name_form.last_name)
+        expect(response.body).to have_html_escaped_string(edit_applicant_name_form.applicant_first_name)
+        expect(response.body).to have_html_escaped_string(edit_applicant_name_form.applicant_last_name)
       end
     end
 
@@ -28,8 +28,8 @@ module WasteExemptionsEngine
       it "pre-fills applicant name information" do
         get "/waste_exemptions_engine/applicant-name/#{renew_applicant_name_form.token}"
 
-        expect(response.body).to have_html_escaped_string(renew_applicant_name_form.first_name)
-        expect(response.body).to have_html_escaped_string(renew_applicant_name_form.last_name)
+        expect(response.body).to have_html_escaped_string(renew_applicant_name_form.applicant_first_name)
+        expect(response.body).to have_html_escaped_string(renew_applicant_name_form.applicant_last_name)
       end
     end
   end


### PR DESCRIPTION
To facilitate the form refactoring and take advantage of delegate, we want to use transient registration attributes names were possible