### PR TITLE
Identify EA Administrative Area for new regs.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     waste_exemptions_engine (0.0.1)
       aasm (~> 4.12)
+      defra_ruby_area
       defra_ruby_validators
       has_secure_token
       high_voltage (~> 3.1)
@@ -72,6 +73,9 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
     database_cleaner (1.7.0)
+    defra_ruby_area (2.0.0)
+      nokogiri (~> 1.10.4)
+      rest-client (~> 2.0)
     defra_ruby_style (0.1.2)
       rubocop
     defra_ruby_validators (2.1.2)
@@ -128,9 +132,9 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2019.0904)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     waste_exemptions_engine (0.0.1)
       aasm (~> 4.12)
+      airbrake (= 5.8.1)
       defra_ruby_area
       defra_ruby_validators
       has_secure_token
@@ -60,6 +61,9 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     afm (0.2.2)
+    airbrake (5.8.1)
+      airbrake-ruby (~> 1.8)
+    airbrake-ruby (1.8.0)
     arel (6.0.4)
     ast (2.4.0)
     builder (3.2.3)

--- a/app/models/waste_exemptions_engine/transient_address.rb
+++ b/app/models/waste_exemptions_engine/transient_address.rb
@@ -23,22 +23,25 @@ module WasteExemptionsEngine
       data["x"] = data["x"].to_f
       data["y"] = data["y"].to_f
 
-      data = update_grid_reference_from_xy(data) if address_type == TransientAddress.address_types[:site]
+      if address_type == TransientAddress.address_types[:site]
+        data = add_site_details(data, TransientAddress.modes[:lookup])
+      end
 
       create_address(data, address_type, TransientAddress.modes[:lookup])
     end
 
     def self.create_from_manual_entry_data(data, address_type)
       if address_type == TransientAddress.address_types[:site]
-        data = update_xy_from_postcode(data)
-        data = update_grid_reference_from_xy(data)
+        data = add_site_details(data, TransientAddress.modes[:manual])
       end
 
       create_address(data, address_type, TransientAddress.modes[:manual])
     end
 
     def self.create_from_grid_reference_data(data, address_type)
-      data = update_xy_from_grid_reference(data)
+      if address_type == TransientAddress.address_types[:site]
+        data = add_site_details(data, TransientAddress.modes[:auto])
+      end
 
       create_address(data, address_type, TransientAddress.modes[:auto])
     end
@@ -48,6 +51,20 @@ module WasteExemptionsEngine
       data["mode"] = mode
 
       TransientAddress.create(data)
+    end
+
+    private_class_method def self.add_site_details(data, mode)
+      # Add x & y dependent on how the site was entered
+      data = update_xy_from_grid_reference(data) if mode == TransientAddress.modes[:auto]
+      data = update_xy_from_postcode(data) if mode == TransientAddress.modes[:manual]
+
+      # Add the grid reference for sites entered using an address
+      data = update_grid_reference_from_xy(data) unless mode == TransientAddress.modes[:auto]
+
+      # Add the EA administrative area
+      data = update_area_from_xy(data)
+
+      data
     end
 
     private_class_method def self.update_xy_from_postcode(data)
@@ -90,6 +107,15 @@ module WasteExemptionsEngine
       rescue OsMapRef::Error
         data["grid_reference"] = nil
       end
+
+      data
+    end
+
+    private_class_method def self.update_area_from_xy(data)
+      return nil unless data
+      return if data["x"].nil? || data["y"].nil?
+
+      data["area"] = AreaLookupService.run(easting: data["x"], northing: data["y"])
 
       data
     end

--- a/app/models/waste_exemptions_engine/transient_address.rb
+++ b/app/models/waste_exemptions_engine/transient_address.rb
@@ -112,8 +112,8 @@ module WasteExemptionsEngine
     end
 
     private_class_method def self.update_area_from_xy(data)
-      return nil unless data
-      return if data["x"].nil? || data["y"].nil?
+      return data unless data
+      return data if data["x"].nil? || data["y"].nil?
 
       data["area"] = AreaLookupService.run(easting: data["x"], northing: data["y"])
 

