### PR TITLE
Use rails associations to define associations with the addresses

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_have_registration_attributes.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_have_registration_attributes.rb
@@ -22,25 +22,5 @@ module WasteExemptionsEngine
     def partnership?
       BUSINESS_TYPES[:partnership] == business_type
     end
-
-    def operator_address
-      find_address_by_type("operator")
-    end
-
-    def contact_address
-      find_address_by_type("contact")
-    end
-
-    def site_address
-      find_address_by_type("site")
-    end
-
-    private
-
-    def find_address_by_type(address_type)
-      return nil unless addresses.present?
-
-      addresses.select { |a| a.address_type == address_type }.first
-    end
   end
 end

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -27,6 +27,14 @@ module WasteExemptionsEngine
     belongs_to :referring_registration, class_name: "Registration"
     has_one :referred_registration, class_name: "Registration", foreign_key: "referring_registration_id"
 
+    # In this case, we have to pass the correct enum value, as `enum` will not generate the right query in this case.
+    has_one :site_address, -> { where(address_type: 3) }, class_name: "Address"
+    has_one :contact_address, -> { where(address_type: 2) }, class_name: "Address"
+    has_one :operator_address, -> { where(address_type: 1) }, class_name: "Address"
+    accepts_nested_attributes_for :site_address
+    accepts_nested_attributes_for :contact_address
+    accepts_nested_attributes_for :operator_address
+
     after_create :apply_reference
 
     has_secure_token :renew_token

--- a/app/models/waste_exemptions_engine/transient_registration.rb
+++ b/app/models/waste_exemptions_engine/transient_registration.rb
@@ -19,12 +19,12 @@ module WasteExemptionsEngine
     has_many :transient_addresses, dependent: :destroy
 
     # In this case, we have to pass the correct enum value, as `enum` will not generate the right query in this case.
-    has_one :transient_site_address, -> { where(address_type: 3) }, class_name: "TransientAddress"
-    has_one :transient_contact_address, -> { where(address_type: 2) }, class_name: "TransientAddress"
-    has_one :transient_operator_address, -> { where(address_type: 1) }, class_name: "TransientAddress"
-    accepts_nested_attributes_for :transient_site_address
-    accepts_nested_attributes_for :transient_contact_address
-    accepts_nested_attributes_for :transient_operator_address
+    has_one :site_address, -> { where(address_type: 3) }, class_name: "TransientAddress"
+    has_one :contact_address, -> { where(address_type: 2) }, class_name: "TransientAddress"
+    has_one :operator_address, -> { where(address_type: 1) }, class_name: "TransientAddress"
+    accepts_nested_attributes_for :site_address
+    accepts_nested_attributes_for :contact_address
+    accepts_nested_attributes_for :operator_address
 
     has_many :transient_people, dependent: :destroy
     has_many :transient_registration_exemptions, dependent: :destroy

--- a/spec/factories/edit_registration.rb
+++ b/spec/factories/edit_registration.rb
@@ -16,7 +16,6 @@ FactoryBot.define do
     trait :modified do
       after(:build) do |edit_registration|
         registration = edit_registration.registration
-        # binding.pry
         # Update string attributes
         (Helpers::ModelProperties::REGISTRATION - %i[is_a_farmer on_a_farm reference submitted_at]).each do |attribute|
           old_value = registration[attribute]

--- a/spec/factories/edit_registration.rb
+++ b/spec/factories/edit_registration.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     trait :modified do
       after(:build) do |edit_registration|
         registration = edit_registration.registration
-
+        # binding.pry
         # Update string attributes
         (Helpers::ModelProperties::REGISTRATION - %i[is_a_farmer on_a_farm reference submitted_at]).each do |attribute|
           old_value = registration[attribute]
@@ -45,6 +45,8 @@ FactoryBot.define do
             # Append 'foo' to the end of all string attributes
             address[key] = "#{value}foo" if value.is_a?(String)
           end
+
+          address.save if address.persisted?
         end
       end
     end

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -220,8 +220,8 @@ module WasteExemptionsEngine
         it "includes related addresses in the JSON" do
           street_address = Faker::Address.street_address
 
-          registration.contact_address.street_address = street_address
-          registration.paper_trail.save_with_version
+          registration.contact_address.update_attributes(street_address: street_address)
+          registration.reload.paper_trail.save_with_version
 
           expect(registration.versions.last.json.to_s).to include(street_address)
         end
@@ -229,7 +229,7 @@ module WasteExemptionsEngine
         it "includes related people in the JSON" do
           first_name = Faker::Name.first_name
 
-          registration.people.first.first_name = first_name
+          registration.people.first.update_attributes(first_name: first_name)
           registration.paper_trail.save_with_version
 
           expect(registration.versions.last.json.to_s).to include(first_name)
@@ -238,7 +238,7 @@ module WasteExemptionsEngine
         it "includes related registration_exemptions in the JSON" do
           expected_message = Faker::Lorem.sentence
 
-          registration.registration_exemptions.first.deregistration_message = expected_message
+          registration.registration_exemptions.first.update_attributes(deregistration_message: expected_message)
           registration.paper_trail.save_with_version
 
           expect(registration.versions.last.json.to_s).to include(expected_message)

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -16,6 +16,31 @@ module WasteExemptionsEngine
 
     it_behaves_like "an owner of registration attributes", :registration, :address
 
