### PR TITLE
Clean db from Addresses

### DIFF
--- a/spec/models/waste_exemptions_engine/address_spec.rb
+++ b/spec/models/waste_exemptions_engine/address_spec.rb
@@ -17,6 +17,12 @@ module WasteExemptionsEngine
     end
 
     context "scopes" do
+      before do
+        # TODO: This is necessary as those tests are generating random failures due to
+        # the database not being cleaned properly by some other test
+        described_class.delete_all
+      end
+
       describe ".missing_easting_or_northing" do
         it "returns all address with x and y information" do
           missing_info_records = []


### PR DESCRIPTION
Some tests are leaving the DB dirty with Addresses, making the model's spec fail.
We have already witnessed some instance of those random failures, such as: https://travis-ci.com/DEFRA/waste-exemptions-engine/builds/128905376

This code should prevent that from happening again