--- a/app/services/waste_exemptions_engine/area_lookup_service.rb
+++ b/app/services/waste_exemptions_engine/area_lookup_service.rb
@@ -31,7 +31,7 @@ module WasteExemptionsEngine
 
     def handle_error(error)
       Airbrake.notify(error, easting: @easting, northing: @northing) if defined? Airbrake
-      Rails.logger.error "Area lookup failed: #{error}"
+      Rails.logger.error "Area lookup failed:\n #{error}"
     end
 
   end

--- a/app/services/waste_exemptions_engine/area_lookup_service.rb
+++ b/app/services/waste_exemptions_engine/area_lookup_service.rb
@@ -8,9 +8,19 @@ module WasteExemptionsEngine
 
       return unless valid_arguments?
 
+      lookup_area
     end
 
     private
+
+    def lookup_area
+      response = DefraRuby::Area::PublicFaceAreaService.run(@easting, @northing)
+
+      return response.areas.first.long_name if response.successful?
+      return "Outside England" if response.error.instance_of?(DefraRuby::Area::NoMatchError)
+
+      nil
+    end
 
     def valid_arguments?
       return false unless @easting.is_a?(Numeric) && @northing.is_a?(Numeric)

--- a/app/services/waste_exemptions_engine/area_lookup_service.rb
+++ b/app/services/waste_exemptions_engine/area_lookup_service.rb
@@ -19,6 +19,7 @@ module WasteExemptionsEngine
       return response.areas.first.long_name if response.successful?
       return "Outside England" if response.error.instance_of?(DefraRuby::Area::NoMatchError)
 
+      handle_error(response.error)
       nil
     end
 
@@ -27,5 +28,11 @@ module WasteExemptionsEngine
 
       true
     end
+
+    def handle_error(error)
+      Airbrake.notify(error, easting: @easting, northing: @northing) if defined? Airbrake
+      Rails.logger.error "Area lookup failed: #{error}"
+    end
+
   end
 end

--- a/app/services/waste_exemptions_engine/area_lookup_service.rb
+++ b/app/services/waste_exemptions_engine/area_lookup_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class AreaLookupService < BaseService
+    def run(easting:, northing:)
+      @easting = easting
+      @northing = northing
+
+      return unless valid_arguments?
+
+    end
+
+    private
+
+    def valid_arguments?
+      return false unless @easting.is_a?(Numeric) && @northing.is_a?(Numeric)
+
+      true
+    end
+  end
+end

--- a/lib/waste_exemptions_engine/engine.rb
+++ b/lib/waste_exemptions_engine/engine.rb
@@ -5,6 +5,7 @@ require "has_secure_token"
 require "high_voltage"
 require "paper_trail"
 require "defra_ruby_validators"
+require "defra_ruby/area"
 require "wicked_pdf"
 
 module WasteExemptionsEngine

--- a/spec/cassettes/site_address_auto_x_and_y_and_area.yml
+++ b/spec/cassettes/site_address_auto_x_and_y_and_area.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 20 Sep 2019 08:28:43 GMT
+      - Sun, 22 Sep 2019 20:48:45 GMT
       Content-Type:
       - application/json
       Vary:
@@ -38,7 +38,66 @@ http_interactions:
         PLC","premises":null,"street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
         5AH","x":"358130.1","y":"172687.87","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"}]}'
     http_version: 
-  recorded_at: Fri, 20 Sep 2019 08:28:43 GMT
+  recorded_at: Sun, 22 Sep 2019 20:48:45 GMT
+- request:
+    method: get
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E358205.03,172708.07%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - environment.data.gov.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 22 Sep 2019 20:48:46 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1679'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8" ?>
+        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+        <gml:boundedBy>
+          <gml:Box srsName="EPSG:27700">
+            <gml:coordinates>0,0,0,0</gml:coordinates>
+          </gml:Box>
+        </gml:boundedBy>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas fid="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.15">
+              <ms:OBJECTID>15</ms:OBJECTID>
+              <ms:long_name>Wessex</ms:long_name>
+              <ms:short_name>Wessex</ms:short_name>
+              <ms:code>WSX</ms:code>
+              <ms:st_area_shape_>11208105093.65494</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>903122.4501194651</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
+          </gml:featureMember>
+        </wfs:FeatureCollection>
+    http_version: 
+  recorded_at: Sun, 22 Sep 2019 20:48:46 GMT
 - request:
     method: get
     uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
