### PR TITLE
Remove exemptions checkbox from inside label

### DIFF
--- a/app/assets/stylesheets/waste_exemptions_engine/application.scss
+++ b/app/assets/stylesheets/waste_exemptions_engine/application.scss
@@ -16,4 +16,3 @@
 
  // Custom styles
  @import 'partials/edit';
- @import 'partials/exemptions';

--- a/app/views/waste_exemptions_engine/exemptions_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/exemptions_forms/new.html.erb
@@ -17,10 +17,10 @@
         <% end %>
 
         <% all_exemptions.each do |exemption|  %>
-          <div class="multiple-choice wex_exemption">
+          <div class="multiple-choice">
+            <%= f.check_box :exemptions, { :multiple => true, id: "exemptions_form_checkbox-#{exemption.code}", checked: @exemptions_form.exemptions&.include?(exemption) }, exemption.id, nil %>
             <%= f.label "checkbox-#{exemption.code}" do %>
-              <%= f.check_box :exemptions, { :multiple => true, id: "exemptions_form_checkbox-#{exemption.code}", checked: @exemptions_form.exemptions&.include?(exemption) }, exemption.id, nil %>
-              <span class="wex_exemption__code"><%= exemption.code %></span> <span class="wex_exemption__title"><%= exemption.summary %></span>
+              <span><%= exemption.code %></span> <span><%= exemption.summary %></span>
             <% end %>
           </div>
         <% end %>

--- a/spec/cassettes/w3c_valid_content/exemptions_forms_spec/when-the-registration-is-in-the-correct-state.yml
+++ b/spec/cassettes/w3c_valid_content/exemptions_forms_spec/when-the-registration-is-in-the-correct-state.yml
@@ -8,6 +8,7 @@ http_interactions:
       string: "<!DOCTYPE html>\n<html>\n<head>\n  <title>Dummy</title>\n  <link rel=\"stylesheet\"
         media=\"all\" href=\"/stylesheets/application.css\" data-turbolinks-track=\"true\"
         />\n  <script src=\"/javascripts/application.js\" data-turbolinks-track=\"true\"></script>\n
+<<<<<<< HEAD
         \ \n</head>\n<body>\n\n<a class=\"link-back\" href=\"/waste_exemptions_engine/Voei5THQSqn7in3MaJwcFpkH/exemptions/back\">Back</a>\n\n\n<div
         class=\"text\">\n  <form class=\"new_exemptions_form\" id=\"new_exemptions_form\"
         action=\"/waste_exemptions_engine/Voei5THQSqn7in3MaJwcFpkH/exemptions\" accept-charset=\"UTF-8\"
@@ -37,6 +38,36 @@ http_interactions:
         \           <label for=\"exemptions_form_checkbox-U5\">\n              <span>U5</span>
         <span>Nemo earum temporibus veniam.</span>\n</label>          </div>\n      </fieldset>\n
         \   </div>\n\n    <input value=\"Voei5THQSqn7in3MaJwcFpkH\" type=\"hidden\"
+=======
+        \ \n</head>\n<body>\n\n<a class=\"link-back\" href=\"/waste_exemptions_engine/exemptions/back/ShxTEVGmiEqDzaCqY61ghfiH\">Back</a>\n\n\n<div
+        class=\"text\">\n  <form class=\"new_exemptions_form\" id=\"new_exemptions_form\"
+        action=\"/waste_exemptions_engine/exemptions\" accept-charset=\"UTF-8\" method=\"post\"><input
+        name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" />\n    \n\n    <h1 class=\"heading-large\">Which
+        exemptions are needed for this waste operation?</h1>\n\n    <p>Select all
+        the waste exemptions you need to add to the registration</p>\n\n    <div class=\"form-group
+        \">\n      <fieldset id=\"matched_exemptions\">\n        <legend class=\"visually-hidden\">Exemptions</legend>\n\n\n
+        \         <div class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U1\"
+        type=\"checkbox\" value=\"1\" name=\"exemptions_form[exemptions][]\" />\n
+        \           <label for=\"exemptions_form_checkbox-U1\">\n              <span>U1</span>
+        <span>Expedita provident molestiae saepe.</span>\n</label>          </div>\n
+        \         <div class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U2\"
+        type=\"checkbox\" value=\"2\" name=\"exemptions_form[exemptions][]\" />\n
+        \           <label for=\"exemptions_form_checkbox-U2\">\n              <span>U2</span>
+        <span>Cumque temporibus voluptatem voluptate.</span>\n</label>          </div>\n
+        \         <div class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U3\"
+        type=\"checkbox\" value=\"3\" name=\"exemptions_form[exemptions][]\" />\n
+        \           <label for=\"exemptions_form_checkbox-U3\">\n              <span>U3</span>
+        <span>Itaque corporis ab dicta.</span>\n</label>          </div>\n          <div
+        class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U4\"
+        type=\"checkbox\" value=\"4\" name=\"exemptions_form[exemptions][]\" />\n
+        \           <label for=\"exemptions_form_checkbox-U4\">\n              <span>U4</span>
+        <span>Totam assumenda quidem ea.</span>\n</label>          </div>\n          <div
+        class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U5\"
+        type=\"checkbox\" value=\"5\" name=\"exemptions_form[exemptions][]\" />\n
+        \           <label for=\"exemptions_form_checkbox-U5\">\n              <span>U5</span>
+        <span>Iure illo explicabo sint.</span>\n</label>          </div>\n      </fieldset>\n
+        \   </div>\n\n    <input value=\"ShxTEVGmiEqDzaCqY61ghfiH\" type=\"hidden\"
+>>>>>>> Update cassette
         name=\"exemptions_form[token]\" id=\"exemptions_form_token\" />\n    <div
         class=\"form-group\">\n      <input type=\"submit\" name=\"commit\" value=\"Continue\"
         class=\"button\" />\n    </div>\n</form></div>\n\n\n</body>\n</html>\n"
@@ -55,7 +86,11 @@ http_interactions:
       message: OK
     headers:
       Date:
+<<<<<<< HEAD
       - Wed, 18 Sep 2019 09:43:04 GMT
+=======
+      - Tue, 17 Sep 2019 14:26:05 GMT
+>>>>>>> Update cassette
       Accept-Encoding:
       - gzip
       Access-Control-Allow-Origin:
@@ -86,7 +121,13 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
+<<<<<<< HEAD
         eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9zdHlsZXNoZWV0cy9hcHBsaWNhdGlvbi5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvamF2YXNjcmlwdHMvYXBwbGljYXRpb24uanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxhIGNsYXNzPVwibGluay1iYWNrXCIgaHJlZj1cIi93YXN0ZV9leGVtcHRpb25zX2VuZ2luZS9Wb2VpNVRIUVNxbjdpbjNNYUp3Y0Zwa0gvZXhlbXB0aW9ucy9iYWNrXCI+QmFjazwvYT5cblxuXG48ZGl2IGNsYXNzPVwidGV4dFwiPlxuICA8Zm9ybSBjbGFzcz1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBpZD1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBhY3Rpb249XCIvd2FzdGVfZXhlbXB0aW9uc19lbmdpbmUvVm9laTVUSFFTcW43aW4zTWFKd2NGcGtIL2V4ZW1wdGlvbnNcIiBhY2NlcHQtY2hhcnNldD1cIlVURi04XCIgbWV0aG9kPVwicG9zdFwiPjxpbnB1dCBuYW1lPVwidXRmOFwiIHR5cGU9XCJoaWRkZW5cIiB2YWx1ZT1cIiYjeDI3MTM7XCIgLz5cbiAgICBcblxuICAgIDxoMSBjbGFzcz1cImhlYWRpbmctbGFyZ2VcIj5XaGljaCBleGVtcHRpb25zIGFyZSBuZWVkZWQgZm9yIHRoaXMgd2FzdGUgb3BlcmF0aW9uPzwvaDE+XG5cbiAgICA8cD5TZWxlY3QgYWxsIHRoZSB3YXN0ZSBleGVtcHRpb25zIHlvdSBuZWVkIHRvIGFkZCB0byB0aGUgcmVnaXN0cmF0aW9uPC9wPlxuXG4gICAgPGRpdiBjbGFzcz1cImZvcm0tZ3JvdXAgXCI+XG4gICAgICA8ZmllbGRzZXQgaWQ9XCJtYXRjaGVkX2V4ZW1wdGlvbnNcIj5cbiAgICAgICAgPGxlZ2VuZCBjbGFzcz1cInZpc3VhbGx5LWhpZGRlblwiPkV4ZW1wdGlvbnM8L2xlZ2VuZD5cblxuXG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUxXCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCIxXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTFcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTE8L3NwYW4+IDxzcGFuPlF1aXMgYWxpcXVpZCBtYWduYW0gbW9sbGl0aWEuPC9zcGFuPlxuPC9sYWJlbD4gICAgICAgICAgPC9kaXY+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUyXCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCIyXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTJcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTI8L3NwYW4+IDxzcGFuPkZ1Z2l0IGFkIHNpdCBtYWduaS48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTNcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjNcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VM1wiPlxuICAgICAgICAgICAgICA8c3Bhbj5VMzwvc3Bhbj4gPHNwYW4+U3VudCB2ZXJpdGF0aXMgdm9sdXB0YXRpYnVzIGFzcGVyaW9yZXMuPC9zcGFuPlxuPC9sYWJlbD4gICAgICAgICAgPC9kaXY+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVU0XCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCI0XCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTRcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTQ8L3NwYW4+IDxzcGFuPkV0IGlkIGRvbG9yZW1xdWUgcXVpLjwvc3Bhbj5cbjwvbGFiZWw+ICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJtdWx0aXBsZS1jaG9pY2VcIj5cbiAgICAgICAgICAgIDxpbnB1dCBpZD1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VNVwiIHR5cGU9XCJjaGVja2JveFwiIHZhbHVlPVwiNVwiIG5hbWU9XCJleGVtcHRpb25zX2Zvcm1bZXhlbXB0aW9uc11bXVwiIC8+XG4gICAgICAgICAgICA8bGFiZWwgZm9yPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVU1XCI+XG4gICAgICAgICAgICAgIDxzcGFuPlU1PC9zcGFuPiA8c3Bhbj5OZW1vIGVhcnVtIHRlbXBvcmlidXMgdmVuaWFtLjwvc3Bhbj5cbjwvbGFiZWw+ICAgICAgICAgIDwvZGl2PlxuICAgICAgPC9maWVsZHNldD5cbiAgICA8L2Rpdj5cblxuICAgIDxpbnB1dCB2YWx1ZT1cIlZvZWk1VEhRU3FuN2luM01hSndjRnBrSFwiIHR5cGU9XCJoaWRkZW5cIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW3Rva2VuXVwiIGlkPVwiZXhlbXB0aW9uc19mb3JtX3Rva2VuXCIgLz5cbiAgICA8ZGl2IGNsYXNzPVwiZm9ybS1ncm91cFwiPlxuICAgICAgPGlucHV0IHR5cGU9XCJzdWJtaXRcIiBuYW1lPVwiY29tbWl0XCIgdmFsdWU9XCJDb250aW51ZVwiIGNsYXNzPVwiYnV0dG9uXCIgLz5cbiAgICA8L2Rpdj5cbjwvZm9ybT48L2Rpdj5cblxuXG48L2JvZHk+XG48L2h0bWw+In19Cg==
     http_version: 
   recorded_at: Wed, 18 Sep 2019 09:43:04 GMT
+=======
+        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9zdHlsZXNoZWV0cy9hcHBsaWNhdGlvbi5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvamF2YXNjcmlwdHMvYXBwbGljYXRpb24uanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxhIGNsYXNzPVwibGluay1iYWNrXCIgaHJlZj1cIi93YXN0ZV9leGVtcHRpb25zX2VuZ2luZS9leGVtcHRpb25zL2JhY2svU2h4VEVWR21pRXFEemFDcVk2MWdoZmlIXCI+QmFjazwvYT5cblxuXG48ZGl2IGNsYXNzPVwidGV4dFwiPlxuICA8Zm9ybSBjbGFzcz1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBpZD1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBhY3Rpb249XCIvd2FzdGVfZXhlbXB0aW9uc19lbmdpbmUvZXhlbXB0aW9uc1wiIGFjY2VwdC1jaGFyc2V0PVwiVVRGLThcIiBtZXRob2Q9XCJwb3N0XCI+PGlucHV0IG5hbWU9XCJ1dGY4XCIgdHlwZT1cImhpZGRlblwiIHZhbHVlPVwiJiN4MjcxMztcIiAvPlxuICAgIFxuXG4gICAgPGgxIGNsYXNzPVwiaGVhZGluZy1sYXJnZVwiPldoaWNoIGV4ZW1wdGlvbnMgYXJlIG5lZWRlZCBmb3IgdGhpcyB3YXN0ZSBvcGVyYXRpb24/PC9oMT5cblxuICAgIDxwPlNlbGVjdCBhbGwgdGhlIHdhc3RlIGV4ZW1wdGlvbnMgeW91IG5lZWQgdG8gYWRkIHRvIHRoZSByZWdpc3RyYXRpb248L3A+XG5cbiAgICA8ZGl2IGNsYXNzPVwiZm9ybS1ncm91cCBcIj5cbiAgICAgIDxmaWVsZHNldCBpZD1cIm1hdGNoZWRfZXhlbXB0aW9uc1wiPlxuICAgICAgICA8bGVnZW5kIGNsYXNzPVwidmlzdWFsbHktaGlkZGVuXCI+RXhlbXB0aW9uczwvbGVnZW5kPlxuXG5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTFcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjFcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VMVwiPlxuICAgICAgICAgICAgICA8c3Bhbj5VMTwvc3Bhbj4gPHNwYW4+RXhwZWRpdGEgcHJvdmlkZW50IG1vbGVzdGlhZSBzYWVwZS48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTJcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjJcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VMlwiPlxuICAgICAgICAgICAgICA8c3Bhbj5VMjwvc3Bhbj4gPHNwYW4+Q3VtcXVlIHRlbXBvcmlidXMgdm9sdXB0YXRlbSB2b2x1cHRhdGUuPC9zcGFuPlxuPC9sYWJlbD4gICAgICAgICAgPC9kaXY+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUzXCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCIzXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTNcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTM8L3NwYW4+IDxzcGFuPkl0YXF1ZSBjb3Jwb3JpcyBhYiBkaWN0YS48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTRcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjRcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VNFwiPlxuICAgICAgICAgICAgICA8c3Bhbj5VNDwvc3Bhbj4gPHNwYW4+VG90YW0gYXNzdW1lbmRhIHF1aWRlbSBlYS48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTVcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjVcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VNVwiPlxuICAgICAgICAgICAgICA8c3Bhbj5VNTwvc3Bhbj4gPHNwYW4+SXVyZSBpbGxvIGV4cGxpY2FibyBzaW50Ljwvc3Bhbj5cbjwvbGFiZWw+ICAgICAgICAgIDwvZGl2PlxuICAgICAgPC9maWVsZHNldD5cbiAgICA8L2Rpdj5cblxuICAgIDxpbnB1dCB2YWx1ZT1cIlNoeFRFVkdtaUVxRHphQ3FZNjFnaGZpSFwiIHR5cGU9XCJoaWRkZW5cIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW3Rva2VuXVwiIGlkPVwiZXhlbXB0aW9uc19mb3JtX3Rva2VuXCIgLz5cbiAgICA8ZGl2IGNsYXNzPVwiZm9ybS1ncm91cFwiPlxuICAgICAgPGlucHV0IHR5cGU9XCJzdWJtaXRcIiBuYW1lPVwiY29tbWl0XCIgdmFsdWU9XCJDb250aW51ZVwiIGNsYXNzPVwiYnV0dG9uXCIgLz5cbiAgICA8L2Rpdj5cbjwvZm9ybT48L2Rpdj5cblxuXG48L2JvZHk+XG48L2h0bWw+In19Cg==
+    http_version: 
+  recorded_at: Tue, 17 Sep 2019 14:26:05 GMT
+>>>>>>> Update cassette
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/w3c_valid_content/exemptions_forms_spec/when-the-registration-is-in-the-correct-state.yml
+++ b/spec/cassettes/w3c_valid_content/exemptions_forms_spec/when-the-registration-is-in-the-correct-state.yml
@@ -8,40 +8,35 @@ http_interactions:
       string: "<!DOCTYPE html>\n<html>\n<head>\n  <title>Dummy</title>\n  <link rel=\"stylesheet\"
         media=\"all\" href=\"/stylesheets/application.css\" data-turbolinks-track=\"true\"
         />\n  <script src=\"/javascripts/application.js\" data-turbolinks-track=\"true\"></script>\n
