### PR TITLE
Forms refactoring - Use helpers to format names

### DIFF
--- a/app/forms/waste_exemptions_engine/data_overview_form.rb
+++ b/app/forms/waste_exemptions_engine/data_overview_form.rb
@@ -10,14 +10,6 @@ module WasteExemptionsEngine
     attr_accessor :on_a_farm, :is_a_farmer, :site_address, :grid_reference, :site_description
     attr_accessor :registration_exemptions, :exemptions
 
-    def applicant_name
-      "#{applicant_first_name} #{applicant_last_name}"
-    end
-
-    def contact_name
-      "#{contact_first_name} #{contact_last_name}"
-    end
-
     # We know this is a long method, but it's just assigning attributes. Breaking
     # it up for the sake of Rubocop would add little benefit, hence the exceptions
     # rubocop:disable Metrics/MethodLength

--- a/app/forms/waste_exemptions_engine/edit_form.rb
+++ b/app/forms/waste_exemptions_engine/edit_form.rb
@@ -23,7 +23,6 @@ module WasteExemptionsEngine
 
     # This form has a lot of attributes, so we have to disable the length cop.
     # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     def initialize(registration)
       registration.save! unless registration.persisted?
 
@@ -51,7 +50,6 @@ module WasteExemptionsEngine
       self.site_address             = @transient_registration.site_address
     end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
 
     def submit(_params)
       # Assign the params for validation and pass them to the BaseForm method for updating

--- a/app/forms/waste_exemptions_engine/edit_form.rb
+++ b/app/forms/waste_exemptions_engine/edit_form.rb
@@ -3,13 +3,13 @@
 module WasteExemptionsEngine
   class EditForm < BaseForm
     attr_accessor :applicant_email
-    attr_accessor :applicant_name
+    attr_accessor :applicant_first_name, :applicant_last_name
     attr_accessor :applicant_phone
     attr_accessor :business_type
     attr_accessor :company_no
     attr_accessor :contact_address
     attr_accessor :contact_email
-    attr_accessor :contact_name
+    attr_accessor :contact_first_name, :contact_last_name
     attr_accessor :contact_phone
     attr_accessor :is_a_farmer
     attr_accessor :location
@@ -30,9 +30,13 @@ module WasteExemptionsEngine
       super
 
       self.applicant_email          = @transient_registration.applicant_email
+      self.applicant_last_name      = @transient_registration.applicant_last_name
+      self.applicant_first_name     = @transient_registration.applicant_first_name
       self.applicant_phone          = @transient_registration.applicant_phone
       self.business_type            = @transient_registration.business_type
       self.company_no               = @transient_registration.company_no
+      self.contact_first_name       = @transient_registration.contact_first_name
+      self.contact_last_name        = @transient_registration.contact_last_name
       self.contact_address          = @transient_registration.contact_address
       self.contact_email            = @transient_registration.contact_email
       self.contact_phone            = @transient_registration.contact_phone
@@ -45,11 +49,6 @@ module WasteExemptionsEngine
       self.reference                = @transient_registration.reference
       self.registration_exemptions  = @transient_registration.registration_exemptions
       self.site_address             = @transient_registration.site_address
-
-      self.applicant_name           = full_name(@transient_registration.applicant_first_name,
-                                                @transient_registration.applicant_last_name)
-      self.contact_name             = full_name(@transient_registration.contact_first_name,
-                                                @transient_registration.contact_last_name)
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
@@ -59,12 +58,6 @@ module WasteExemptionsEngine
       attributes = {}
 
       super(attributes)
-    end
-
-    private
-
-    def full_name(first_name, last_name)
-      "#{first_name} #{last_name}"
     end
   end
 end

--- a/app/helpers/waste_exemptions_engine/application_helper.rb
+++ b/app/helpers/waste_exemptions_engine/application_helper.rb
@@ -9,6 +9,10 @@ module WasteExemptionsEngine
       title_elements.join(" - ")
     end
 