@@ -60,7 +119,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 20 Sep 2019 08:28:43 GMT
+      - Sun, 22 Sep 2019 20:48:46 GMT
       Content-Type:
       - application/json
       Vary:
@@ -77,7 +136,66 @@ http_interactions:
         PLC","premises":null,"street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
         5AH","x":"358130.1","y":"172687.87","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"}]}'
     http_version: 
-  recorded_at: Fri, 20 Sep 2019 08:28:43 GMT
+  recorded_at: Sun, 22 Sep 2019 20:48:46 GMT
+- request:
+    method: get
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E358205.03,172708.07%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - environment.data.gov.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 22 Sep 2019 20:48:47 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1679'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8" ?>
+        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+        <gml:boundedBy>
+          <gml:Box srsName="EPSG:27700">
+            <gml:coordinates>0,0,0,0</gml:coordinates>
+          </gml:Box>
+        </gml:boundedBy>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas fid="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.15">
+              <ms:OBJECTID>15</ms:OBJECTID>
+              <ms:long_name>Wessex</ms:long_name>
+              <ms:short_name>Wessex</ms:short_name>
+              <ms:code>WSX</ms:code>
+              <ms:st_area_shape_>11208105093.65494</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>903122.4501194651</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
+          </gml:featureMember>
+        </wfs:FeatureCollection>
+    http_version: 
+  recorded_at: Sun, 22 Sep 2019 20:48:47 GMT
 - request:
     method: get
     uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
@@ -99,7 +217,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 20 Sep 2019 08:28:43 GMT
+      - Sun, 22 Sep 2019 20:48:47 GMT
       Content-Type:
       - application/json
       Vary:
@@ -116,7 +234,66 @@ http_interactions:
         PLC","premises":null,"street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
         5AH","x":"358130.1","y":"172687.87","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"}]}'
     http_version: 
-  recorded_at: Fri, 20 Sep 2019 08:28:43 GMT
+  recorded_at: Sun, 22 Sep 2019 20:48:47 GMT
+- request:
+    method: get
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E358205.03,172708.07%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - environment.data.gov.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 22 Sep 2019 20:48:47 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1679'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8" ?>
+        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+        <gml:boundedBy>
+          <gml:Box srsName="EPSG:27700">
+            <gml:coordinates>0,0,0,0</gml:coordinates>
+          </gml:Box>
+        </gml:boundedBy>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas fid="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.15">
+              <ms:OBJECTID>15</ms:OBJECTID>
+              <ms:long_name>Wessex</ms:long_name>
+              <ms:short_name>Wessex</ms:short_name>
+              <ms:code>WSX</ms:code>
+              <ms:st_area_shape_>11208105093.65494</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>903122.4501194651</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
+          </gml:featureMember>
+        </wfs:FeatureCollection>
+    http_version: 
+  recorded_at: Sun, 22 Sep 2019 20:48:47 GMT
 - request:
     method: get
     uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
@@ -138,7 +315,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 20 Sep 2019 08:28:43 GMT
+      - Sun, 22 Sep 2019 20:48:47 GMT
       Content-Type:
       - application/json
       Vary:
@@ -155,5 +332,64 @@ http_interactions:
         PLC","premises":null,"street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
         5AH","x":"358130.1","y":"172687.87","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"}]}'
     http_version: 
