### PR TITLE
Do not save value of :address_finder_error at initialize

### DIFF
--- a/app/forms/waste_exemptions_engine/address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/address_manual_form.rb
@@ -16,8 +16,7 @@ module WasteExemptionsEngine
 
       # Check if the user reached this page through an Address finder error.
       # Then wipe the temp attribute as we only need it for routing
-      self.address_finder_error = @transient_registration.address_finder_error
-      @transient_registration.update_attributes(address_finder_error: nil)
+      @transient_registration.update_attributes(address_finder_error: false)
 
       # Prefill the existing address unless the postcode has changed from the existing address's postcode
       prefill_existing_address if saved_address_still_valid?


### PR DESCRIPTION
The main reason why I am removing this, is because I believe it makes no difference to the user experience.
I could not find any issue caused by this removal and so I am opening a separate PR for this change so we can decide if we can remove it or not. I miss some history :D