+    describe "associations" do
+      subject(:registration) { create(:registration, :complete) }
+
+      describe "#site_address" do
+        it "returns an Address of type :site" do
+          site_address = registration.addresses.find_by(address_type: 3)
+          expect(registration.site_address).to eq(site_address)
+        end
+      end
+
+      describe "#operator_address" do
+        it "returns an Address of type :operator" do
+          operator_address = registration.addresses.find_by(address_type: 1)
+          expect(registration.operator_address).to eq(operator_address)
+        end
+      end
+
+      describe "#contact_address" do
+        it "returns an Address of type :contact" do
+          contact_address = registration.addresses.find_by(address_type: 2)
+          expect(registration.contact_address).to eq(contact_address)
+        end
+      end
+    end
+
     describe "#renewal?" do
       subject(:registration) { create(:registration) }
 

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -221,7 +221,7 @@ module WasteExemptionsEngine
           street_address = Faker::Address.street_address
 
           registration.contact_address.update_attributes(street_address: street_address)
-          registration.paper_trail.save_with_version
+          registration.reload.paper_trail.save_with_version
 
           expect(registration.versions.last.json.to_s).to include(street_address)
         end

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -221,7 +221,7 @@ module WasteExemptionsEngine
           street_address = Faker::Address.street_address
 
           registration.contact_address.update_attributes(street_address: street_address)
-          registration.reload.paper_trail.save_with_version
+          registration.paper_trail.save_with_version
 
           expect(registration.versions.last.json.to_s).to include(street_address)
         end

--- a/spec/support/shared_examples/models/owner_of_registration_attributes.rb
+++ b/spec/support/shared_examples/models/owner_of_registration_attributes.rb
@@ -49,22 +49,4 @@ RSpec.shared_examples "an owner of registration attributes" do |model_factory, a
 
     end
   end
-
-  describe "#operator_address" do
-    it "returns the operator address" do
-      expect(instance.operator_address).to eq(operator_address)
-    end
-  end
-
-  describe "#contact_address" do
-    it "returns the contact address" do
-      expect(instance.contact_address).to eq(contact_address)
-    end
-  end
-
-  describe "#site_address" do
-    it "returns the site address" do
-      expect(instance.site_address).to eq(site_address)
-    end
-  end
 end

--- a/spec/support/shared_examples/models/transient_registration.rb
+++ b/spec/support/shared_examples/models/transient_registration.rb
@@ -14,21 +14,24 @@ RSpec.shared_examples "a transient_registration" do |model_factory|
   describe "associations" do
     subject(:transient_registration) { create(model_factory, :with_all_addresses) }
 
-    describe "#transient_site_address" do
+    describe "#site_address" do
       it "returns an TransientAddress of type :site" do
-        expect(transient_registration.transient_site_address).to eq(transient_registration.site_address)
+        site_address = transient_registration.addresses.find_by(address_type: :site)
+        expect(transient_registration.site_address).to eq(site_address)
       end
     end
 
-    describe "#transient_operator_address" do
+    describe "#operator_address" do
       it "returns an TransientAddress of type :operator" do
-        expect(transient_registration.transient_operator_address).to eq(transient_registration.operator_address)
+        operator_address = transient_registration.addresses.find_by(address_type: :operator)
+        expect(transient_registration.operator_address).to eq(operator_address)
       end
     end
 
-    describe "#transient_contact_address" do
+    describe "#contact_address" do
       it "returns an TransientAddress of type :contact" do
-        expect(transient_registration.transient_contact_address).to eq(transient_registration.contact_address)
+        contact_address = transient_registration.addresses.find_by(address_type: :contact)
+        expect(transient_registration.contact_address).to eq(contact_address)
       end
     end
   end

--- a/spec/support/shared_examples/models/transient_registration.rb
+++ b/spec/support/shared_examples/models/transient_registration.rb
@@ -16,21 +16,21 @@ RSpec.shared_examples "a transient_registration" do |model_factory|
 
     describe "#site_address" do
       it "returns an TransientAddress of type :site" do
-        site_address = transient_registration.addresses.find_by(address_type: :site)
+        site_address = transient_registration.addresses.find_by(address_type: 3)
         expect(transient_registration.site_address).to eq(site_address)
       end
     end
 
     describe "#operator_address" do
       it "returns an TransientAddress of type :operator" do
-        operator_address = transient_registration.addresses.find_by(address_type: :operator)
+        operator_address = transient_registration.addresses.find_by(address_type: 1)
         expect(transient_registration.operator_address).to eq(operator_address)
       end
     end
 
     describe "#contact_address" do
       it "returns an TransientAddress of type :contact" do
-        contact_address = transient_registration.addresses.find_by(address_type: :contact)
+        contact_address = transient_registration.addresses.find_by(address_type: 2)
         expect(transient_registration.contact_address).to eq(contact_address)
       end
     end


### PR DESCRIPTION
In both the Registration and Transient registration we are implementing Rails association in order to associate those registration with the correct addresses.
We have decided that the name of the methods should be the same for bot Transient registration and non transient registration.
This allow for us to be able to easely reuse the same code on the 2 kind of object, and at the same time gives us the ability to edit and update the addresses on those registration without having to deal with the addresses array association complication.