### PR TITLE
Site Address manual form refactoring

### DIFF
--- a/app/forms/waste_exemptions_engine/site_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/site_address_manual_form.rb
@@ -1,8 +1,63 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
-  class SiteAddressManualForm < AddressManualForm
-    include SiteAddressForm
+  class SiteAddressManualForm < BaseForm
+    attr_accessor :address_finder_error
+    attr_accessor :site_address
+    attr_accessor :premises, :street_address, :locality, :postcode, :city
 
+    validates :site_address, "waste_exemptions_engine/manual_address": true
+
+    def initialize(registration)
+      super
+
+      self.postcode = transient_registration.temp_site_postcode
+
+      self.site_address = @transient_registration.site_address
+
+      # Check if the user reached this page through an Address finder error.
+      # Then wipe the temp attribute as we only need it for routing
+      self.address_finder_error = @transient_registration.address_finder_error
+      transient_registration.update_attributes(address_finder_error: nil)
+
+      # Prefill the existing address unless the postcode has changed from the existing address's postcode
+      prefill_site_address_params if saved_address_still_valid?
+    end
+
+    def submit(params)
+      permitted_attributes = params.require(:site_address)
+      permitted_attributes = permitted_attributes.permit(:locality, :postcode, :city, :premises, :street_address, :mode)
+
+      # Needed for validation
+      assign_params(permitted_attributes)
+
+      super(site_address_attributes: permitted_attributes)
+    end
+
+    private
+
+    def assign_params(permitted_attributes)
+      self.site_address = transient_registration.build_site_address(permitted_attributes)
+
+      prefill_site_address_params
+    end
+
+    def saved_address_still_valid?
+      return false unless site_address
+      return true if postcode.blank?
+      return true if postcode == site_address.postcode
+
+      false
+    end
+
+    def prefill_site_address_params
+      return unless site_address
+
+      self.premises = site_address.premises&.strip
+      self.street_address = site_address.street_address&.strip
+      self.locality = site_address.locality&.strip
+      self.city = site_address.city&.strip
+      self.postcode = site_address.postcode&.strip
+    end
   end
 end

--- a/app/views/waste_exemptions_engine/site_address_manual_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/site_address_manual_forms/new.html.erb
@@ -19,7 +19,9 @@
       <%= link_to(t(".postcode_change_link"), back_site_address_manual_forms_path(@site_address_manual_form.token)) %>
     </div>
 
-    <%= render("waste_exemptions_engine/shared/manual_address", form: @site_address_manual_form, f: f) %>
+    <%= f.fields_for :site_address do |f| %>
+      <%= render("waste_exemptions_engine/shared/manual_address", form: @site_address_manual_form, f: f) %>
+    <% end %>
 
     <%= f.hidden_field :token, value: @site_address_manual_form.token %>
     <div class="form-group">

--- a/spec/forms/waste_exemptions_engine/site_address_manual_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/site_address_manual_form_spec.rb
@@ -4,13 +4,130 @@ require "rails_helper"
 
 module WasteExemptionsEngine
   RSpec.describe SiteAddressManualForm, type: :model do
-    it_behaves_like "a manual address form", :site_address_manual_form
+    let(:form_factory) { :site_address_manual_form }
 
-    it "includes SiteAddressForm" do
-      included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
+    it "validates the address data using the ManualAddressValidator class" do
+      validators = build(form_factory)._validators
+      validator_classes = validators.values.flatten.map(&:class)
+      expect(validator_classes).to include(WasteExemptionsEngine::ManualAddressValidator)
+    end
 
