### PR TITLE
Add active_and_expired_exemptions scope to registrations

### DIFF
--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -24,6 +24,12 @@ module WasteExemptionsEngine
       through: :registration_exemptions,
       source: :exemption
     )
+    has_many(
+      :expired_and_active_exemptions,
+      -> { WasteExemptionsEngine::RegistrationExemption.where(state: %i[expired active]) },
+      through: :registration_exemptions,
+      source: :exemption
+    )
     belongs_to :referring_registration, class_name: "Registration"
     has_one :referred_registration, class_name: "Registration", foreign_key: "referring_registration_id"
 

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
       registration_exemptions { build_list(:registration_exemption, 5, state: :expired) }
     end
 
+    trait :with_expired_and_active_exemptions do
+      registration_exemptions { build_list(:registration_exemption, 5, state: %i[expired active].sample) }
+    end
+
     trait :limited_company do
       business_type { WasteExemptionsEngine::Registration::BUSINESS_TYPES[:limited_company] }
     end

--- a/spec/models/waste_exemptions_engine/registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_spec.rb
@@ -105,6 +105,18 @@ module WasteExemptionsEngine
       end
     end
 
+    describe "#expired_and_active_exemptions" do
+      subject(:registration) { create(:registration, :with_expired_and_active_exemptions) }
+
+      it "returns a list of registrations in an active status" do
+        pending_exemption = registration.registration_exemptions.first
+        pending_exemption.state = :pending
+        pending_exemption.save
+
+        expect(registration.expired_and_active_exemptions.count).to eq(registration.exemptions.count - 1)
+      end
+    end
+
     describe "#past_renewal_window?" do
       let(:registration_exemption) { build(:registration_exemption, expires_on: expires_on) }
 


### PR DESCRIPTION
In the back office, in more than one place, we have the need of get a unique list (scope) of active and expired exemptions since we want to be able to declare an order to the list.