### PR TITLE
Refactor address lookups form

### DIFF
--- a/app/forms/concerns/waste_exemptions_engine/can_create_address_from_finder_data.rb
+++ b/app/forms/concerns/waste_exemptions_engine/can_create_address_from_finder_data.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module CanCreateAddressFromFinderData
+    extend ActiveSupport::Concern
+
+    included do
+      def create_address(selected_address_uprn, type)
+        return if selected_address_uprn.blank?
+
+        data = temp_addresses.detect { |address| address["uprn"] == selected_address_uprn.to_i }
+        return unless data
+
+        address = TransientAddress.create_from_address_finder_data(data, type)
+
+        address
+      end
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/address_lookup_form_base.rb
+++ b/app/forms/waste_exemptions_engine/address_lookup_form_base.rb
@@ -1,39 +1,18 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
-  class AddressLookupForm < BaseForm
-    include CanAddOrReplaceAnAddress
+  class AddressLookupFormBase < BaseForm
+    include CanCreateAddressFromFinderData
 
-    attr_accessor :temp_addresses
-    attr_accessor :temp_address
-    attr_accessor :postcode
+    attr_accessor :temp_addresses, :temp_address
 
     validates :temp_address, "waste_exemptions_engine/address": true
 
     def initialize(registration)
       super
 
-      self.postcode = existing_postcode
-
       look_up_addresses
       preselect_existing_address
-    end
-
-    def submit(params)
-      # Assign the params for validation and pass them to the BaseForm method for updating
-      new_address = create_address(params[:temp_address])
-
-      self.temp_address = new_address
-
-      attributes = {
-        transient_addresses: add_or_replace_address(
-          new_address,
-          @transient_registration.transient_addresses,
-          existing_address
-        )
-      }
-
-      super(attributes)
     end
 
     private
@@ -61,17 +40,6 @@ module WasteExemptionsEngine
       return false unless existing_address.uprn.present?
 
       true
-    end
-
-    def create_address(selected_address_uprn)
-      return if selected_address_uprn.blank?
-
-      data = temp_addresses.detect { |address| address["uprn"] == selected_address_uprn.to_i }
-      return unless data
-
-      address = TransientAddress.create_from_address_finder_data(data, address_type)
-
-      address
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/contact_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_address_lookup_form.rb
@@ -4,8 +4,8 @@ module WasteExemptionsEngine
   class ContactAddressLookupForm < AddressLookupFormBase
     delegate :temp_contact_postcode, :contact_address, :business_type, to: :transient_registration
 
-    alias_method :existing_address, :contact_address
-    alias_method :postcode, :temp_contact_postcode
+    alias existing_address contact_address
+    alias postcode temp_contact_postcode
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating

--- a/app/forms/waste_exemptions_engine/contact_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_address_lookup_form.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
-  class ContactAddressLookupForm < AddressLookupForm
+  class ContactAddressLookupForm < AddressLookupFormBase
+    delegate :temp_contact_postcode, :contact_address, :business_type, to: :transient_registration
 
-    private
+    alias_method :existing_address, :contact_address
+    alias_method :postcode, :temp_contact_postcode
 
-    def existing_postcode
-      @transient_registration.temp_contact_postcode
-    end
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      contact_address = create_address(params[:temp_address], :contact)
 
-    def existing_address
-      @transient_registration.contact_address
-    end
+      self.temp_address = contact_address
 
-    def address_type
-      TransientAddress.address_types[:contact]
+      super(contact_address: contact_address)
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/operator_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_lookup_form.rb
@@ -1,21 +1,19 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
-  class OperatorAddressLookupForm < AddressLookupForm
-    delegate :business_type, to: :transient_registration
+  class OperatorAddressLookupForm < AddressLookupFormBase
+    delegate :temp_operator_postcode, :operator_address, :business_type, to: :transient_registration
 
-    private
+    alias_method :existing_address, :operator_address
+    alias_method :postcode, :temp_operator_postcode
 
-    def existing_postcode
-      @transient_registration.temp_operator_postcode
-    end
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      operator_address = create_address(params[:temp_address], :operator)
 
-    def existing_address
-      @transient_registration.operator_address
-    end
+      self.temp_address = operator_address
 
-    def address_type
-      TransientAddress.address_types[:operator]
+      super(operator_address: operator_address)
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/operator_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_lookup_form.rb
@@ -4,8 +4,8 @@ module WasteExemptionsEngine
   class OperatorAddressLookupForm < AddressLookupFormBase
     delegate :temp_operator_postcode, :operator_address, :business_type, to: :transient_registration
 
-    alias_method :existing_address, :operator_address
-    alias_method :postcode, :temp_operator_postcode
+    alias existing_address operator_address
+    alias postcode temp_operator_postcode
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating

--- a/app/forms/waste_exemptions_engine/site_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/site_address_lookup_form.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
 module WasteExemptionsEngine
-  class SiteAddressLookupForm < AddressLookupForm
+  class SiteAddressLookupForm < AddressLookupFormBase
+    delegate :temp_site_postcode, :site_address, to: :transient_registration
 
-    private
+    alias_method :existing_address, :site_address
+    alias_method :postcode, :temp_site_postcode
 
-    def existing_postcode
-      @transient_registration.temp_site_postcode
-    end
+    def submit(params)
+      # Assign the params for validation and pass them to the BaseForm method for updating
+      site_address = create_address(params[:temp_address], :site)
 
-    def existing_address
-      @transient_registration.site_address
-    end
+      self.temp_address = site_address
 
-    def address_type
-      TransientAddress.address_types[:site]
+      super(site_address: site_address)
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/site_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/site_address_lookup_form.rb
@@ -4,8 +4,8 @@ module WasteExemptionsEngine
   class SiteAddressLookupForm < AddressLookupFormBase
     delegate :temp_site_postcode, :site_address, to: :transient_registration
 
-    alias_method :existing_address, :site_address
-    alias_method :postcode, :temp_site_postcode
+    alias existing_address site_address
+    alias postcode temp_site_postcode
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating

--- a/spec/support/shared_examples/forms/address_lookup_form.rb
+++ b/spec/support/shared_examples/forms/address_lookup_form.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "an address lookup form", vcr: true do |form_factory|
-  it "includes CanAddOrReplaceAnAddress" do
+  it "includes CanCreateAddressFromFinderData" do
     included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
-    expect(included_modules).to include(WasteExemptionsEngine::CanAddOrReplaceAnAddress)
+    expect(included_modules).to include(WasteExemptionsEngine::CanCreateAddressFromFinderData)
   end
 
-  it "is a type of AddressLookupForm" do
-    expect(described_class.ancestors).to include(WasteExemptionsEngine::AddressLookupForm)
+  it "is a type of AddressLookupFormBase" do
+    expect(described_class.ancestors).to include(WasteExemptionsEngine::AddressLookupFormBase)
   end
 
   it "validates the temp_address using the AddressValidator class" do


### PR DESCRIPTION
Part of the form refactoring.
In this case I have kept the base Lookup Forms class, but I have moved the implementation of the submit method in the children.
This will allow easier refactoring for the rest of the class.
The create address from urpn function have moved to a concern and has no more any dependency with methods defined in the including classes.
Use delegate and alias instead of attribute accessors.