-        \ \n</head>\n<body>\n\n<a class=\"link-back\" href=\"/waste_exemptions_engine/mPW6cha6p4y1CTnbAcqJ9QNe/exemptions/back\">Back</a>\n\n\n<div
+        \ \n</head>\n<body>\n\n<a class=\"link-back\" href=\"/waste_exemptions_engine/Voei5THQSqn7in3MaJwcFpkH/exemptions/back\">Back</a>\n\n\n<div
         class=\"text\">\n  <form class=\"new_exemptions_form\" id=\"new_exemptions_form\"
-        action=\"/waste_exemptions_engine/mPW6cha6p4y1CTnbAcqJ9QNe/exemptions\" accept-charset=\"UTF-8\"
+        action=\"/waste_exemptions_engine/Voei5THQSqn7in3MaJwcFpkH/exemptions\" accept-charset=\"UTF-8\"
         method=\"post\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" />\n
         \   \n\n    <h1 class=\"heading-large\">Which exemptions are needed for this
         waste operation?</h1>\n\n    <p>Select all the waste exemptions you need to
         add to the registration</p>\n\n    <div class=\"form-group \">\n      <fieldset
         id=\"matched_exemptions\">\n        <legend class=\"visually-hidden\">Exemptions</legend>\n\n\n
-        \         <div class=\"multiple-choice wex_exemption\">\n            <label
-        for=\"exemptions_form_checkbox-U171\">\n              <input id=\"exemptions_form_checkbox-U171\"
-        type=\"checkbox\" value=\"171\" name=\"exemptions_form[exemptions][]\" />\n
-        \             <span class=\"wex_exemption__code\">U171</span> <span class=\"wex_exemption__title\">Recusandae
-        et aut ut.</span>\n</label>          </div>\n          <div class=\"multiple-choice
-        wex_exemption\">\n            <label for=\"exemptions_form_checkbox-U172\">\n
-        \             <input id=\"exemptions_form_checkbox-U172\" type=\"checkbox\"
-        value=\"172\" name=\"exemptions_form[exemptions][]\" />\n              <span
-        class=\"wex_exemption__code\">U172</span> <span class=\"wex_exemption__title\">Voluptatibus
-        debitis repellendus molestiae.</span>\n</label>          </div>\n          <div
-        class=\"multiple-choice wex_exemption\">\n            <label for=\"exemptions_form_checkbox-U173\">\n
-        \             <input id=\"exemptions_form_checkbox-U173\" type=\"checkbox\"
-        value=\"173\" name=\"exemptions_form[exemptions][]\" />\n              <span
-        class=\"wex_exemption__code\">U173</span> <span class=\"wex_exemption__title\">Veritatis
-        qui quia delectus.</span>\n</label>          </div>\n          <div class=\"multiple-choice
-        wex_exemption\">\n            <label for=\"exemptions_form_checkbox-U174\">\n
-        \             <input id=\"exemptions_form_checkbox-U174\" type=\"checkbox\"
-        value=\"174\" name=\"exemptions_form[exemptions][]\" />\n              <span
-        class=\"wex_exemption__code\">U174</span> <span class=\"wex_exemption__title\">Deserunt
-        reiciendis perferendis totam.</span>\n</label>          </div>\n          <div
-        class=\"multiple-choice wex_exemption\">\n            <label for=\"exemptions_form_checkbox-U175\">\n
-        \             <input id=\"exemptions_form_checkbox-U175\" type=\"checkbox\"
-        value=\"175\" name=\"exemptions_form[exemptions][]\" />\n              <span
-        class=\"wex_exemption__code\">U175</span> <span class=\"wex_exemption__title\">Labore
-        eum possimus aspernatur.</span>\n</label>          </div>\n      </fieldset>\n
-        \   </div>\n\n    <input value=\"mPW6cha6p4y1CTnbAcqJ9QNe\" type=\"hidden\"
+        \         <div class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U1\"
+        type=\"checkbox\" value=\"1\" name=\"exemptions_form[exemptions][]\" />\n
+        \           <label for=\"exemptions_form_checkbox-U1\">\n              <span>U1</span>
+        <span>Quis aliquid magnam mollitia.</span>\n</label>          </div>\n          <div
+        class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U2\"
+        type=\"checkbox\" value=\"2\" name=\"exemptions_form[exemptions][]\" />\n
+        \           <label for=\"exemptions_form_checkbox-U2\">\n              <span>U2</span>
+        <span>Fugit ad sit magni.</span>\n</label>          </div>\n          <div
+        class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U3\"
+        type=\"checkbox\" value=\"3\" name=\"exemptions_form[exemptions][]\" />\n
+        \           <label for=\"exemptions_form_checkbox-U3\">\n              <span>U3</span>
+        <span>Sunt veritatis voluptatibus asperiores.</span>\n</label>          </div>\n
+        \         <div class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U4\"
+        type=\"checkbox\" value=\"4\" name=\"exemptions_form[exemptions][]\" />\n
+        \           <label for=\"exemptions_form_checkbox-U4\">\n              <span>U4</span>
+        <span>Et id doloremque qui.</span>\n</label>          </div>\n          <div
+        class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U5\"
+        type=\"checkbox\" value=\"5\" name=\"exemptions_form[exemptions][]\" />\n
+        \           <label for=\"exemptions_form_checkbox-U5\">\n              <span>U5</span>
+        <span>Nemo earum temporibus veniam.</span>\n</label>          </div>\n      </fieldset>\n
+        \   </div>\n\n    <input value=\"Voei5THQSqn7in3MaJwcFpkH\" type=\"hidden\"
         name=\"exemptions_form[token]\" id=\"exemptions_form_token\" />\n    <div
         class=\"form-group\">\n      <input type=\"submit\" name=\"commit\" value=\"Continue\"
         class=\"button\" />\n    </div>\n</form></div>\n\n\n</body>\n</html>\n"