-  recorded_at: Fri, 20 Sep 2019 08:28:44 GMT
+  recorded_at: Sun, 22 Sep 2019 20:48:47 GMT
+- request:
+    method: get
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E358205.03,172708.07%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - environment.data.gov.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 22 Sep 2019 20:48:48 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1679'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8" ?>
+        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+        <gml:boundedBy>
+          <gml:Box srsName="EPSG:27700">
+            <gml:coordinates>0,0,0,0</gml:coordinates>
+          </gml:Box>
+        </gml:boundedBy>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas fid="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.15">
+              <ms:OBJECTID>15</ms:OBJECTID>
+              <ms:long_name>Wessex</ms:long_name>
+              <ms:short_name>Wessex</ms:short_name>
+              <ms:code>WSX</ms:code>
+              <ms:st_area_shape_>11208105093.65494</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>903122.4501194651</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
+          </gml:featureMember>
+        </wfs:FeatureCollection>
+    http_version: 
+  recorded_at: Sun, 22 Sep 2019 20:48:48 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/site_address_auto_x_and_y_and_area.yml
+++ b/spec/cassettes/site_address_auto_x_and_y_and_area.yml
@@ -1,0 +1,159 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - localhost:9002
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 Sep 2019 08:28:43 GMT
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalMatches":2,"startMatch":1,"endMatch":2,"uri_to_supplier":"https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=BS15AH&maxresults=100&dataset=DPA","uri_from_client":"stub","results":[{"uprn":340116,"address":"ENVIRONMENT
+        AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH","organisation":"ENVIRONMENT
+        AGENCY","premises":"HORIZON HOUSE","street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
+        5AH","x":"358205.03","y":"172708.07","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"},{"uprn":340117,"address":"THRIVE
+        RENEWABLES PLC, DEANERY ROAD, BRISTOL, BS1 5AH","organisation":"THRIVE RENEWABLES
+        PLC","premises":null,"street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
+        5AH","x":"358130.1","y":"172687.87","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"}]}'
+    http_version: 
+  recorded_at: Fri, 20 Sep 2019 08:28:43 GMT
+- request:
+    method: get
+    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - localhost:9002
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 Sep 2019 08:28:43 GMT
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalMatches":2,"startMatch":1,"endMatch":2,"uri_to_supplier":"https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=BS15AH&maxresults=100&dataset=DPA","uri_from_client":"stub","results":[{"uprn":340116,"address":"ENVIRONMENT
+        AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH","organisation":"ENVIRONMENT
+        AGENCY","premises":"HORIZON HOUSE","street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
+        5AH","x":"358205.03","y":"172708.07","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"},{"uprn":340117,"address":"THRIVE
+        RENEWABLES PLC, DEANERY ROAD, BRISTOL, BS1 5AH","organisation":"THRIVE RENEWABLES
+        PLC","premises":null,"street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
+        5AH","x":"358130.1","y":"172687.87","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"}]}'
+    http_version: 
+  recorded_at: Fri, 20 Sep 2019 08:28:43 GMT
+- request:
+    method: get
+    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - localhost:9002
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 Sep 2019 08:28:43 GMT
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalMatches":2,"startMatch":1,"endMatch":2,"uri_to_supplier":"https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=BS15AH&maxresults=100&dataset=DPA","uri_from_client":"stub","results":[{"uprn":340116,"address":"ENVIRONMENT
+        AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH","organisation":"ENVIRONMENT
+        AGENCY","premises":"HORIZON HOUSE","street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
+        5AH","x":"358205.03","y":"172708.07","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"},{"uprn":340117,"address":"THRIVE
+        RENEWABLES PLC, DEANERY ROAD, BRISTOL, BS1 5AH","organisation":"THRIVE RENEWABLES
+        PLC","premises":null,"street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
+        5AH","x":"358130.1","y":"172687.87","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"}]}'
+    http_version: 
+  recorded_at: Fri, 20 Sep 2019 08:28:43 GMT
+- request:
+    method: get
+    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - localhost:9002
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 Sep 2019 08:28:43 GMT
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalMatches":2,"startMatch":1,"endMatch":2,"uri_to_supplier":"https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=BS15AH&maxresults=100&dataset=DPA","uri_from_client":"stub","results":[{"uprn":340116,"address":"ENVIRONMENT
+        AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH","organisation":"ENVIRONMENT
+        AGENCY","premises":"HORIZON HOUSE","street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
+        5AH","x":"358205.03","y":"172708.07","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"},{"uprn":340117,"address":"THRIVE
+        RENEWABLES PLC, DEANERY ROAD, BRISTOL, BS1 5AH","organisation":"THRIVE RENEWABLES
+        PLC","premises":null,"street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
+        5AH","x":"358130.1","y":"172687.87","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"}]}'
+    http_version: 
+  recorded_at: Fri, 20 Sep 2019 08:28:44 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/site_address_from_grid_ref_auto_area.yml
+++ b/spec/cassettes/site_address_from_grid_ref_auto_area.yml
@@ -1,0 +1,180 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E358337.0,172855.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - environment.data.gov.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 22 Sep 2019 20:54:57 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1679'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8" ?>
+        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+        <gml:boundedBy>
+          <gml:Box srsName="EPSG:27700">
+            <gml:coordinates>0,0,0,0</gml:coordinates>
+          </gml:Box>
+        </gml:boundedBy>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas fid="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.15">
+              <ms:OBJECTID>15</ms:OBJECTID>
+              <ms:long_name>Wessex</ms:long_name>
+              <ms:short_name>Wessex</ms:short_name>
+              <ms:code>WSX</ms:code>
+              <ms:st_area_shape_>11208105093.65494</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>903122.4501194651</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
+          </gml:featureMember>
+        </wfs:FeatureCollection>
+    http_version: 
+  recorded_at: Sun, 22 Sep 2019 20:54:57 GMT
+- request:
+    method: get
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E358337.0,172855.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - environment.data.gov.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 22 Sep 2019 20:54:58 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1679'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8" ?>
+        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+        <gml:boundedBy>
+          <gml:Box srsName="EPSG:27700">
+            <gml:coordinates>0,0,0,0</gml:coordinates>
+          </gml:Box>
+        </gml:boundedBy>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas fid="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.15">
+              <ms:OBJECTID>15</ms:OBJECTID>
+              <ms:long_name>Wessex</ms:long_name>
+              <ms:short_name>Wessex</ms:short_name>
+              <ms:code>WSX</ms:code>
+              <ms:st_area_shape_>11208105093.65494</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>903122.4501194651</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
+          </gml:featureMember>
+        </wfs:FeatureCollection>
+    http_version: 
+  recorded_at: Sun, 22 Sep 2019 20:54:58 GMT
+- request:
+    method: get
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E358337.0,172855.0%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - environment.data.gov.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 22 Sep 2019 20:54:58 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1679'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8" ?>
+        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+        <gml:boundedBy>
+          <gml:Box srsName="EPSG:27700">
+            <gml:coordinates>0,0,0,0</gml:coordinates>
+          </gml:Box>
+        </gml:boundedBy>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas fid="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.15">
+              <ms:OBJECTID>15</ms:OBJECTID>
+              <ms:long_name>Wessex</ms:long_name>
+              <ms:short_name>Wessex</ms:short_name>
+              <ms:code>WSX</ms:code>
+              <ms:st_area_shape_>11208105093.65494</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>903122.4501194651</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
+          </gml:featureMember>
+        </wfs:FeatureCollection>
+    http_version: 
+  recorded_at: Sun, 22 Sep 2019 20:54:58 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/site_address_from_lookup_auto_area.yml
+++ b/spec/cassettes/site_address_from_lookup_auto_area.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?Filter=(%3CFilter%3E%3CIntersects%3E%3CPropertyName%3ESHAPE%3C/PropertyName%3E%3Cgml:Point%3E%3Cgml:coordinates%3E358205.03,172708.07%3C/gml:coordinates%3E%3C/gml:Point%3E%3C/Intersects%3E%3C/Filter%3E)&REQUEST=GetFeature&SERVICE=WFS&SRSName=EPSG:27700&VERSION=1.0.0&propertyName=area_id,area_name,code,long_name,short_name&typeName=ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - environment.data.gov.uk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 22 Sep 2019 20:54:54 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '1679'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8" ?>
+        <wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:ms="https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs https://environment.data.gov.uk/spatialdata/administrative-boundaries-environment-agency-and-natural-england-public-face-areas/wfs?service=wfs%26version=1.0.0%26request=DescribeFeatureType">
+        <gml:boundedBy>
+          <gml:Box srsName="EPSG:27700">
+            <gml:coordinates>0,0,0,0</gml:coordinates>
+          </gml:Box>
+        </gml:boundedBy>
+          <gml:featureMember>
+            <ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas fid="Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas.15">
+              <ms:OBJECTID>15</ms:OBJECTID>
+              <ms:long_name>Wessex</ms:long_name>
+              <ms:short_name>Wessex</ms:short_name>
+              <ms:code>WSX</ms:code>
+              <ms:st_area_shape_>11208105093.65494</ms:st_area_shape_>
+              <ms:st_perimeter_shape_>903122.4501194651</ms:st_perimeter_shape_>
+            </ms:Administrative_Boundaries_Environment_Agency_and_Natural_England_Public_Face_Areas>
+          </gml:featureMember>
+        </wfs:FeatureCollection>
+    http_version: 
+  recorded_at: Sun, 22 Sep 2019 20:54:54 GMT
+recorded_with: VCR 5.0.0

