### PR TITLE
Add transient addresses has_one associations to TransientRegistration

### DIFF
--- a/app/models/waste_exemptions_engine/transient_registration.rb
+++ b/app/models/waste_exemptions_engine/transient_registration.rb
@@ -17,6 +17,15 @@ module WasteExemptionsEngine
     validates_presence_of :token, on: :save
 
     has_many :transient_addresses, dependent: :destroy
+
+    # In this case, we have to pass the correct enum value, as `enum` will not generate the right query in this case.
+    has_one :transient_site_address, -> { where(address_type: 3) }, class_name: "TransientAddress"
+    has_one :transient_contact_address, -> { where(address_type: 2) }, class_name: "TransientAddress"
+    has_one :transient_operator_address, -> { where(address_type: 1) }, class_name: "TransientAddress"
+    accepts_nested_attributes_for :transient_site_address
+    accepts_nested_attributes_for :transient_contact_address
+    accepts_nested_attributes_for :transient_operator_address
+
     has_many :transient_people, dependent: :destroy
     has_many :transient_registration_exemptions, dependent: :destroy
     has_many :exemptions, through: :transient_registration_exemptions

--- a/spec/factories/edit_registration.rb
+++ b/spec/factories/edit_registration.rb
@@ -49,6 +49,16 @@ FactoryBot.define do
       end
     end
 
+    trait :with_all_addresses do
+      addresses do
+        [
+          build(:transient_address, :operator_address, :manual),
+          build(:transient_address, :contact_address, :manual),
+          build(:transient_address, :site_address, :manual)
+        ]
+      end
+    end
+
     trait :modified_people do
       after(:build) do |edit_registration|
         edit_registration.people.each do |person|

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -38,8 +38,19 @@ FactoryBot.define do
       company_no { "09360070" }
     end
 
+    trait :with_all_addresses do
+      addresses do
+        [
+          build(:transient_address, :operator_address, :manual),
+          build(:transient_address, :contact_address, :manual),
+          build(:transient_address, :site_address, :manual)
+        ]
+      end
+    end
+
     trait :complete do
       limited_company
+      with_all_addresses
 
       location { "england" }
       applicant_first_name { Faker::Name.first_name }
@@ -56,14 +67,6 @@ FactoryBot.define do
       on_a_farm { true }
       is_a_farmer { true }
       exemptions { WasteExemptionsEngine::Exemption.all }
-
-      addresses do
-        [
-          build(:transient_address, :operator_address, :manual),
-          build(:transient_address, :contact_address, :manual),
-          build(:transient_address, :site_address, :manual)
-        ]
-      end
     end
   end
 end

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -15,6 +15,16 @@ FactoryBot.define do
       end
     end
 
+    trait :with_all_addresses do
+      addresses do
+        [
+          build(:transient_address, :operator_address, :manual),
+          build(:transient_address, :contact_address, :manual),
+          build(:transient_address, :site_address, :manual)
+        ]
+      end
+    end
+
     factory :renewing_registration_without_changes do
       temp_renew_without_changes { true }
     end

--- a/spec/support/shared_examples/models/transient_registration.rb
+++ b/spec/support/shared_examples/models/transient_registration.rb
@@ -11,6 +11,28 @@ RSpec.shared_examples "a transient_registration" do |model_factory|
     end
   end
 
+  describe "associations" do
+    subject(:transient_registration) { create(model_factory, :with_all_addresses) }
+
+    describe "#transient_site_address" do
+      it "returns an TransientAddress of type :site" do
+        expect(transient_registration.transient_site_address).to eq(transient_registration.site_address)
+      end
+    end
+
+    describe "#transient_operator_address" do
+      it "returns an TransientAddress of type :operator" do
+        expect(transient_registration.transient_operator_address).to eq(transient_registration.operator_address)
+      end
+    end
+
+    describe "#transient_contact_address" do
+      it "returns an TransientAddress of type :contact" do
+        expect(transient_registration.transient_contact_address).to eq(transient_registration.contact_address)
+      end
+    end
+  end
+
   describe "#token" do
     context "when a transient registration is created" do
       it "has a token" do


### PR DESCRIPTION
With this little trick, we don't have to worry any more about stuff like "Can add or replace an address" as we have the ability to manipulate the transient addresses separate.
It does also make more sense logically and makes the form nested attribute implementation much easier.

The code using this is part of a bigger PR that will land later. 