### PR TITLE
Rename start to start_option in the StartForm

### DIFF
--- a/app/forms/waste_exemptions_engine/start_form.rb
+++ b/app/forms/waste_exemptions_engine/start_form.rb
@@ -2,19 +2,19 @@
 
 module WasteExemptionsEngine
   class StartForm < BaseForm
-    attr_accessor :start
+    attr_accessor :start_option
 
-    validates :start, "waste_exemptions_engine/start": true
+    validates :start_option, "waste_exemptions_engine/start": true
 
     def initialize(registration)
       super
-      self.start = @transient_registration.start_option
+      self.start_option = @transient_registration.start_option
     end
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.start = params[:start]
-      attributes = { start_option: start }
+      self.start_option = params[:start_option]
+      attributes = { start_option: start_option }
 
       super(attributes)
     end

--- a/app/views/waste_exemptions_engine/start_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/start_forms/new.html.erb
@@ -5,26 +5,26 @@
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
     <div class="form-group <%= "form-group-error" if @start_form.errors[:start].any? %>">
-      <fieldset id="start">
+      <fieldset id="start_option">
         <legend class="visuallyhidden">
           <%= t(".heading") %>
         </legend>
 
-        <% if @start_form.errors[:start].any? %>
-          <span class="error-message"><%= @start_form.errors[:start].join(", ") %></span>
+        <% if @start_form.errors[:start_option].any? %>
+          <span class="error-message"><%= @start_form.errors[:start_option].join(", ") %></span>
         <% end %>
 
         <div class="multiple-choice">
-          <%= f.radio_button :start, 'new' %>
-          <%= f.label :start, t(".options.new"), value: 'new' %>
+          <%= f.radio_button :start_option, 'new' %>
+          <%= f.label :start_option, t(".options.new"), value: 'new' %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :start, 'reregister' %>
-          <%= f.label :start, t(".options.reregister"), value: 'reregister' %>
+          <%= f.radio_button :start_option, 'reregister' %>
+          <%= f.label :start_option, t(".options.reregister"), value: 'reregister' %>
         </div>
         <div class="multiple-choice">
-          <%= f.radio_button :start, 'change' %>
-          <%= f.label :start, t(".options.change"), value: 'change' %>
+          <%= f.radio_button :start_option, 'change' %>
+          <%= f.label :start_option, t(".options.change"), value: 'change' %>
         </div>
       </fieldset>
     </div>

--- a/config/locales/forms/start_forms/en.yml
+++ b/config/locales/forms/start_forms/en.yml
@@ -14,7 +14,7 @@ en:
       models:
         waste_exemptions_engine/start_form:
           attributes:
-            start:
+            start_option:
               inclusion: "You must answer this question"
             token:
               invalid_format: "The token is not valid"

--- a/spec/forms/waste_exemptions_engine/start_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/start_form_spec.rb
@@ -12,17 +12,17 @@ module WasteExemptionsEngine
 
     it "validates the start option using the StartValidator class" do
       validators = form._validators
-      expect(validators.keys).to include(:start)
-      expect(validators[:start].first.class)
+      expect(validators.keys).to include(:start_option)
+      expect(validators[:start_option].first.class)
         .to eq(WasteExemptionsEngine::StartValidator)
     end
 
     it_behaves_like "a validated form", :start_form do
-      let(:valid_params) { { token: form.token, start: START_OPTIONS.sample } }
+      let(:valid_params) { { token: form.token, start_option: START_OPTIONS.sample } }
       let(:invalid_params) do
         [
-          { token: form.token, start: "foo" },
-          { token: form.token, start: "" }
+          { token: form.token, start_option: "foo" },
+          { token: form.token, start_option: "" }
         ]
       end
     end
@@ -31,7 +31,7 @@ module WasteExemptionsEngine
       context "when the form is valid" do
         it "updates the transient registration with the selected start option" do
           start_option = START_OPTIONS.sample
-          valid_params = { token: form.token, start: start_option }
+          valid_params = { token: form.token, start_option: start_option }
           transient_registration = form.transient_registration
 
           expect(transient_registration.start_option).to be_blank

--- a/spec/requests/waste_exemptions_engine/start_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/start_forms_spec.rb
@@ -27,7 +27,7 @@ module WasteExemptionsEngine
 
     describe "POST start_form" do
       let(:request_path) { "/waste_exemptions_engine/start/" }
-      let(:request_body) { { start_form: { token: form.token, start: "new" } } }
+      let(:request_body) { { start_form: { token: form.token, start_option: "new" } } }
       status_code = WasteExemptionsEngine::ApplicationController::SUCCESSFUL_REDIRECTION_CODE
 
       # A successful POST request redirects to the next form in the work flow. We have chosen to


### PR DESCRIPTION
As part of the form refactoring, this rename the form `start` attribute to `start_option`, in line with the transient_registration attribute name.