+    def format_names(first_name, last_name)
+      "#{first_name} #{last_name}"
+    end
+
     def current_git_commit
       @current_git_commit ||= begin
         sha =

--- a/app/views/waste_exemptions_engine/edit_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/edit_forms/new.html.erb
@@ -55,7 +55,7 @@
               <%= t(".sections.applicant.labels.applicant_name") %>
             </td>
             <td>
-              <%= @edit_form.applicant_name %>
+              <%= format_names(@edit_form.applicant_first_name, @edit_form.applicant_last_name) %>
             </td>
             <td class="change_link_column">
               <%= link_to applicant_name_edit_forms_path(@edit_form.token) do %>
@@ -188,7 +188,7 @@
               <%= t(".sections.contact.labels.contact_name") %>
             </td>
             <td>
-              <%= @edit_form.contact_name %>
+              <%= format_names(@edit_form.contact_first_name, @edit_form.contact_last_name) %>
             </td>
             <td class="change_link_column">
               <%= link_to contact_name_edit_forms_path(@edit_form.token) do %>

--- a/app/views/waste_exemptions_engine/shared/data_overview/_applicant.html.erb
+++ b/app/views/waste_exemptions_engine/shared/data_overview/_applicant.html.erb
@@ -1,6 +1,6 @@
 <h2 class="heading-medium"><%= t(".subheading") %></h2>
 <ul class="list list-bullet">
-  <li><%= t(".name_html", value: form.applicant_name) %></li>
+  <li><%= t(".name_html", value: format_names(form.applicant_first_name, form.applicant_last_name)) %></li>
   <li><%= t(".phone_html", value: form.applicant_phone) %></li>
   <li><%= t(".email_html", value: form.applicant_email) %></li>
 </ul>

--- a/app/views/waste_exemptions_engine/shared/data_overview/_contact.html.erb
+++ b/app/views/waste_exemptions_engine/shared/data_overview/_contact.html.erb
@@ -1,6 +1,6 @@
 <h2 class="heading-medium"><%= t(".subheading") %></h2>
 <ul class="list list-bullet">
-  <li><%= t(".name_html", value: form.contact_name) %></li>
+  <li><%= t(".name_html", value: format_names(form.contact_first_name, form.contact_last_name)) %></li>
   <% if form.contact_position.present? %>
     <li><%= t(".position_html", value: form.contact_position) %></li>
   <% end %>

--- a/spec/dummy/app/helpers/application_helper.rb
+++ b/spec/dummy/app/helpers/application_helper.rb
@@ -1,2 +1,0 @@
-module ApplicationHelper
-end

--- a/spec/helpers/waste_exemptions_engine/application_helper_spec.rb
+++ b/spec/helpers/waste_exemptions_engine/application_helper_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WasteExemptionsEngine::ApplicationHelper, type: :helper do
+  describe "#format_names" do
+    it "concatenates first and last name into a full name" do
+      expect(helper.format_names("Fiona", "Laurel")).to eq("Fiona Laurel")
+    end
+  end
+end

--- a/spec/helpers/waste_exemptions_engine/application_helper_spec.rb
+++ b/spec/helpers/waste_exemptions_engine/application_helper_spec.rb
@@ -2,10 +2,12 @@
 
 require "rails_helper"
 
-RSpec.describe WasteExemptionsEngine::ApplicationHelper, type: :helper do
-  describe "#format_names" do
-    it "concatenates first and last name into a full name" do
-      expect(helper.format_names("Fiona", "Laurel")).to eq("Fiona Laurel")
+module WasteExemptionsEngine
+  RSpec.describe ApplicationHelper, type: :helper do
+    describe "#format_names" do
+      it "concatenates first and last name into a full name" do
+        expect(helper.format_names("Fiona", "Laurel")).to eq("Fiona Laurel")
+      end
     end
   end
 end


### PR DESCRIPTION
Instead of adding an attr_accessor to the form in order to format data for the view, we have decided to use Helpers.
This replace the form-defined methods with a `format_names` helper method used for applicant and contact names.