### PR TITLE
Operator Address manual form refactoring

### DIFF
--- a/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
@@ -1,7 +1,63 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
-  class OperatorAddressManualForm < AddressManualForm
-    include OperatorAddressForm
+  class OperatorAddressManualForm < BaseForm
+    attr_accessor :address_finder_error
+    attr_accessor :operator_address
+    attr_accessor :premises, :street_address, :locality, :postcode, :city, :business_type
+
+    validates :operator_address, "waste_exemptions_engine/manual_address": true
+
+    def initialize(registration)
+      super
+
+      self.postcode = transient_registration.temp_operator_postcode
+
+      self.operator_address = @transient_registration.operator_address
+
+      # Check if the user reached this page through an Address finder error.
+      # Then wipe the temp attribute as we only need it for routing
+      self.address_finder_error = @transient_registration.address_finder_error
+      transient_registration.update_attributes(address_finder_error: nil)
+
+      # Prefill the existing address unless the postcode has changed from the existing address's postcode
+      prefill_operator_address_params if saved_address_still_valid?
+    end
+
+    def submit(params)
+      permitted_attributes = params.require(:operator_address)
+      permitted_attributes = permitted_attributes.permit(:locality, :postcode, :city, :premises, :street_address, :mode)
+
+      # Needed for validation
+      assign_params(permitted_attributes)
+
+      super(operator_address_attributes: permitted_attributes)
+    end
+
+    private
+
+    def assign_params(permitted_attributes)
+      self.operator_address = transient_registration.build_operator_address(permitted_attributes)
+
+      prefill_operator_address_params
+    end
+
+    def saved_address_still_valid?
+      return false unless operator_address
+      return true if postcode.blank?
+      return true if postcode == operator_address.postcode
+
+      false
+    end
+
+    def prefill_operator_address_params
+      return unless operator_address
+
+      self.premises = operator_address.premises&.strip
+      self.street_address = operator_address.street_address&.strip
+      self.locality = operator_address.locality&.strip
+      self.city = operator_address.city&.strip
+      self.postcode = operator_address.postcode&.strip
+    end
   end
 end

--- a/app/views/waste_exemptions_engine/operator_address_manual_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_address_manual_forms/new.html.erb
@@ -19,7 +19,9 @@
       <%= link_to(t(".postcode_change_link"), back_operator_address_manual_forms_path(@operator_address_manual_form.token)) %>
     </div>
 
-    <%= render("waste_exemptions_engine/shared/manual_address", form: @operator_address_manual_form, f: f) %>
+    <%= f.fields_for :operator_address do |f| %>
+      <%= render("waste_exemptions_engine/shared/manual_address", form: @operator_address_manual_form, f: f) %>
+    <% end %>
 
     <%= f.hidden_field :token, value: @operator_address_manual_form.token %>
     <div class="form-group">

--- a/spec/forms/waste_exemptions_engine/operator_address_manual_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/operator_address_manual_form_spec.rb
@@ -4,13 +4,130 @@ require "rails_helper"
 
 module WasteExemptionsEngine
   RSpec.describe OperatorAddressManualForm, type: :model do
-    it_behaves_like "a manual address form", :operator_address_manual_form
+    let(:form_factory) { :operator_address_manual_form }
 
-    it "includes OperatorAddressForm" do
-      included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
+    it "validates the address data using the ManualAddressValidator class" do
+      validators = build(form_factory)._validators
+      validator_classes = validators.values.flatten.map(&:class)
+      expect(validator_classes).to include(WasteExemptionsEngine::ManualAddressValidator)
+    end
 
