### PR TITLE
Add visually hidden name info to delete partner button

### DIFF
--- a/app/views/waste_exemptions_engine/main_people_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/main_people_forms/new.html.erb
@@ -36,11 +36,17 @@
         <% @transient_registration.transient_people.each do |person| %>
           <li>
             <%= person.first_name %> <%= person.last_name %>
-            <%= button_to(t(".delete_person_link"),
+            <%= button_to(
                 delete_person_main_people_forms_path(token: @main_people_form.token, id: person.id),
                 class: "button-link",
                 method: :delete,
-                params: { token: @main_people_form.token }) %>
+                params: { token: @main_people_form.token }
+            ) do %>
+              <%= t(".delete_person_link") %>
+              <span class="visually-hidden">
+                <%= person.first_name %> <%= person.last_name %>
+              </span>
+            <% end %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
Closes: https://eaflood.atlassian.net/browse/RUBY-609

Add visually hidden text so that screen readers can distinguish a delete button from another in the main people list.

<img width="1154" alt="Screenshot 2019-09-20 at 11 04 56" src="https://user-images.githubusercontent.com/1385397/65319150-e3817400-db96-11e9-8517-e7615fad8875.png">
