### PR TITLE
Fix broken link to NRW waste exemptions page

### DIFF
--- a/app/views/waste_exemptions_engine/register_in_wales_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/register_in_wales_forms/new.html.erb
@@ -8,7 +8,7 @@
 
     <div class="form-group">
       <p><%= t(".paragraph_1") %></p>
-      <p><%= t(".paragraph_2") %> <a href="https://naturalresources.wales/permits-and-permissions/waste/register-your-waste-exemptions"><%= t(".service_link") %></a>.</p>
+      <p><%= t(".paragraph_2") %> <a href="https://naturalresources.wales/permits-and-permissions/waste-permitting"><%= t(".service_link") %></a>.</p>
       <p><%= t(".paragraph_3") %></p>
     </div>
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-647

Our QA @andrewhick spotted in testing that the link to NRW on the register in wales page was no longer working. When clicked users were presented with a 404 from the NRW site.

The issue appears to be that they no longer have a root waste exemptions page. They now have

- [Register or renew your waste exemptions: agricultural premises](https://naturalresources.wales/permits-and-permissions/waste-permitting/register-or-renew-your-waste-exemptions-agricultural-premises/)
- [Register or renew your waste exemptions: non-agricultural premises](https://naturalresources.wales/permits-and-permissions/waste-permitting/register-or-renew-your-waste-exemptions-non-agricultural-waste/)

There was some discussion about whether we needed to update our page to include both links, but in agreement with our Product Manager we have opted to use the link to the parent page for the 2 waste exemptions ones, which is [Waste permitting](https://naturalresources.wales/permits-and-permissions/waste-permitting).