@@ -60,7 +55,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 17 Sep 2019 13:46:08 GMT
+      - Wed, 18 Sep 2019 09:43:04 GMT
       Accept-Encoding:
       - gzip
       Access-Control-Allow-Origin:
@@ -91,7 +86,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9zdHlsZXNoZWV0cy9hcHBsaWNhdGlvbi5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvamF2YXNjcmlwdHMvYXBwbGljYXRpb24uanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxhIGNsYXNzPVwibGluay1iYWNrXCIgaHJlZj1cIi93YXN0ZV9leGVtcHRpb25zX2VuZ2luZS9tUFc2Y2hhNnA0eTFDVG5iQWNxSjlRTmUvZXhlbXB0aW9ucy9iYWNrXCI+QmFjazwvYT5cblxuXG48ZGl2IGNsYXNzPVwidGV4dFwiPlxuICA8Zm9ybSBjbGFzcz1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBpZD1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBhY3Rpb249XCIvd2FzdGVfZXhlbXB0aW9uc19lbmdpbmUvbVBXNmNoYTZwNHkxQ1RuYkFjcUo5UU5lL2V4ZW1wdGlvbnNcIiBhY2NlcHQtY2hhcnNldD1cIlVURi04XCIgbWV0aG9kPVwicG9zdFwiPjxpbnB1dCBuYW1lPVwidXRmOFwiIHR5cGU9XCJoaWRkZW5cIiB2YWx1ZT1cIiYjeDI3MTM7XCIgLz5cbiAgICBcblxuICAgIDxoMSBjbGFzcz1cImhlYWRpbmctbGFyZ2VcIj5XaGljaCBleGVtcHRpb25zIGFyZSBuZWVkZWQgZm9yIHRoaXMgd2FzdGUgb3BlcmF0aW9uPzwvaDE+XG5cbiAgICA8cD5TZWxlY3QgYWxsIHRoZSB3YXN0ZSBleGVtcHRpb25zIHlvdSBuZWVkIHRvIGFkZCB0byB0aGUgcmVnaXN0cmF0aW9uPC9wPlxuXG4gICAgPGRpdiBjbGFzcz1cImZvcm0tZ3JvdXAgXCI+XG4gICAgICA8ZmllbGRzZXQgaWQ9XCJtYXRjaGVkX2V4ZW1wdGlvbnNcIj5cbiAgICAgICAgPGxlZ2VuZCBjbGFzcz1cInZpc3VhbGx5LWhpZGRlblwiPkV4ZW1wdGlvbnM8L2xlZ2VuZD5cblxuXG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZSB3ZXhfZXhlbXB0aW9uXCI+XG4gICAgICAgICAgICA8bGFiZWwgZm9yPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUxNzFcIj5cbiAgICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUxNzFcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjE3MVwiIG5hbWU9XCJleGVtcHRpb25zX2Zvcm1bZXhlbXB0aW9uc11bXVwiIC8+XG4gICAgICAgICAgICAgIDxzcGFuIGNsYXNzPVwid2V4X2V4ZW1wdGlvbl9fY29kZVwiPlUxNzE8L3NwYW4+IDxzcGFuIGNsYXNzPVwid2V4X2V4ZW1wdGlvbl9fdGl0bGVcIj5SZWN1c2FuZGFlIGV0IGF1dCB1dC48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlIHdleF9leGVtcHRpb25cIj5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTE3MlwiPlxuICAgICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTE3MlwiIHR5cGU9XCJjaGVja2JveFwiIHZhbHVlPVwiMTcyXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgICAgPHNwYW4gY2xhc3M9XCJ3ZXhfZXhlbXB0aW9uX19jb2RlXCI+VTE3Mjwvc3Bhbj4gPHNwYW4gY2xhc3M9XCJ3ZXhfZXhlbXB0aW9uX190aXRsZVwiPlZvbHVwdGF0aWJ1cyBkZWJpdGlzIHJlcGVsbGVuZHVzIG1vbGVzdGlhZS48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlIHdleF9leGVtcHRpb25cIj5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTE3M1wiPlxuICAgICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTE3M1wiIHR5cGU9XCJjaGVja2JveFwiIHZhbHVlPVwiMTczXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgICAgPHNwYW4gY2xhc3M9XCJ3ZXhfZXhlbXB0aW9uX19jb2RlXCI+VTE3Mzwvc3Bhbj4gPHNwYW4gY2xhc3M9XCJ3ZXhfZXhlbXB0aW9uX190aXRsZVwiPlZlcml0YXRpcyBxdWkgcXVpYSBkZWxlY3R1cy48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlIHdleF9leGVtcHRpb25cIj5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTE3NFwiPlxuICAgICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTE3NFwiIHR5cGU9XCJjaGVja2JveFwiIHZhbHVlPVwiMTc0XCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgICAgPHNwYW4gY2xhc3M9XCJ3ZXhfZXhlbXB0aW9uX19jb2RlXCI+VTE3NDwvc3Bhbj4gPHNwYW4gY2xhc3M9XCJ3ZXhfZXhlbXB0aW9uX190aXRsZVwiPkRlc2VydW50IHJlaWNpZW5kaXMgcGVyZmVyZW5kaXMgdG90YW0uPC9zcGFuPlxuPC9sYWJlbD4gICAgICAgICAgPC9kaXY+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZSB3ZXhfZXhlbXB0aW9uXCI+XG4gICAgICAgICAgICA8bGFiZWwgZm9yPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUxNzVcIj5cbiAgICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUxNzVcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjE3NVwiIG5hbWU9XCJleGVtcHRpb25zX2Zvcm1bZXhlbXB0aW9uc11bXVwiIC8+XG4gICAgICAgICAgICAgIDxzcGFuIGNsYXNzPVwid2V4X2V4ZW1wdGlvbl9fY29kZVwiPlUxNzU8L3NwYW4+IDxzcGFuIGNsYXNzPVwid2V4X2V4ZW1wdGlvbl9fdGl0bGVcIj5MYWJvcmUgZXVtIHBvc3NpbXVzIGFzcGVybmF0dXIuPC9zcGFuPlxuPC9sYWJlbD4gICAgICAgICAgPC9kaXY+XG4gICAgICA8L2ZpZWxkc2V0PlxuICAgIDwvZGl2PlxuXG4gICAgPGlucHV0IHZhbHVlPVwibVBXNmNoYTZwNHkxQ1RuYkFjcUo5UU5lXCIgdHlwZT1cImhpZGRlblwiIG5hbWU9XCJleGVtcHRpb25zX2Zvcm1bdG9rZW5dXCIgaWQ9XCJleGVtcHRpb25zX2Zvcm1fdG9rZW5cIiAvPlxuICAgIDxkaXYgY2xhc3M9XCJmb3JtLWdyb3VwXCI+XG4gICAgICA8aW5wdXQgdHlwZT1cInN1Ym1pdFwiIG5hbWU9XCJjb21taXRcIiB2YWx1ZT1cIkNvbnRpbnVlXCIgY2xhc3M9XCJidXR0b25cIiAvPlxuICAgIDwvZGl2PlxuPC9mb3JtPjwvZGl2PlxuXG5cbjwvYm9keT5cbjwvaHRtbD4ifX0K
+        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9zdHlsZXNoZWV0cy9hcHBsaWNhdGlvbi5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvamF2YXNjcmlwdHMvYXBwbGljYXRpb24uanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxhIGNsYXNzPVwibGluay1iYWNrXCIgaHJlZj1cIi93YXN0ZV9leGVtcHRpb25zX2VuZ2luZS9Wb2VpNVRIUVNxbjdpbjNNYUp3Y0Zwa0gvZXhlbXB0aW9ucy9iYWNrXCI+QmFjazwvYT5cblxuXG48ZGl2IGNsYXNzPVwidGV4dFwiPlxuICA8Zm9ybSBjbGFzcz1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBpZD1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBhY3Rpb249XCIvd2FzdGVfZXhlbXB0aW9uc19lbmdpbmUvVm9laTVUSFFTcW43aW4zTWFKd2NGcGtIL2V4ZW1wdGlvbnNcIiBhY2NlcHQtY2hhcnNldD1cIlVURi04XCIgbWV0aG9kPVwicG9zdFwiPjxpbnB1dCBuYW1lPVwidXRmOFwiIHR5cGU9XCJoaWRkZW5cIiB2YWx1ZT1cIiYjeDI3MTM7XCIgLz5cbiAgICBcblxuICAgIDxoMSBjbGFzcz1cImhlYWRpbmctbGFyZ2VcIj5XaGljaCBleGVtcHRpb25zIGFyZSBuZWVkZWQgZm9yIHRoaXMgd2FzdGUgb3BlcmF0aW9uPzwvaDE+XG5cbiAgICA8cD5TZWxlY3QgYWxsIHRoZSB3YXN0ZSBleGVtcHRpb25zIHlvdSBuZWVkIHRvIGFkZCB0byB0aGUgcmVnaXN0cmF0aW9uPC9wPlxuXG4gICAgPGRpdiBjbGFzcz1cImZvcm0tZ3JvdXAgXCI+XG4gICAgICA8ZmllbGRzZXQgaWQ9XCJtYXRjaGVkX2V4ZW1wdGlvbnNcIj5cbiAgICAgICAgPGxlZ2VuZCBjbGFzcz1cInZpc3VhbGx5LWhpZGRlblwiPkV4ZW1wdGlvbnM8L2xlZ2VuZD5cblxuXG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUxXCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCIxXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTFcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTE8L3NwYW4+IDxzcGFuPlF1aXMgYWxpcXVpZCBtYWduYW0gbW9sbGl0aWEuPC9zcGFuPlxuPC9sYWJlbD4gICAgICAgICAgPC9kaXY+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUyXCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCIyXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTJcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTI8L3NwYW4+IDxzcGFuPkZ1Z2l0IGFkIHNpdCBtYWduaS48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTNcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjNcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VM1wiPlxuICAgICAgICAgICAgICA8c3Bhbj5VMzwvc3Bhbj4gPHNwYW4+U3VudCB2ZXJpdGF0aXMgdm9sdXB0YXRpYnVzIGFzcGVyaW9yZXMuPC9zcGFuPlxuPC9sYWJlbD4gICAgICAgICAgPC9kaXY+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVU0XCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCI0XCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTRcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTQ8L3NwYW4+IDxzcGFuPkV0IGlkIGRvbG9yZW1xdWUgcXVpLjwvc3Bhbj5cbjwvbGFiZWw+ICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJtdWx0aXBsZS1jaG9pY2VcIj5cbiAgICAgICAgICAgIDxpbnB1dCBpZD1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VNVwiIHR5cGU9XCJjaGVja2JveFwiIHZhbHVlPVwiNVwiIG5hbWU9XCJleGVtcHRpb25zX2Zvcm1bZXhlbXB0aW9uc11bXVwiIC8+XG4gICAgICAgICAgICA8bGFiZWwgZm9yPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVU1XCI+XG4gICAgICAgICAgICAgIDxzcGFuPlU1PC9zcGFuPiA8c3Bhbj5OZW1vIGVhcnVtIHRlbXBvcmlidXMgdmVuaWFtLjwvc3Bhbj5cbjwvbGFiZWw+ICAgICAgICAgIDwvZGl2PlxuICAgICAgPC9maWVsZHNldD5cbiAgICA8L2Rpdj5cblxuICAgIDxpbnB1dCB2YWx1ZT1cIlZvZWk1VEhRU3FuN2luM01hSndjRnBrSFwiIHR5cGU9XCJoaWRkZW5cIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW3Rva2VuXVwiIGlkPVwiZXhlbXB0aW9uc19mb3JtX3Rva2VuXCIgLz5cbiAgICA8ZGl2IGNsYXNzPVwiZm9ybS1ncm91cFwiPlxuICAgICAgPGlucHV0IHR5cGU9XCJzdWJtaXRcIiBuYW1lPVwiY29tbWl0XCIgdmFsdWU9XCJDb250aW51ZVwiIGNsYXNzPVwiYnV0dG9uXCIgLz5cbiAgICA8L2Rpdj5cbjwvZm9ybT48L2Rpdj5cblxuXG48L2JvZHk+XG48L2h0bWw+In19Cg==
     http_version: 
