### PR TITLE
Prevent random failure of scenario

### DIFF
--- a/spec/helpers/waste_exemptions_engine/exemptions_forms_helper_spec.rb
+++ b/spec/helpers/waste_exemptions_engine/exemptions_forms_helper_spec.rb
@@ -6,6 +6,10 @@ module WasteExemptionsEngine
   RSpec.describe ExemptionsFormsHelper, type: :helper do
     describe "#all_exemptions" do
       it "returns a list of all exemptions ordered by ID" do
+        # FIXME: There are still tests leaving the DB dirty with exemptions.
+        # This line will prevent random failure of this scenario
+        WasteExemptionsEngine::Exemption.delete_all
+
         exemptions = create_list(:exemption, 3)
         expect(helper.all_exemptions).to eq(exemptions)
       end


### PR DESCRIPTION
I have observed that we randomly fail the scenario subject of this PR because the DB is in a dirty status.

Example: https://travis-ci.com/DEFRA/waste-exemptions-engine/builds/125219718