### PR TITLE
Postcode form - Postcode validator

### DIFF
--- a/app/forms/waste_exemptions_engine/postcode_form.rb
+++ b/app/forms/waste_exemptions_engine/postcode_form.rb
@@ -27,16 +27,17 @@ module WasteExemptionsEngine
       super({})
     end
 
-    def address_finder_error(error_occurred)
-      transient_registration.address_finder_error = error_occurred
+    def address_finder_errored!
+      # Used in the postcode validator to set the parameter.
+      # This is then saved in the `#submit` and used by AASM to decide
+      # what is the next valid status for the user.
+      transient_registration.address_finder_error = true
     end
 
     private
 
     def format_postcode(postcode)
-      return unless postcode.present?
-
-      postcode.upcase.strip
+      postcode&.upcase&.strip
     end
 
     # We use this to work out what the temp field name will be in the model.

--- a/app/validators/waste_exemptions_engine/postcode_validator.rb
+++ b/app/validators/waste_exemptions_engine/postcode_validator.rb
@@ -34,10 +34,9 @@ module WasteExemptionsEngine
         record.errors[attribute] << error_message(record, attribute, "no_results")
         false
       when :error
-        record.address_finder_error(true) if record.respond_to? :address_finder_error
+        record.address_finder_errored!
         true
       else
-        record.address_finder_error(false) if record.respond_to? :address_finder_error
         true
       end
     end

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/site_grid_reference_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/site_grid_reference_form_spec.rb
@@ -14,8 +14,6 @@ module WasteExemptionsEngine
           next_state = :check_your_answers_form
           alt_state = :site_postcode_form
 
-          before(:each) { new_registration.address_finder_error = false }
-
           it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
             permitted_states = Helpers::WorkflowStates.permitted_states(new_registration)
             expect(permitted_states).to match_array([previous_state, next_state, alt_state])

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_grid_reference_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/site_grid_reference_form_spec.rb
@@ -14,8 +14,6 @@ module WasteExemptionsEngine
           next_state = :check_your_answers_form
           alt_state = :site_postcode_form
 
-          before(:each) { renewing_registration.address_finder_error = false }
-
           it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
             permitted_states = Helpers::WorkflowStates.permitted_states(renewing_registration)
             expect(permitted_states).to match_array([previous_state, next_state, alt_state])

--- a/spec/support/shared_examples/models/transient_registration_workflow_state/a_postcode_transition.rb
+++ b/spec/support/shared_examples/models/transient_registration_workflow_state/a_postcode_transition.rb
@@ -9,8 +9,6 @@ RSpec.shared_examples "a postcode transition" do |previous_state:, address_type:
       next_state = "#{address_type}_address_lookup_form".to_sym
       alt_state = "#{address_type}_address_manual_form".to_sym
 
-      before(:each) { subject.address_finder_error = false }
-
       it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
         permitted_states = Helpers::WorkflowStates.permitted_states(subject)
         expect(permitted_states).to match_array([previous_state, next_state, alt_state])

--- a/spec/support/shared_examples/models/transient_registration_workflow_state/an_address_lookup_transition.rb
+++ b/spec/support/shared_examples/models/transient_registration_workflow_state/an_address_lookup_transition.rb
@@ -10,8 +10,6 @@ RSpec.shared_examples "an address lookup transition" do |next_state_if_not_skipp
       next_state = next_state_if_not_skipping_to_manual
       alt_state = "#{address_type}_address_manual_form".to_sym
 
-      before(:each) { subject.address_finder_error = false }
-
       it "can only transition to either #{previous_state}, #{next_state}, or #{alt_state}" do
         permitted_states = Helpers::WorkflowStates.permitted_states(subject)
         expect(permitted_states).to match_array([previous_state, next_state, alt_state])


### PR DESCRIPTION
The `address_finder_error` attribute on the transient registration is used by the aasm machine to decide were to redirect the user.
Since the value has a default value of `false`, is only relevant to update it when we are updating the value to `true`.