--- a/spec/models/waste_exemptions_engine/transient_address_spec.rb
+++ b/spec/models/waste_exemptions_engine/transient_address_spec.rb
@@ -76,7 +76,7 @@ module WasteExemptionsEngine
       end
 
       context "when the address is a site address" do
-        before(:context) { VCR.insert_cassette("site_address_auto_area", allow_playback_repeats: true) }
+        before(:context) { VCR.insert_cassette("site_address_from_lookup_auto_area", allow_playback_repeats: true) }
         after(:context) { VCR.eject_cassette }
 
         let(:address_type) { 3 }
@@ -146,7 +146,7 @@ module WasteExemptionsEngine
     end
 
     describe ".create_from_grid_reference_data" do
-      before(:context) { VCR.insert_cassette("site_address_auto_area", allow_playback_repeats: true) }
+      before(:context) { VCR.insert_cassette("site_address_from_grid_ref_auto_area", allow_playback_repeats: true) }
       after(:context) { VCR.eject_cassette }
 
       let(:grid_reference_data) do

--- a/spec/models/waste_exemptions_engine/transient_address_spec.rb
+++ b/spec/models/waste_exemptions_engine/transient_address_spec.rb
@@ -76,10 +76,17 @@ module WasteExemptionsEngine
       end
 
       context "when the address is a site address" do
