### PR TITLE
Revert "Restrict address missing scopes to site addresses (#365)"

### DIFF
--- a/app/models/waste_exemptions_engine/address.rb
+++ b/app/models/waste_exemptions_engine/address.rb
@@ -11,8 +11,8 @@ module WasteExemptionsEngine
     enum address_type: { unknown: 0, operator: 1, contact: 2, site: 3 }
     enum mode: { unknown_mode: 0, lookup: 1, manual: 2, auto: 3 }
 
-    scope :sites_missing_easting_or_northing, -> { where("address_type = 3 AND (x IS NULL OR y IS NULL)") }
-    scope :sites_with_easting_and_northing, -> { where("address_type = 3 AND x IS NOT NULL AND y IS NOT NULL") }
-    scope :sites_missing_area, -> { where("address_type = 3 AND (area = '' OR area IS NULL)") }
+    scope :missing_easting_or_northing, -> { where("x IS NULL OR y IS NULL") }
+    scope :with_easting_and_northing, -> { where.not(x: nil, y: nil) }
+    scope :missing_area, -> { where(area: [nil, ""]) }
   end
 end

--- a/spec/models/waste_exemptions_engine/address_spec.rb
+++ b/spec/models/waste_exemptions_engine/address_spec.rb
@@ -18,53 +18,45 @@ module WasteExemptionsEngine
 
     context "scopes" do
       before do
-        # TODO: This is necessary as these tests are generating random failures due to
+        # TODO: This is necessary as those tests are generating random failures due to
         # the database not being cleaned properly by some other test
         described_class.delete_all
       end
 
-      describe ".sites_missing_easting_or_northing" do
-        it "returns all site addresses missing x and y information" do
+      describe ".missing_easting_or_northing" do
+        it "returns all address with x and y information" do
           missing_info_records = []
-          missing_info_records << create(:address, :site_address, x: nil, y: 123.4)
-          missing_info_records << create(:address, :site_address, x: 123.4, y: nil)
-          missing_info_records << create(:address, :site_address, x: nil, y: nil)
+          missing_info_records << create(:address, x: nil, y: 123.4)
+          missing_info_records << create(:address, x: 123.4, y: nil)
+          missing_info_records << create(:address, x: nil, y: nil)
 
           create(:address, x: 123.4, y: 123.4)
-          create(:address, x: nil, y: nil)
-          create(:address, :site_address, x: 123.4, y: 123.4)
 
-          expect(described_class.sites_missing_easting_or_northing).to match_array(missing_info_records)
+          expect(described_class.missing_easting_or_northing).to match_array(missing_info_records)
         end
       end
-      describe ".sites_with_easting_and_northing" do
-        it "returns all site addresses with x and y information" do
+      describe ".with_easting_and_northing" do
+        it "returns all address with x and y information" do
           create(:address, x: nil, y: 123.4)
           create(:address, x: 123.4, y: nil)
-          create(:address, x: 123.4, y: 123.4)
-          create(:address, :site_address, x: nil, y: 123.4)
-          create(:address, :site_address, x: 123.4, y: nil)
 
-          valid_address = create(:address, :site_address, x: 123.4, y: 123.4)
+          valid_address = create(:address, x: 123.4, y: 123.4)
 
-          expect(described_class.sites_with_easting_and_northing.size).to eq(1)
-          expect(described_class.sites_with_easting_and_northing.first).to eq(valid_address)
+          expect(described_class.with_easting_and_northing.size).to eq(1)
+          expect(described_class.with_easting_and_northing.first).to eq(valid_address)
         end
       end
 
-      describe ".sites_missing_area" do
-        it "returns all site addresses with a missing area" do
-          create(:address, area: nil)
-          create(:address, area: "")
+      describe ".missing_area" do
+        it "returns all addresses with a missing area" do
           create(:address, area: "West Midlands")
-          create(:address, :site_address, area: "West Midlands")
 
-          nil_area = create(:address, :site_address, area: nil)
-          empty_area = create(:address, :site_address, area: "")
+          nil_area = create(:address, area: nil)
+          empty_area = create(:address, area: "")
 
-          expect(described_class.sites_missing_area.size).to eq(2)
-          expect(described_class.sites_missing_area).to include(empty_area)
-          expect(described_class.sites_missing_area).to include(nil_area)
+          expect(described_class.missing_area.size).to eq(2)
+          expect(described_class.missing_area).to include(empty_area)
+          expect(described_class.missing_area).to include(nil_area)
         end
       end
     end


### PR DESCRIPTION
This reverts commit 5556ffacd07d339af54d34deb28c347ac2810683.

The change made was due to a lack of understanding about scopes, and the fact that because we use enums that we get the scope `:site` for free on the address.

So rather than changing the current scopes to include a condition to test for the address type, instead we can just chain scopes together

```ruby
WasteExemptionsEngine::Address.site.missing_area
```

This gives the same result as `sites_missing_area`. By reverting this change our scopes become flexible again, and we can do things in a much more 'rails' way.