### PR TITLE
Rename translation errors parameters

### DIFF
--- a/config/locales/forms/applicant_name_forms/en.yml
+++ b/config/locales/forms/applicant_name_forms/en.yml
@@ -14,11 +14,11 @@ en:
       models:
         waste_exemptions_engine/applicant_name_form:
           attributes:
-            first_name:
+            applicant_first_name:
               blank: "You must enter a first name"
               invalid: "The first name must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
               too_long: "The first name must have no more than 70 characters"
-            last_name:
+            applicant_last_name:
               blank: "You must enter a last name"
               invalid: "The last name must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
               too_long: "The last name must have no more than 70 characters"


### PR DESCRIPTION
I have realised that the error message also rely on the attribute names, hence this is necessary to fix a missing translation error in the validation of the form