-      expect(included_modules)
-        .to include(WasteExemptionsEngine::OperatorAddressForm)
+    before(:each) { VCR.insert_cassette("postcode_valid") }
+    after(:each) { VCR.eject_cassette }
+
+    it_behaves_like "a validated form", :operator_address_manual_form do
+      let(:valid_params) do
+        [
+          {
+            token: form.token,
+            operator_address: {
+              premises: "Horizon House",
+              street_address: "Deanery Rd",
+              locality: "Bristol",
+              city: "Bristol",
+              postcode: "BS1 5AH"
+            }
+          },
+          {
+            token: form.token,
+            operator_address: {
+              premises: "Horizon House",
+              street_address: "Deanery Rd",
+              locality: "",
+              city: "Bristol",
+              postcode: ""
+            }
+          }
+        ]
+      end
+      let(:invalid_params) do
+        [
+          {
+            token: form.token,
+            operator_address: {
+              premises: "",
+              street_address: "",
+              locality: "",
+              city: "",
+              postcode: ""
+            }
+          },
+          {
+            token: form.token,
+            operator_address: {
+              premises: Helpers::TextGenerator.random_string(201), # The max length is 200.
+              street_address: Helpers::TextGenerator.random_string(161), # The max length is 160.
+              locality: Helpers::TextGenerator.random_string(71), # The max length is 70.
+              city: Helpers::TextGenerator.random_string(31), # The max length is 30.
+              postcode: Helpers::TextGenerator.random_string(9) # The max length is 8.
+            }
+          }
+        ]
+      end
+    end
+
+    # Make sure the transient registration gets updated when submitted.
+    describe "#submit" do
+      context "when the form is valid" do
+        subject(:form) { build(form_factory) }
+        let(:address_data) do
+          {
+            operator_address: {
+              premises: "Example House",
+              street_address: "2 On The Road",
+              locality: "Near Horizon House",
+              city: "Bristol",
+              postcode: "BS1 5AH"
+            }
+          }
+        end
+        let(:white_space_address_data) do
+          {
+            operator_address: {
+              premises: "  Example House ",
+              street_address: " 2 On The Road  ",
+              locality: " Near Horizon House   ",
+              city: "  Bristol  ",
+              postcode: "   BS1 5AH  "
+            }
+          }
+        end
+        let(:valid_params) { address_data.merge(token: form.token) }
+        let(:white_space_params) { white_space_address_data.merge(token: form.token) }
+        let(:transient_registration) { form.transient_registration }
+
+        it "updates the transient registration with the submitted address data" do
+          # Ensure the test data is properly configured:
+          expect(transient_registration.transient_addresses).to be_empty
+
+          form.submit(ActionController::Parameters.new(valid_params))
+
+          expect(transient_registration.transient_addresses.count).to eq(1)
+          submitted_address = transient_registration.transient_addresses.first
+          address_data[:operator_address].each do |key, value|
+            expect(submitted_address.send(key)).to eq(value)
+          end
+        end
+
+        context "when the address data includes extraneous white space" do
+          it "strips the extraneous white space from the submitted address data" do
+            # Ensure the test data is properly configured:
+            address_data[:operator_address].each do |key, value|
+              expect(white_space_params[:operator_address][key]).not_to eq(value)
+              expect(white_space_params[:operator_address][key].strip).to eq(value)
+            end
+            expect(transient_registration.transient_addresses).to be_empty
+
+            form.submit(ActionController::Parameters.new(white_space_params))
+
+            expect(transient_registration.reload.transient_addresses.count).to eq(1)
+            submitted_address = transient_registration.transient_addresses.first
+            address_data[:operator_address].each do |key, value|
+              expect(submitted_address.send(key)).to eq(value)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/operator_address_manual_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/operator_address_manual_forms_spec.rb
@@ -12,21 +12,25 @@ module WasteExemptionsEngine
     include_examples "POST form", :operator_address_manual_form, "/operator-address-manual" do
       let(:form_data) do
         {
-          premises: "Example House",
-          street_address: "2 On The Road",
-          locality: "Near Horizon House",
-          city: "Bristol",
-          postcode: "BS1 5AH"
+          operator_address: {
+            premises: "Example House",
+            street_address: "2 On The Road",
+            locality: "Near Horizon House",
+            city: "Bristol",
+            postcode: "BS1 5AH"
+          }
         }
       end
       let(:invalid_form_data) do
         [
           {
-            premises: nil,
-            street_address: nil,
-            locality: nil,
-            city: nil,
-            postcode: nil
+            operator_address: {
+              premises: nil,
+              street_address: nil,
+              locality: nil,
+              city: nil,
+              postcode: nil
+            }
           }
         ]
       end


### PR DESCRIPTION
Following on: https://github.com/DEFRA/waste-exemptions-engine/pull/341/files
This apply the same refactoing to the operator address manual form.
The goal is to make use of rails-ness on these forms, so we want them to name the attributes as per TransientAddress attributes. This will allow the use of strong parameters and less code to custom-submit these forms rather than letting rails do the job for us :D