-      expect(included_modules)
-        .to include(WasteExemptionsEngine::SiteAddressForm)
+    before(:each) { VCR.insert_cassette("postcode_valid") }
+    after(:each) { VCR.eject_cassette }
+
+    it_behaves_like "a validated form", :site_address_manual_form do
+      let(:valid_params) do
+        [
+          {
+            token: form.token,
+            site_address: {
+              premises: "Horizon House",
+              street_address: "Deanery Rd",
+              locality: "Bristol",
+              city: "Bristol",
+              postcode: "BS1 5AH"
+            }
+          },
+          {
+            token: form.token,
+            site_address: {
+              premises: "Horizon House",
+              street_address: "Deanery Rd",
+              locality: "",
+              city: "Bristol",
+              postcode: ""
+            }
+          }
+        ]
+      end
+      let(:invalid_params) do
+        [
+          {
+            token: form.token,
+            site_address: {
+              premises: "",
+              street_address: "",
+              locality: "",
+              city: "",
+              postcode: ""
+            }
+          },
+          {
+            token: form.token,
+            site_address: {
+              premises: Helpers::TextGenerator.random_string(201), # The max length is 200.
+              street_address: Helpers::TextGenerator.random_string(161), # The max length is 160.
+              locality: Helpers::TextGenerator.random_string(71), # The max length is 70.
+              city: Helpers::TextGenerator.random_string(31), # The max length is 30.
+              postcode: Helpers::TextGenerator.random_string(9) # The max length is 8.
+            }
+          }
+        ]
+      end
+    end
+
+    # Make sure the transient registration gets updated when submitted.
+    describe "#submit" do
+      context "when the form is valid" do
+        subject(:form) { build(form_factory) }
+        let(:address_data) do
+          {
+            site_address: {
+              premises: "Example House",
+              street_address: "2 On The Road",
+              locality: "Near Horizon House",
+              city: "Bristol",
+              postcode: "BS1 5AH"
+            }
+          }
+        end
+        let(:white_space_address_data) do
+          {
+            site_address: {
+              premises: "  Example House ",
+              street_address: " 2 On The Road  ",
+              locality: " Near Horizon House   ",
+              city: "  Bristol  ",
+              postcode: "   BS1 5AH  "
+            }
+          }
+        end
+        let(:valid_params) { address_data.merge(token: form.token) }
+        let(:white_space_params) { white_space_address_data.merge(token: form.token) }
+        let(:transient_registration) { form.transient_registration }
+
+        it "updates the transient registration with the submitted address data" do
+          # Ensure the test data is properly configured:
+          expect(transient_registration.transient_addresses).to be_empty
+
+          form.submit(ActionController::Parameters.new(valid_params))
+
+          expect(transient_registration.transient_addresses.count).to eq(1)
+          submitted_address = transient_registration.transient_addresses.first
+          address_data[:site_address].each do |key, value|
+            expect(submitted_address.send(key)).to eq(value)
+          end
+        end
+
+        context "when the address data includes extraneous white space" do
+          it "strips the extraneous white space from the submitted address data" do
+            # Ensure the test data is properly configured:
+            address_data[:site_address].each do |key, value|
+              expect(white_space_params[:site_address][key]).not_to eq(value)
+              expect(white_space_params[:site_address][key].strip).to eq(value)
+            end
+            expect(transient_registration.transient_addresses).to be_empty
+
+            form.submit(ActionController::Parameters.new(white_space_params))
+
+            expect(transient_registration.reload.transient_addresses.count).to eq(1)
+            submitted_address = transient_registration.transient_addresses.first
+            address_data[:site_address].each do |key, value|
+              expect(submitted_address.send(key)).to eq(value)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/site_address_manual_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_address_manual_forms_spec.rb
@@ -12,22 +12,26 @@ module WasteExemptionsEngine
     include_examples "POST form", :site_address_manual_form, "/site-address-manual" do
       let(:form_data) do
         {
-          premises: "Example House",
-          street_address: "2 On The Road",
-          locality: "Near Horizon House",
-          city: "Bristol",
-          postcode: "BS1 5AH"
+          site_address: {
+            premises: "Example House",
+            street_address: "2 On The Road",
+            locality: "Near Horizon House",
+            city: "Bristol",
+            postcode: "BS1 5AH"
+          }
         }
       end
 
       let(:invalid_form_data) do
         [
           {
-            premises: nil,
-            street_address: nil,
-            locality: nil,
-            city: nil,
-            postcode: nil
+            site_address: {
+              premises: nil,
+              street_address: nil,
+              locality: nil,
+              city: nil,
+              postcode: nil
+            }
           }
         ]
       end


### PR DESCRIPTION
Following on: https://github.com/DEFRA/waste-exemptions-engine/pull/341/files
This apply the same refactoing to the site address manual form.
The goal is to make use of rails-ness on these forms, so we want them to name the attributes as per TransientAddress attributes. This will allow the use of strong parameters and less code to custom-submit these forms rather than letting rails do the job for us :D