-  recorded_at: Tue, 17 Sep 2019 13:46:08 GMT
+  recorded_at: Wed, 18 Sep 2019 09:43:04 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/w3c_valid_content/exemptions_forms_spec/when-the-registration-is-in-the-correct-state.yml
+++ b/spec/cassettes/w3c_valid_content/exemptions_forms_spec/when-the-registration-is-in-the-correct-state.yml
@@ -8,10 +8,9 @@ http_interactions:
       string: "<!DOCTYPE html>\n<html>\n<head>\n  <title>Dummy</title>\n  <link rel=\"stylesheet\"
         media=\"all\" href=\"/stylesheets/application.css\" data-turbolinks-track=\"true\"
         />\n  <script src=\"/javascripts/application.js\" data-turbolinks-track=\"true\"></script>\n
-<<<<<<< HEAD
-        \ \n</head>\n<body>\n\n<a class=\"link-back\" href=\"/waste_exemptions_engine/Voei5THQSqn7in3MaJwcFpkH/exemptions/back\">Back</a>\n\n\n<div
+        \ \n</head>\n<body>\n\n<a class=\"link-back\" href=\"/waste_exemptions_engine/zG1GBhhN3uc8Q2tqujTsK7K5/exemptions/back\">Back</a>\n\n\n<div
         class=\"text\">\n  <form class=\"new_exemptions_form\" id=\"new_exemptions_form\"
-        action=\"/waste_exemptions_engine/Voei5THQSqn7in3MaJwcFpkH/exemptions\" accept-charset=\"UTF-8\"
+        action=\"/waste_exemptions_engine/zG1GBhhN3uc8Q2tqujTsK7K5/exemptions\" accept-charset=\"UTF-8\"
         method=\"post\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" />\n
         \   \n\n    <h1 class=\"heading-large\">Which exemptions are needed for this
         waste operation?</h1>\n\n    <p>Select all the waste exemptions you need to
@@ -20,54 +19,24 @@ http_interactions:
         \         <div class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U1\"
         type=\"checkbox\" value=\"1\" name=\"exemptions_form[exemptions][]\" />\n
         \           <label for=\"exemptions_form_checkbox-U1\">\n              <span>U1</span>
-        <span>Quis aliquid magnam mollitia.</span>\n</label>          </div>\n          <div
+        <span>Commodi nobis nam rerum.</span>\n</label>          </div>\n          <div
         class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U2\"
         type=\"checkbox\" value=\"2\" name=\"exemptions_form[exemptions][]\" />\n
         \           <label for=\"exemptions_form_checkbox-U2\">\n              <span>U2</span>
-        <span>Fugit ad sit magni.</span>\n</label>          </div>\n          <div
+        <span>Tempora minima in perferendis.</span>\n</label>          </div>\n          <div
         class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U3\"
         type=\"checkbox\" value=\"3\" name=\"exemptions_form[exemptions][]\" />\n
         \           <label for=\"exemptions_form_checkbox-U3\">\n              <span>U3</span>