+        before(:context) { VCR.insert_cassette("site_address_auto_area", allow_playback_repeats: true) }
+        after(:context) { VCR.eject_cassette }
+
         let(:address_type) { 3 }
 
         it "does automatically determine the grid reference" do
           expect(address.grid_reference).to eq("ST 58205 72708")
+        end
+
+        it "does automatically determine the area" do
+          expect(address.area).to eq("Wessex")
         end
       end
     end
@@ -112,7 +119,7 @@ module WasteExemptionsEngine
       end
 
       context "when the address is a site address", vcr: true do
-        before(:context) { VCR.insert_cassette("site_address_auto_x_and_y", allow_playback_repeats: true) }
+        before(:context) { VCR.insert_cassette("site_address_auto_x_and_y_and_area", allow_playback_repeats: true) }
         after(:context) { VCR.eject_cassette }
 
         let(:address_type) { 3 }
@@ -131,10 +138,17 @@ module WasteExemptionsEngine
         it "does automatically determine the grid reference" do
           expect(address.grid_reference).to eq("ST 58205 72708")
         end
+
+        it "does automatically determine the area" do
+          expect(address.area).to eq("Wessex")
+        end
       end
     end
 
     describe ".create_from_grid_reference_data" do
+      before(:context) { VCR.insert_cassette("site_address_auto_area", allow_playback_repeats: true) }
+      after(:context) { VCR.eject_cassette }
+
       let(:grid_reference_data) do
         {
           grid_reference: "ST 58337 72855",
@@ -153,6 +167,10 @@ module WasteExemptionsEngine
       it "automatically determines the x & y values" do
         x_and_y = { x: address.x, y: address.y }
         expect(x_and_y).to eq(x: 358_337.0, y: 172_855.0)
+      end
+
+      it "does automatically determine the area" do
+        expect(address.area).to eq("Wessex")
       end
     end
   end

--- a/spec/services/waste_exemptions_engine/area_lookup_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/area_lookup_service_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "airbrake"
 
 module Test
   module Area
@@ -60,17 +61,23 @@ module WasteExemptionsEngine
         context "because it failed" do
           let(:response) { Test::Area::Response.new([], false, StandardError.new) }
 
-          it "returns null" do
+          it "returns 'nil'" do
             expect(described_class.run(coordinates)).to be_nil
+          end
+
+          it "uses Airbrake to notify Errbit of the error" do
+            expect(Airbrake).to receive(:notify)
+
+            described_class.run(coordinates)
           end
         end
       end
 
       context "when passed invalid arguments" do
-        context "for example nil" do
+        context "for example 'nil'" do
           let(:coordinates) { { easting: nil, northing: 215_313 } }
 
-          it "returns null" do
+          it "returns 'nil'" do
             expect(described_class.run(coordinates)).to be_nil
           end
         end
@@ -78,7 +85,7 @@ module WasteExemptionsEngine
         context "for example not a numeric value" do
           let(:coordinates) { { easting: "not_a_number", northing: 215_313 } }
 
-          it "returns null" do
+          it "returns 'nil'" do
             expect(described_class.run(coordinates)).to be_nil
           end
         end

--- a/spec/services/waste_exemptions_engine/area_lookup_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/area_lookup_service_spec.rb
@@ -52,8 +52,8 @@ module WasteExemptionsEngine
         context "because no match was found" do
           let(:response) { Test::Area::Response.new([], false, DefraRuby::Area::NoMatchError.new) }
 
-          it "returns null" do
-            expect(described_class.run(coordinates)).to be_nil
+          it "returns 'Outside England'" do
+            expect(described_class.run(coordinates)).to eq("Outside England")
           end
         end
 

--- a/spec/services/waste_exemptions_engine/area_lookup_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/area_lookup_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Test
+  module Area
+    Response = Struct.new(:areas, :successful, :error) do
+      def successful?
+        successful
+      end
+    end
+
+    Area = Struct.new(:code, :long_name, :short_name)
+  end
+end
+
+module WasteExemptionsEngine
+  RSpec.describe AreaLookupService do
+    describe ".run" do
+      before(:each) do
+        allow(DefraRuby::Area::PublicFaceAreaService)
+          .to receive(:run)
+          .and_return(response)
+      end
+
+      context "when the lookup is successful" do
+        let(:easting) { 358_205.03 }
+        let(:northing) { 172_708.07 }
+        let(:response) do
+          area = Test::Area::Area.new(
+            "WSX",
+            "Wessex",
+            "Wessex"
+          )
+          Test::Area::Response.new([area], true)
+        end
+
+        it "returns the matching area" do
+          expect(described_class.run(easting, northing)).to eq("Wessex")
+        end
+      end
+
+      context "when the lookup is unsuccessful" do
+        context "because no match was found" do
+          let(:easting) { 194_868 }
+          let(:northing) { 215_313 }
+          let(:response) { Test::Area::Response.new([], false, DefraRuby::Area::NoMatchError.new) }
+
+          it "returns null" do
+            expect(described_class.run(easting, northing)).to be_nil
+          end
+        end
+
+        context "because it failed" do
+          let(:easting) { 194_868 }
+          let(:northing) { 215_313 }
+          let(:response) { Test::Area::Response.new([], false, StandardError.new) }
+
+          it "returns null" do
+            expect(described_class.run(easting, northing)).to be_nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_exemptions_engine/area_lookup_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/area_lookup_service_spec.rb
@@ -17,15 +17,15 @@ end
 module WasteExemptionsEngine
   RSpec.describe AreaLookupService do
     describe ".run" do
-      before(:each) do
-        allow(DefraRuby::Area::PublicFaceAreaService)
-          .to receive(:run)
-          .and_return(response)
-      end
 
       context "when the lookup is successful" do
-        let(:easting) { 358_205.03 }
-        let(:northing) { 172_708.07 }
+        before(:each) do
+          allow(DefraRuby::Area::PublicFaceAreaService)
+            .to receive(:run)
+            .and_return(response)
+        end
+
+        let(:coordinates) { { easting: 358_205.03, northing: 172_708.07 } }
         let(:response) do
           area = Test::Area::Area.new(
             "WSX",
@@ -36,28 +36,50 @@ module WasteExemptionsEngine
         end
 
         it "returns the matching area" do
-          expect(described_class.run(easting, northing)).to eq("Wessex")
+          expect(described_class.run(coordinates)).to eq("Wessex")
         end
       end
 
       context "when the lookup is unsuccessful" do
+        before(:each) do
+          allow(DefraRuby::Area::PublicFaceAreaService)
+            .to receive(:run)
+            .and_return(response)
+        end
+
+        let(:coordinates) { { easting: 194_868, northing: 215_313 } }
+
         context "because no match was found" do
-          let(:easting) { 194_868 }
-          let(:northing) { 215_313 }
           let(:response) { Test::Area::Response.new([], false, DefraRuby::Area::NoMatchError.new) }
 
           it "returns null" do
-            expect(described_class.run(easting, northing)).to be_nil
+            expect(described_class.run(coordinates)).to be_nil
           end
         end
 
         context "because it failed" do
-          let(:easting) { 194_868 }
-          let(:northing) { 215_313 }
           let(:response) { Test::Area::Response.new([], false, StandardError.new) }
 
           it "returns null" do
-            expect(described_class.run(easting, northing)).to be_nil
+            expect(described_class.run(coordinates)).to be_nil
+          end
+        end
+      end
+
+      context "when passed invalid arguments" do
+        context "for example nil" do
+          let(:coordinates) { { easting: nil, northing: 215_313 } }
+
+          it "returns null" do
+            expect(described_class.run(coordinates)).to be_nil
+          end
+        end
+
+        context "for example not a numeric value" do
+          let(:coordinates) { { easting: "not_a_number", northing: 215_313 } }
+
+          it "returns null" do
+            expect(described_class.run(coordinates)).to be_nil
           end
         end
       end

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -21,6 +21,10 @@ Gem::Specification.new do |s|
 
   # Use AASM to manage states and transitions
   s.add_dependency "aasm", "~> 4.12"
+
+  # Use Airbrake for error reporting to Errbit
+  # Version 6 and above cause errors with Errbit, so use 5.8.1 for now
+  s.add_dependency "airbrake", "5.8.1"
   s.add_dependency "has_secure_token"
   s.add_dependency "high_voltage", "~> 3.1"
   s.add_dependency "rails", "~> 4.2.11"

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -30,6 +30,9 @@ Gem::Specification.new do |s|
   # Used to convert national grid references to easting and northing coordinates
   s.add_dependency "os_map_ref", "~> 0.5"
 
+  # Used to identify the EA area for a registration
+  s.add_dependency "defra_ruby_area"
+
   s.add_dependency "pg", "~> 0.18.4"
 
   # Used for auditing and version control


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-483

The previous WEX service would attempt to identify the EA Admin area for a site once it had been entered as part of the registration. This stopped working in December 2018.

When we shipped the new version of the service we left out this functionality because

- we were still awaiting a fix
- we knew both FRAE and WEX depend on this so wanted to implement a shared solution

With the creation of [defra-ruby-area](https://github.com/DEFRA/defra-ruby-area) we now have that shared solution.

So this change covers everything needed to integrate the gem and identify the area as part of the new registration journey.