### PR TITLE
Make confirmed email an attribute of the form

### DIFF
--- a/app/forms/waste_exemptions_engine/applicant_email_form.rb
+++ b/app/forms/waste_exemptions_engine/applicant_email_form.rb
@@ -2,7 +2,8 @@
 
 module WasteExemptionsEngine
   class ApplicantEmailForm < BaseForm
-    attr_accessor :applicant_email, :confirmed_email
+    attr_accessor :applicant_email
+    attr_writer :confirmed_email
 
     validates :applicant_email, :confirmed_email, "defra_ruby/validators/email": true
     validates :confirmed_email, "waste_exemptions_engine/matching_email": { compare_to: :applicant_email }
@@ -10,17 +11,20 @@ module WasteExemptionsEngine
     def initialize(registration)
       super
       self.applicant_email = @transient_registration.applicant_email
-      self.confirmed_email = @transient_registration.applicant_email
     end
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
       self.applicant_email = params[:applicant_email]
-      self.confirmed_email = params[:confirmed_email]
+      @confirmed_email = params[:confirmed_email]
 
       attributes = { applicant_email: applicant_email }
 
       super(attributes)
+    end
+
+    def confirmed_email
+      @confirmed_email ||= transient_registration.applicant_email
     end
   end
 end

--- a/spec/support/shared_examples/requests/post_form.rb
+++ b/spec/support/shared_examples/requests/post_form.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples "POST form" do |form_factory, path, empty_form_is_valid = 
 
           invalid_form.errors.messages.values.flatten.each do |error_message|
             # We include error messages twice, but RSpec has no built-in "include twice" method yet.
-            # Hence, the scan will make sure we match the message twice in the rendered page.
+            # Hence, the scan will make sure we match the message *at least* twice in the rendered page.
             expect(response.body.scan(error_message).count).to be > 1
           end
         end


### PR DESCRIPTION
As part of the form refactoring, we want to be able to use delegate on our attributes and not re-write main initialize and submit methods.
In the case of the applicant confirmed email, we want the form to deal with the attribute in this different way, were we are able to set and read it and overwrite its value.
When sorting out the `submit` method, we will also change the setting of the attribute from params making use of callbacks with parameters.