-        <span>Sunt veritatis voluptatibus asperiores.</span>\n</label>          </div>\n
-        \         <div class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U4\"
-        type=\"checkbox\" value=\"4\" name=\"exemptions_form[exemptions][]\" />\n
-        \           <label for=\"exemptions_form_checkbox-U4\">\n              <span>U4</span>
-        <span>Et id doloremque qui.</span>\n</label>          </div>\n          <div
-        class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U5\"
-        type=\"checkbox\" value=\"5\" name=\"exemptions_form[exemptions][]\" />\n
-        \           <label for=\"exemptions_form_checkbox-U5\">\n              <span>U5</span>
-        <span>Nemo earum temporibus veniam.</span>\n</label>          </div>\n      </fieldset>\n
-        \   </div>\n\n    <input value=\"Voei5THQSqn7in3MaJwcFpkH\" type=\"hidden\"
-=======
-        \ \n</head>\n<body>\n\n<a class=\"link-back\" href=\"/waste_exemptions_engine/exemptions/back/ShxTEVGmiEqDzaCqY61ghfiH\">Back</a>\n\n\n<div
-        class=\"text\">\n  <form class=\"new_exemptions_form\" id=\"new_exemptions_form\"
-        action=\"/waste_exemptions_engine/exemptions\" accept-charset=\"UTF-8\" method=\"post\"><input
-        name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" />\n    \n\n    <h1 class=\"heading-large\">Which
-        exemptions are needed for this waste operation?</h1>\n\n    <p>Select all
-        the waste exemptions you need to add to the registration</p>\n\n    <div class=\"form-group
-        \">\n      <fieldset id=\"matched_exemptions\">\n        <legend class=\"visually-hidden\">Exemptions</legend>\n\n\n
-        \         <div class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U1\"
-        type=\"checkbox\" value=\"1\" name=\"exemptions_form[exemptions][]\" />\n
-        \           <label for=\"exemptions_form_checkbox-U1\">\n              <span>U1</span>
-        <span>Expedita provident molestiae saepe.</span>\n</label>          </div>\n
-        \         <div class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U2\"
-        type=\"checkbox\" value=\"2\" name=\"exemptions_form[exemptions][]\" />\n
-        \           <label for=\"exemptions_form_checkbox-U2\">\n              <span>U2</span>
-        <span>Cumque temporibus voluptatem voluptate.</span>\n</label>          </div>\n
-        \         <div class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U3\"
-        type=\"checkbox\" value=\"3\" name=\"exemptions_form[exemptions][]\" />\n
-        \           <label for=\"exemptions_form_checkbox-U3\">\n              <span>U3</span>
-        <span>Itaque corporis ab dicta.</span>\n</label>          </div>\n          <div
+        <span>Aliquid quod vero sit.</span>\n</label>          </div>\n          <div
         class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U4\"
         type=\"checkbox\" value=\"4\" name=\"exemptions_form[exemptions][]\" />\n
         \           <label for=\"exemptions_form_checkbox-U4\">\n              <span>U4</span>
-        <span>Totam assumenda quidem ea.</span>\n</label>          </div>\n          <div
+        <span>Autem vitae minima molestias.</span>\n</label>          </div>\n          <div
         class=\"multiple-choice\">\n            <input id=\"exemptions_form_checkbox-U5\"
         type=\"checkbox\" value=\"5\" name=\"exemptions_form[exemptions][]\" />\n
         \           <label for=\"exemptions_form_checkbox-U5\">\n              <span>U5</span>
-        <span>Iure illo explicabo sint.</span>\n</label>          </div>\n      </fieldset>\n
-        \   </div>\n\n    <input value=\"ShxTEVGmiEqDzaCqY61ghfiH\" type=\"hidden\"
->>>>>>> Update cassette
+        <span>Ad corporis voluptatum labore.</span>\n</label>          </div>\n      </fieldset>\n
+        \   </div>\n\n    <input value=\"zG1GBhhN3uc8Q2tqujTsK7K5\" type=\"hidden\"
         name=\"exemptions_form[token]\" id=\"exemptions_form_token\" />\n    <div
         class=\"form-group\">\n      <input type=\"submit\" name=\"commit\" value=\"Continue\"
         class=\"button\" />\n    </div>\n</form></div>\n\n\n</body>\n</html>\n"
@@ -86,11 +55,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-<<<<<<< HEAD
-      - Wed, 18 Sep 2019 09:43:04 GMT
-=======
-      - Tue, 17 Sep 2019 14:26:05 GMT
->>>>>>> Update cassette
+      - Wed, 18 Sep 2019 09:46:16 GMT
       Accept-Encoding:
       - gzip
       Access-Control-Allow-Origin:
@@ -121,13 +86,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-<<<<<<< HEAD
-        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9zdHlsZXNoZWV0cy9hcHBsaWNhdGlvbi5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvamF2YXNjcmlwdHMvYXBwbGljYXRpb24uanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxhIGNsYXNzPVwibGluay1iYWNrXCIgaHJlZj1cIi93YXN0ZV9leGVtcHRpb25zX2VuZ2luZS9Wb2VpNVRIUVNxbjdpbjNNYUp3Y0Zwa0gvZXhlbXB0aW9ucy9iYWNrXCI+QmFjazwvYT5cblxuXG48ZGl2IGNsYXNzPVwidGV4dFwiPlxuICA8Zm9ybSBjbGFzcz1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBpZD1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBhY3Rpb249XCIvd2FzdGVfZXhlbXB0aW9uc19lbmdpbmUvVm9laTVUSFFTcW43aW4zTWFKd2NGcGtIL2V4ZW1wdGlvbnNcIiBhY2NlcHQtY2hhcnNldD1cIlVURi04XCIgbWV0aG9kPVwicG9zdFwiPjxpbnB1dCBuYW1lPVwidXRmOFwiIHR5cGU9XCJoaWRkZW5cIiB2YWx1ZT1cIiYjeDI3MTM7XCIgLz5cbiAgICBcblxuICAgIDxoMSBjbGFzcz1cImhlYWRpbmctbGFyZ2VcIj5XaGljaCBleGVtcHRpb25zIGFyZSBuZWVkZWQgZm9yIHRoaXMgd2FzdGUgb3BlcmF0aW9uPzwvaDE+XG5cbiAgICA8cD5TZWxlY3QgYWxsIHRoZSB3YXN0ZSBleGVtcHRpb25zIHlvdSBuZWVkIHRvIGFkZCB0byB0aGUgcmVnaXN0cmF0aW9uPC9wPlxuXG4gICAgPGRpdiBjbGFzcz1cImZvcm0tZ3JvdXAgXCI+XG4gICAgICA8ZmllbGRzZXQgaWQ9XCJtYXRjaGVkX2V4ZW1wdGlvbnNcIj5cbiAgICAgICAgPGxlZ2VuZCBjbGFzcz1cInZpc3VhbGx5LWhpZGRlblwiPkV4ZW1wdGlvbnM8L2xlZ2VuZD5cblxuXG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUxXCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCIxXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTFcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTE8L3NwYW4+IDxzcGFuPlF1aXMgYWxpcXVpZCBtYWduYW0gbW9sbGl0aWEuPC9zcGFuPlxuPC9sYWJlbD4gICAgICAgICAgPC9kaXY+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUyXCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCIyXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTJcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTI8L3NwYW4+IDxzcGFuPkZ1Z2l0IGFkIHNpdCBtYWduaS48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTNcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjNcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VM1wiPlxuICAgICAgICAgICAgICA8c3Bhbj5VMzwvc3Bhbj4gPHNwYW4+U3VudCB2ZXJpdGF0aXMgdm9sdXB0YXRpYnVzIGFzcGVyaW9yZXMuPC9zcGFuPlxuPC9sYWJlbD4gICAgICAgICAgPC9kaXY+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVU0XCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCI0XCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTRcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTQ8L3NwYW4+IDxzcGFuPkV0IGlkIGRvbG9yZW1xdWUgcXVpLjwvc3Bhbj5cbjwvbGFiZWw+ICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJtdWx0aXBsZS1jaG9pY2VcIj5cbiAgICAgICAgICAgIDxpbnB1dCBpZD1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VNVwiIHR5cGU9XCJjaGVja2JveFwiIHZhbHVlPVwiNVwiIG5hbWU9XCJleGVtcHRpb25zX2Zvcm1bZXhlbXB0aW9uc11bXVwiIC8+XG4gICAgICAgICAgICA8bGFiZWwgZm9yPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVU1XCI+XG4gICAgICAgICAgICAgIDxzcGFuPlU1PC9zcGFuPiA8c3Bhbj5OZW1vIGVhcnVtIHRlbXBvcmlidXMgdmVuaWFtLjwvc3Bhbj5cbjwvbGFiZWw+ICAgICAgICAgIDwvZGl2PlxuICAgICAgPC9maWVsZHNldD5cbiAgICA8L2Rpdj5cblxuICAgIDxpbnB1dCB2YWx1ZT1cIlZvZWk1VEhRU3FuN2luM01hSndjRnBrSFwiIHR5cGU9XCJoaWRkZW5cIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW3Rva2VuXVwiIGlkPVwiZXhlbXB0aW9uc19mb3JtX3Rva2VuXCIgLz5cbiAgICA8ZGl2IGNsYXNzPVwiZm9ybS1ncm91cFwiPlxuICAgICAgPGlucHV0IHR5cGU9XCJzdWJtaXRcIiBuYW1lPVwiY29tbWl0XCIgdmFsdWU9XCJDb250aW51ZVwiIGNsYXNzPVwiYnV0dG9uXCIgLz5cbiAgICA8L2Rpdj5cbjwvZm9ybT48L2Rpdj5cblxuXG48L2JvZHk+XG48L2h0bWw+In19Cg==
+        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9zdHlsZXNoZWV0cy9hcHBsaWNhdGlvbi5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvamF2YXNjcmlwdHMvYXBwbGljYXRpb24uanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxhIGNsYXNzPVwibGluay1iYWNrXCIgaHJlZj1cIi93YXN0ZV9leGVtcHRpb25zX2VuZ2luZS96RzFHQmhoTjN1YzhRMnRxdWpUc0s3SzUvZXhlbXB0aW9ucy9iYWNrXCI+QmFjazwvYT5cblxuXG48ZGl2IGNsYXNzPVwidGV4dFwiPlxuICA8Zm9ybSBjbGFzcz1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBpZD1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBhY3Rpb249XCIvd2FzdGVfZXhlbXB0aW9uc19lbmdpbmUvekcxR0JoaE4zdWM4UTJ0cXVqVHNLN0s1L2V4ZW1wdGlvbnNcIiBhY2NlcHQtY2hhcnNldD1cIlVURi04XCIgbWV0aG9kPVwicG9zdFwiPjxpbnB1dCBuYW1lPVwidXRmOFwiIHR5cGU9XCJoaWRkZW5cIiB2YWx1ZT1cIiYjeDI3MTM7XCIgLz5cbiAgICBcblxuICAgIDxoMSBjbGFzcz1cImhlYWRpbmctbGFyZ2VcIj5XaGljaCBleGVtcHRpb25zIGFyZSBuZWVkZWQgZm9yIHRoaXMgd2FzdGUgb3BlcmF0aW9uPzwvaDE+XG5cbiAgICA8cD5TZWxlY3QgYWxsIHRoZSB3YXN0ZSBleGVtcHRpb25zIHlvdSBuZWVkIHRvIGFkZCB0byB0aGUgcmVnaXN0cmF0aW9uPC9wPlxuXG4gICAgPGRpdiBjbGFzcz1cImZvcm0tZ3JvdXAgXCI+XG4gICAgICA8ZmllbGRzZXQgaWQ9XCJtYXRjaGVkX2V4ZW1wdGlvbnNcIj5cbiAgICAgICAgPGxlZ2VuZCBjbGFzcz1cInZpc3VhbGx5LWhpZGRlblwiPkV4ZW1wdGlvbnM8L2xlZ2VuZD5cblxuXG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUxXCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCIxXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTFcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTE8L3NwYW4+IDxzcGFuPkNvbW1vZGkgbm9iaXMgbmFtIHJlcnVtLjwvc3Bhbj5cbjwvbGFiZWw+ICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJtdWx0aXBsZS1jaG9pY2VcIj5cbiAgICAgICAgICAgIDxpbnB1dCBpZD1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VMlwiIHR5cGU9XCJjaGVja2JveFwiIHZhbHVlPVwiMlwiIG5hbWU9XCJleGVtcHRpb25zX2Zvcm1bZXhlbXB0aW9uc11bXVwiIC8+XG4gICAgICAgICAgICA8bGFiZWwgZm9yPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUyXCI+XG4gICAgICAgICAgICAgIDxzcGFuPlUyPC9zcGFuPiA8c3Bhbj5UZW1wb3JhIG1pbmltYSBpbiBwZXJmZXJlbmRpcy48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTNcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjNcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VM1wiPlxuICAgICAgICAgICAgICA8c3Bhbj5VMzwvc3Bhbj4gPHNwYW4+QWxpcXVpZCBxdW9kIHZlcm8gc2l0Ljwvc3Bhbj5cbjwvbGFiZWw+ICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJtdWx0aXBsZS1jaG9pY2VcIj5cbiAgICAgICAgICAgIDxpbnB1dCBpZD1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VNFwiIHR5cGU9XCJjaGVja2JveFwiIHZhbHVlPVwiNFwiIG5hbWU9XCJleGVtcHRpb25zX2Zvcm1bZXhlbXB0aW9uc11bXVwiIC8+XG4gICAgICAgICAgICA8bGFiZWwgZm9yPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVU0XCI+XG4gICAgICAgICAgICAgIDxzcGFuPlU0PC9zcGFuPiA8c3Bhbj5BdXRlbSB2aXRhZSBtaW5pbWEgbW9sZXN0aWFzLjwvc3Bhbj5cbjwvbGFiZWw+ICAgICAgICAgIDwvZGl2PlxuICAgICAgICAgIDxkaXYgY2xhc3M9XCJtdWx0aXBsZS1jaG9pY2VcIj5cbiAgICAgICAgICAgIDxpbnB1dCBpZD1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VNVwiIHR5cGU9XCJjaGVja2JveFwiIHZhbHVlPVwiNVwiIG5hbWU9XCJleGVtcHRpb25zX2Zvcm1bZXhlbXB0aW9uc11bXVwiIC8+XG4gICAgICAgICAgICA8bGFiZWwgZm9yPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVU1XCI+XG4gICAgICAgICAgICAgIDxzcGFuPlU1PC9zcGFuPiA8c3Bhbj5BZCBjb3Jwb3JpcyB2b2x1cHRhdHVtIGxhYm9yZS48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgIDwvZmllbGRzZXQ+XG4gICAgPC9kaXY+XG5cbiAgICA8aW5wdXQgdmFsdWU9XCJ6RzFHQmhoTjN1YzhRMnRxdWpUc0s3SzVcIiB0eXBlPVwiaGlkZGVuXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVt0b2tlbl1cIiBpZD1cImV4ZW1wdGlvbnNfZm9ybV90b2tlblwiIC8+XG4gICAgPGRpdiBjbGFzcz1cImZvcm0tZ3JvdXBcIj5cbiAgICAgIDxpbnB1dCB0eXBlPVwic3VibWl0XCIgbmFtZT1cImNvbW1pdFwiIHZhbHVlPVwiQ29udGludWVcIiBjbGFzcz1cImJ1dHRvblwiIC8+XG4gICAgPC9kaXY+XG48L2Zvcm0+PC9kaXY+XG5cblxuPC9ib2R5PlxuPC9odG1sPiJ9fQo=
     http_version: 
