### PR TITLE
Form refactoring - Rename contact first and last names

### DIFF
--- a/app/forms/waste_exemptions_engine/contact_name_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_name_form.rb
@@ -2,23 +2,23 @@
 
 module WasteExemptionsEngine
   class ContactNameForm < BaseForm
-    attr_accessor :first_name, :last_name
+    attr_accessor :contact_first_name, :contact_last_name
 
-    validates :first_name, :last_name, "waste_exemptions_engine/person_name": true
+    validates :contact_first_name, :contact_last_name, "waste_exemptions_engine/person_name": true
 
     def initialize(registration)
       super
-      self.first_name = @transient_registration.contact_first_name
-      self.last_name = @transient_registration.contact_last_name
+      self.contact_first_name = @transient_registration.contact_first_name
+      self.contact_last_name = @transient_registration.contact_last_name
     end
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.first_name = params[:first_name]
-      self.last_name = params[:last_name]
+      self.contact_first_name = params[:contact_first_name]
+      self.contact_last_name = params[:contact_last_name]
       attributes = {
-        contact_first_name: first_name,
-        contact_last_name: last_name
+        contact_first_name: contact_first_name,
+        contact_last_name: contact_last_name
       }
 
       super(attributes)

--- a/app/views/waste_exemptions_engine/contact_name_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_name_forms/new.html.erb
@@ -8,25 +8,25 @@
 
     <p><%= t(".description") %></p>
 
