### PR TITLE
Forms refactoring - Exemptions form division of responsibilities

### DIFF
--- a/app/forms/waste_exemptions_engine/exemptions_form.rb
+++ b/app/forms/waste_exemptions_engine/exemptions_form.rb
@@ -2,27 +2,20 @@
 
 module WasteExemptionsEngine
   class ExemptionsForm < BaseForm
-    attr_accessor :exemptions, :matched_exemptions, :matched_exemption_ids
+    attr_accessor :exemptions
 
-    validates :matched_exemptions, "waste_exemptions_engine/exemptions": true
+    validates :exemptions, "waste_exemptions_engine/exemptions": true
 
     def initialize(registration)
       super
 
-      # We rely on the fact that db/exemptions.csv is ordered in the way we want
-      # it displayed in the UI, hence its in that order in the database.
-      # This saves any unnecessary logic to try and replicate the ordering we
-      # want, so we simply ensure the order is by ID, i.e. the order the
-      # exemptions were seeded from the file and inserted into the table
-      self.exemptions = Exemption.order(:id)
-      self.matched_exemptions = @transient_registration.exemptions
-      self.matched_exemption_ids = matched_exemptions ? matched_exemptions.map(&:id) : []
+      self.exemptions = @transient_registration.exemptions
     end
 
     def submit(params)
-      self.matched_exemptions = determine_matched_exemptions(params)
+      self.exemptions = determine_matched_exemptions(params)
 
-      super(exemptions: matched_exemptions)
+      super(exemptions: exemptions)
     end
 
     private
@@ -30,7 +23,7 @@ module WasteExemptionsEngine
     def determine_matched_exemptions(params)
       return nil unless params[:exemptions]
 
-      exemptions.select { |ex| params[:exemptions].include?(ex.id.to_s) }
+      Exemption.where(id: params[:exemptions])
     end
   end
 end

--- a/app/helpers/waste_exemptions_engine/exemptions_forms_helper.rb
+++ b/app/helpers/waste_exemptions_engine/exemptions_forms_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module ExemptionsFormsHelper
+    def all_exemptions
+      Exemption.all.order(:id)
+    end
+  end
+end
+

--- a/app/helpers/waste_exemptions_engine/exemptions_forms_helper.rb
+++ b/app/helpers/waste_exemptions_engine/exemptions_forms_helper.rb
@@ -7,4 +7,3 @@ module WasteExemptionsEngine
     end
   end
 end
-

--- a/app/views/waste_exemptions_engine/exemptions_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/exemptions_forms/new.html.erb
@@ -10,8 +10,8 @@
 
     <div class="form-group <%= "form-group-error" if @exemptions_form.errors[:matched_exemptions].any? %>">
       <fieldset id="<%="matched_exemptions"%>">
-        <% if @exemptions_form.errors[:matched_exemptions].any? %>
-          <span class="error-message"><%= @exemptions_form.errors[:matched_exemptions].join(", ") %></span>
+        <% if @exemptions_form.errors[:exemptions].any? %>
+          <span class="error-message"><%= @exemptions_form.errors[:exemptions].join(", ") %></span>
         <% end %>
 
         <table role="presentation">
@@ -22,11 +22,11 @@
           </tr>
           </thead>
           <tbody>
-            <% @exemptions_form.exemptions.each do |exemption|  %>
+            <% all_exemptions.each do |exemption|  %>
               <tr>
                 <td>
                   <div class="multiple-choice">
-                    <%= f.check_box :exemptions, { :multiple => true, id: "exemptions_form_checkbox-#{exemption.code}", checked: @exemptions_form.matched_exemption_ids.include?(exemption.id) }, exemption.id, nil %>
+                    <%= f.check_box :exemptions, { :multiple => true, id: "exemptions_form_checkbox-#{exemption.code}", checked: @exemptions_form.exemptions&.include?(exemption) }, exemption.id, nil %>
                     <%= f.label "checkbox-#{exemption.code}" do %>
                       <%= exemption.code %><span class="visually-hidden"> <%= exemption.summary %></span>
                     <% end %>

--- a/config/locales/forms/exemptions_forms/en.yml
+++ b/config/locales/forms/exemptions_forms/en.yml
@@ -14,7 +14,7 @@ en:
       models:
         waste_exemptions_engine/exemptions_form:
           attributes:
-            matched_exemptions:
+            exemptions:
               inclusion: "You must select at least one exemption"
             token:
               invalid_format: "The token is not valid"

--- a/spec/forms/waste_exemptions_engine/exemptions_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/exemptions_form_spec.rb
@@ -16,8 +16,8 @@ module WasteExemptionsEngine
 
     it "validates the matched exemptions using the ExemptionsValidator class" do
       validators = form._validators
-      expect(validators.keys).to include(:matched_exemptions)
-      expect(validators[:matched_exemptions].first.class)
+      expect(validators.keys).to include(:exemptions)
+      expect(validators[:exemptions].first.class)
         .to eq(WasteExemptionsEngine::ExemptionsValidator)
     end
 

--- a/spec/helpers/waste_exemptions_engine/exemptions_forms_helper_spec.rb
+++ b/spec/helpers/waste_exemptions_engine/exemptions_forms_helper_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe ExemptionsFormsHelper, type: :helper do
+    describe "#all_exemptions" do
+      it "returns a list of all exemptions ordered by ID" do
+        exemptions = create_list(:exemption, 3)
+        expect(helper.all_exemptions).to eq(exemptions)
+      end
+    end
+  end
+end

--- a/spec/requests/waste_exemptions_engine/exemptions_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/exemptions_forms_spec.rb
@@ -12,7 +12,7 @@ module WasteExemptionsEngine
     include_examples "GET form", :exemptions_form, "/exemptions"
     include_examples "go back", :exemptions_form, "/exemptions/back"
     include_examples "POST form", :exemptions_form, "/exemptions" do
-      let(:form_data) { { exemptions: Exemption.all.map(&:id).map(&:to_s) } }
+      let(:form_data) { { exemptions: Exemption.limit(5).pluck(:id).map(&:to_s) } }
       let(:invalid_form_data) { [{ exemptions: [] }] }
     end
   end


### PR DESCRIPTION
Leave to the view what belongs to the view and to the form what belongs to the form :D

This change remove the list of exemptions being assigned to the form using the attribute name that is suppose to return the transient registration exemptions. It instead uses it as the real list of exemptions that are part of a registration or assign to them the registration ticked in the form itself. An helper is instead responsible to fetch the list of all exemptions for the view to show.