-  recorded_at: Wed, 18 Sep 2019 09:43:04 GMT
-=======
-        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9zdHlsZXNoZWV0cy9hcHBsaWNhdGlvbi5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvamF2YXNjcmlwdHMvYXBwbGljYXRpb24uanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxhIGNsYXNzPVwibGluay1iYWNrXCIgaHJlZj1cIi93YXN0ZV9leGVtcHRpb25zX2VuZ2luZS9leGVtcHRpb25zL2JhY2svU2h4VEVWR21pRXFEemFDcVk2MWdoZmlIXCI+QmFjazwvYT5cblxuXG48ZGl2IGNsYXNzPVwidGV4dFwiPlxuICA8Zm9ybSBjbGFzcz1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBpZD1cIm5ld19leGVtcHRpb25zX2Zvcm1cIiBhY3Rpb249XCIvd2FzdGVfZXhlbXB0aW9uc19lbmdpbmUvZXhlbXB0aW9uc1wiIGFjY2VwdC1jaGFyc2V0PVwiVVRGLThcIiBtZXRob2Q9XCJwb3N0XCI+PGlucHV0IG5hbWU9XCJ1dGY4XCIgdHlwZT1cImhpZGRlblwiIHZhbHVlPVwiJiN4MjcxMztcIiAvPlxuICAgIFxuXG4gICAgPGgxIGNsYXNzPVwiaGVhZGluZy1sYXJnZVwiPldoaWNoIGV4ZW1wdGlvbnMgYXJlIG5lZWRlZCBmb3IgdGhpcyB3YXN0ZSBvcGVyYXRpb24/PC9oMT5cblxuICAgIDxwPlNlbGVjdCBhbGwgdGhlIHdhc3RlIGV4ZW1wdGlvbnMgeW91IG5lZWQgdG8gYWRkIHRvIHRoZSByZWdpc3RyYXRpb248L3A+XG5cbiAgICA8ZGl2IGNsYXNzPVwiZm9ybS1ncm91cCBcIj5cbiAgICAgIDxmaWVsZHNldCBpZD1cIm1hdGNoZWRfZXhlbXB0aW9uc1wiPlxuICAgICAgICA8bGVnZW5kIGNsYXNzPVwidmlzdWFsbHktaGlkZGVuXCI+RXhlbXB0aW9uczwvbGVnZW5kPlxuXG5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTFcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjFcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VMVwiPlxuICAgICAgICAgICAgICA8c3Bhbj5VMTwvc3Bhbj4gPHNwYW4+RXhwZWRpdGEgcHJvdmlkZW50IG1vbGVzdGlhZSBzYWVwZS48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTJcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjJcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VMlwiPlxuICAgICAgICAgICAgICA8c3Bhbj5VMjwvc3Bhbj4gPHNwYW4+Q3VtcXVlIHRlbXBvcmlidXMgdm9sdXB0YXRlbSB2b2x1cHRhdGUuPC9zcGFuPlxuPC9sYWJlbD4gICAgICAgICAgPC9kaXY+XG4gICAgICAgICAgPGRpdiBjbGFzcz1cIm11bHRpcGxlLWNob2ljZVwiPlxuICAgICAgICAgICAgPGlucHV0IGlkPVwiZXhlbXB0aW9uc19mb3JtX2NoZWNrYm94LVUzXCIgdHlwZT1cImNoZWNrYm94XCIgdmFsdWU9XCIzXCIgbmFtZT1cImV4ZW1wdGlvbnNfZm9ybVtleGVtcHRpb25zXVtdXCIgLz5cbiAgICAgICAgICAgIDxsYWJlbCBmb3I9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTNcIj5cbiAgICAgICAgICAgICAgPHNwYW4+VTM8L3NwYW4+IDxzcGFuPkl0YXF1ZSBjb3Jwb3JpcyBhYiBkaWN0YS48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTRcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjRcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VNFwiPlxuICAgICAgICAgICAgICA8c3Bhbj5VNDwvc3Bhbj4gPHNwYW4+VG90YW0gYXNzdW1lbmRhIHF1aWRlbSBlYS48L3NwYW4+XG48L2xhYmVsPiAgICAgICAgICA8L2Rpdj5cbiAgICAgICAgICA8ZGl2IGNsYXNzPVwibXVsdGlwbGUtY2hvaWNlXCI+XG4gICAgICAgICAgICA8aW5wdXQgaWQ9XCJleGVtcHRpb25zX2Zvcm1fY2hlY2tib3gtVTVcIiB0eXBlPVwiY2hlY2tib3hcIiB2YWx1ZT1cIjVcIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW2V4ZW1wdGlvbnNdW11cIiAvPlxuICAgICAgICAgICAgPGxhYmVsIGZvcj1cImV4ZW1wdGlvbnNfZm9ybV9jaGVja2JveC1VNVwiPlxuICAgICAgICAgICAgICA8c3Bhbj5VNTwvc3Bhbj4gPHNwYW4+SXVyZSBpbGxvIGV4cGxpY2FibyBzaW50Ljwvc3Bhbj5cbjwvbGFiZWw+ICAgICAgICAgIDwvZGl2PlxuICAgICAgPC9maWVsZHNldD5cbiAgICA8L2Rpdj5cblxuICAgIDxpbnB1dCB2YWx1ZT1cIlNoeFRFVkdtaUVxRHphQ3FZNjFnaGZpSFwiIHR5cGU9XCJoaWRkZW5cIiBuYW1lPVwiZXhlbXB0aW9uc19mb3JtW3Rva2VuXVwiIGlkPVwiZXhlbXB0aW9uc19mb3JtX3Rva2VuXCIgLz5cbiAgICA8ZGl2IGNsYXNzPVwiZm9ybS1ncm91cFwiPlxuICAgICAgPGlucHV0IHR5cGU9XCJzdWJtaXRcIiBuYW1lPVwiY29tbWl0XCIgdmFsdWU9XCJDb250aW51ZVwiIGNsYXNzPVwiYnV0dG9uXCIgLz5cbiAgICA8L2Rpdj5cbjwvZm9ybT48L2Rpdj5cblxuXG48L2JvZHk+XG48L2h0bWw+In19Cg==
-    http_version: 
-  recorded_at: Tue, 17 Sep 2019 14:26:05 GMT
->>>>>>> Update cassette
+  recorded_at: Wed, 18 Sep 2019 09:46:16 GMT
 recorded_with: VCR 5.0.0


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-608

We have tried to restyle the GDS elements checkbox to try achieve better reading for screen readers on our exemptions list.
In doing so, however, we have created a visual issue in the fact that the `focus` status's stile does not get applied to the checkboxes.
We have then decided to wait for GDS to deal with the screen readers issue (a ticket have been opened with them and is in their backlog).
So we are rolling back a part of this refactoring and the custom style in order to restore the checkboxes to their original behaviour.