-    <div class="form-group <%= "form-group-error" if @contact_name_form.errors[:first_name].any? %>">
-      <fieldset id="first_name">
-        <% if @contact_name_form.errors[:first_name].any? %>
-          <span class="error-message"><%= @contact_name_form.errors[:first_name].join(", ") %></span>
+    <div class="form-group <%= "form-group-error" if @contact_name_form.errors[:contact_first_name].any? %>">
+      <fieldset id="contact_first_name">
+        <% if @contact_name_form.errors[:contact_first_name].any? %>
+          <span class="error-message"><%= @contact_name_form.errors[:contact_first_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :first_name, t(".first_name_label"), class: "form-label" %>
-        <%= f.text_field :first_name, value: @contact_name_form.first_name, class: "form-control govuk-input--width-20" %>
+        <%= f.label :contact_first_name, t(".contact_first_name_label"), class: "form-label" %>
+        <%= f.text_field :contact_first_name, value: @contact_name_form.contact_first_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>
 
-    <div class="form-group <%= "form-group-error" if @contact_name_form.errors[:last_name].any? %>">
-      <fieldset id="last_name">
-        <% if @contact_name_form.errors[:last_name].any? %>
-          <span class="error-message"><%= @contact_name_form.errors[:last_name].join(", ") %></span>
+    <div class="form-group <%= "form-group-error" if @contact_name_form.errors[:contact_last_name].any? %>">
+      <fieldset id="contact_last_name">
+        <% if @contact_name_form.errors[:contact_last_name].any? %>
+          <span class="error-message"><%= @contact_name_form.errors[:contact_last_name].join(", ") %></span>
         <% end %>
 
-        <%= f.label :last_name, t(".last_name_label"), class: "form-label" %>
-        <%= f.text_field :last_name, value: @contact_name_form.last_name, class: "form-control govuk-input--width-20" %>
+        <%= f.label :contact_last_name, t(".contact_last_name_label"), class: "form-label" %>
+        <%= f.text_field :contact_last_name, value: @contact_name_form.contact_last_name, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>
 

--- a/config/locales/forms/contact_name_forms/en.yml
+++ b/config/locales/forms/contact_name_forms/en.yml
@@ -5,8 +5,8 @@ en:
         title: Contact name
         heading: Who should we contact about this waste exemption operation?
         description: We will contact this person if we need to discuss the waste operation
-        first_name_label: First name
-        last_name_label: Last name
+        contact_first_name_label: First name
+        contact_last_name_label: Last name
         error_heading: A problem to fix
         next_button: Continue
   activemodel:
@@ -14,11 +14,11 @@ en:
       models:
         waste_exemptions_engine/contact_name_form:
           attributes:
-            first_name:
+            contact_first_name:
               blank: "You must enter a first name"
               invalid: "The first name must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
               too_long: "The first name must have no more than 70 characters"
-            last_name:
+            contact_last_name:
               blank: "You must enter a last name"
               invalid: "The last name must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
               too_long: "The last name must have no more than 70 characters"

--- a/spec/forms/waste_exemptions_engine/contact_name_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/contact_name_form_spec.rb
@@ -10,27 +10,27 @@ module WasteExemptionsEngine
       subject(:validators) { form._validators }
 
       it "validates the first name using the PersonNameValidator class" do
-        expect(validators.keys).to include(:first_name)
-        expect(validators[:first_name].first.class)
+        expect(validators.keys).to include(:contact_first_name)
+        expect(validators[:contact_first_name].first.class)
           .to eq(WasteExemptionsEngine::PersonNameValidator)
       end
 
       it "validates the last name using the PersonNameValidator class" do
-        expect(validators.keys).to include(:last_name)
-        expect(validators[:first_name].first.class)
+        expect(validators.keys).to include(:contact_last_name)
+        expect(validators[:contact_first_name].first.class)
           .to eq(WasteExemptionsEngine::PersonNameValidator)
       end
     end
 
     it_behaves_like "a validated form", :contact_name_form do
       let(:valid_params) do
-        { token: form.token, first_name: "Joe", last_name: "Bloggs" }
+        { token: form.token, contact_first_name: "Joe", contact_last_name: "Bloggs" }
       end
       let(:invalid_params) do
         [
-          { token: form.token, first_name: "", last_name: "Bloggs" },
-          { token: form.token, first_name: "Joe", last_name: "" },
-          { token: form.token, first_name: "", last_name: "" }
+          { token: form.token, contact_first_name: "", contact_last_name: "Bloggs" },
+          { token: form.token, contact_first_name: "Joe", contact_last_name: "" },
+          { token: form.token, contact_first_name: "", contact_last_name: "" }
         ]
       end
     end
@@ -40,7 +40,7 @@ module WasteExemptionsEngine
         it "updates the transient registration with the contact name" do
           first_name = "Joe"
           last_name = "Bloggs"
-          valid_params = { token: form.token, first_name: first_name, last_name: last_name }
+          valid_params = { token: form.token, contact_first_name: first_name, contact_last_name: last_name }
           transient_registration = form.transient_registration
 
           expect(transient_registration.contact_first_name).to be_blank

--- a/spec/requests/waste_exemptions_engine/contact_name_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_name_forms_spec.rb
@@ -7,8 +7,8 @@ module WasteExemptionsEngine
     include_examples "GET form", :contact_name_form, "/contact-name"
     include_examples "go back", :contact_name_form, "/contact-name/back"
     include_examples "POST form", :contact_name_form, "/contact-name" do
-      let(:form_data) { { first_name: "Joe", last_name: "Bloggs" } }
-      let(:invalid_form_data) { [{ first_name: nil, last_name: nil }] }
+      let(:form_data) { { contact_first_name: "Joe", contact_last_name: "Bloggs" } }
+      let(:invalid_form_data) { [{ contact_first_name: nil, contact_last_name: nil }] }
     end
 
     context "when editing an existing registration" do
@@ -17,8 +17,8 @@ module WasteExemptionsEngine
       it "pre-fills contact name information" do
         get "/waste_exemptions_engine/contact-name/#{edit_contact_name_form.token}"
 
-        expect(response.body).to have_html_escaped_string(edit_contact_name_form.first_name)
-        expect(response.body).to have_html_escaped_string(edit_contact_name_form.last_name)
+        expect(response.body).to have_html_escaped_string(edit_contact_name_form.contact_first_name)
+        expect(response.body).to have_html_escaped_string(edit_contact_name_form.contact_last_name)
       end
     end
 
@@ -28,8 +28,8 @@ module WasteExemptionsEngine
       it "pre-fills contact name information" do
         get "/waste_exemptions_engine/contact-name/#{renew_contact_name_form.token}"
 
-        expect(response.body).to have_html_escaped_string(renew_contact_name_form.first_name)
-        expect(response.body).to have_html_escaped_string(renew_contact_name_form.last_name)
+        expect(response.body).to have_html_escaped_string(renew_contact_name_form.contact_first_name)
+        expect(response.body).to have_html_escaped_string(renew_contact_name_form.contact_last_name)
       end
     end
   end


### PR DESCRIPTION
In order to take advantage of a delegate approach, we want our attribute names to be consistent with what we define in the models.