### PR TITLE
Restrict address missing scopes to site addresses

### DIFF
--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -11,7 +11,7 @@ module WasteExemptionsEngine
     enum address_type: { unknown: 0, operator: 1, contact: 2, site: 3 }
     enum mode: { unknown_mode: 0, lookup: 1, manual: 2, auto: 3 }
 
-    scope :missing_easting_or_northing, -> { where("x IS NULL OR y IS NULL") }
+    scope :sites_missing_easting_or_northing, -> { where("address_type = 3 AND (x IS NULL OR y IS NULL)") }
     scope :with_easting_and_northing, -> { where.not(x: nil, y: nil) }
     scope :missing_area, -> { where(area: [nil, ""]) }
   end

--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -12,7 +12,7 @@ module WasteExemptionsEngine
     enum mode: { unknown_mode: 0, lookup: 1, manual: 2, auto: 3 }
 
     scope :sites_missing_easting_or_northing, -> { where("address_type = 3 AND (x IS NULL OR y IS NULL)") }
-    scope :with_easting_and_northing, -> { where.not(x: nil, y: nil) }
+    scope :sites_with_easting_and_northing, -> { where("address_type = 3 AND x IS NOT NULL AND y IS NOT NULL") }
     scope :missing_area, -> { where(area: [nil, ""]) }
   end
 end

--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -13,6 +13,6 @@ module WasteExemptionsEngine
 
     scope :sites_missing_easting_or_northing, -> { where("address_type = 3 AND (x IS NULL OR y IS NULL)") }
     scope :sites_with_easting_and_northing, -> { where("address_type = 3 AND x IS NOT NULL AND y IS NOT NULL") }
-    scope :missing_area, -> { where(area: [nil, ""]) }
+    scope :sites_missing_area, -> { where("address_type = 3 AND (area = '' OR area IS NULL)") }
   end
 end

--- a/spec/models/waste_exemptions_engine/address_spec.rb
+++ b/spec/models/waste_exemptions_engine/address_spec.rb
@@ -40,6 +40,9 @@ module WasteExemptionsEngine
       describe ".sites_with_easting_and_northing" do
         it "returns all site addresses with x and y information" do
           create(:address, x: nil, y: 123.4)
+          create(:address, x: 123.4, y: nil)
+          create(:address, x: 123.4, y: 123.4)
+          create(:address, :site_address, x: nil, y: 123.4)
           create(:address, :site_address, x: 123.4, y: nil)
 
           valid_address = create(:address, :site_address, x: 123.4, y: 123.4)

--- a/spec/models/waste_exemptions_engine/address_spec.rb
+++ b/spec/models/waste_exemptions_engine/address_spec.rb
@@ -18,21 +18,23 @@ module WasteExemptionsEngine
 
     context "scopes" do
       before do
-        # TODO: This is necessary as those tests are generating random failures due to
+        # TODO: This is necessary as these tests are generating random failures due to
         # the database not being cleaned properly by some other test
         described_class.delete_all
       end
 
-      describe ".missing_easting_or_northing" do
-        it "returns all address with x and y information" do
+      describe ".sites_missing_easting_or_northing" do
+        it "returns all site addresses missing x and y information" do
           missing_info_records = []
-          missing_info_records << create(:address, x: nil, y: 123.4)
-          missing_info_records << create(:address, x: 123.4, y: nil)
-          missing_info_records << create(:address, x: nil, y: nil)
+          missing_info_records << create(:address, :site_address, x: nil, y: 123.4)
+          missing_info_records << create(:address, :site_address, x: 123.4, y: nil)
+          missing_info_records << create(:address, :site_address, x: nil, y: nil)
 
           create(:address, x: 123.4, y: 123.4)
+          create(:address, x: nil, y: nil)
+          create(:address, :site_address, x: 123.4, y: 123.4)
 
-          expect(described_class.missing_easting_or_northing).to match_array(missing_info_records)
+          expect(described_class.sites_missing_easting_or_northing).to match_array(missing_info_records)
         end
       end
       describe ".with_easting_and_northing" do

--- a/spec/models/waste_exemptions_engine/address_spec.rb
+++ b/spec/models/waste_exemptions_engine/address_spec.rb
@@ -37,15 +37,15 @@ module WasteExemptionsEngine
           expect(described_class.sites_missing_easting_or_northing).to match_array(missing_info_records)
         end
       end
-      describe ".with_easting_and_northing" do
-        it "returns all address with x and y information" do
+      describe ".sites_with_easting_and_northing" do
+        it "returns all site addresses with x and y information" do
           create(:address, x: nil, y: 123.4)
-          create(:address, x: 123.4, y: nil)
+          create(:address, :site_address, x: 123.4, y: nil)
 
-          valid_address = create(:address, x: 123.4, y: 123.4)
+          valid_address = create(:address, :site_address, x: 123.4, y: 123.4)
 
-          expect(described_class.with_easting_and_northing.size).to eq(1)
-          expect(described_class.with_easting_and_northing.first).to eq(valid_address)
+          expect(described_class.sites_with_easting_and_northing.size).to eq(1)
+          expect(described_class.sites_with_easting_and_northing.first).to eq(valid_address)
         end
       end
 

--- a/spec/models/waste_exemptions_engine/address_spec.rb
+++ b/spec/models/waste_exemptions_engine/address_spec.rb
@@ -49,16 +49,19 @@ module WasteExemptionsEngine
         end
       end
 
-      describe ".missing_area" do
-        it "returns all addresses with a missing area" do
+      describe ".sites_missing_area" do
+        it "returns all site addresses with a missing area" do
+          create(:address, area: nil)
+          create(:address, area: "")
           create(:address, area: "West Midlands")
+          create(:address, :site_address, area: "West Midlands")
 
-          nil_area = create(:address, area: nil)
-          empty_area = create(:address, area: "")
+          nil_area = create(:address, :site_address, area: nil)
+          empty_area = create(:address, :site_address, area: "")
 
-          expect(described_class.missing_area.size).to eq(2)
-          expect(described_class.missing_area).to include(empty_area)
-          expect(described_class.missing_area).to include(nil_area)
+          expect(described_class.sites_missing_area.size).to eq(2)
+          expect(described_class.sites_missing_area).to include(empty_area)
+          expect(described_class.sites_missing_area).to include(nil_area)
         end
       end
     end


### PR DESCRIPTION
The various scopes on Address to identify those with missing x & y, and area information is used in jobs to ensure they are populated. The aim is to try and identify the EA area for each registration we have.

The address we use to determine this though is the **site**. Where the site is located is what determines the a registration's area. So we don't care if the x & y or area is missing on the other addresses. We only care they are populated for the site address.