### PR TITLE
Contact Position Form refactoring

### DIFF
--- a/app/forms/waste_exemptions_engine/contact_position_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_position_form.rb
@@ -2,19 +2,19 @@
 
 module WasteExemptionsEngine
   class ContactPositionForm < BaseForm
-    attr_accessor :position
+    attr_accessor :contact_position
 
-    validates :position, "defra_ruby/validators/position": true
+    validates :contact_position, "defra_ruby/validators/position": true
 
     def initialize(registration)
       super
-      self.position = @transient_registration.contact_position
+      self.contact_position = @transient_registration.contact_position
     end
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
-      self.position = params[:position]
-      attributes = { contact_position: position }
+      self.contact_position = params[:contact_position]
+      attributes = { contact_position: contact_position }
 
       super(attributes)
     end

--- a/app/views/waste_exemptions_engine/contact_position_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_position_forms/new.html.erb
@@ -6,17 +6,17 @@
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
-    <div class="form-group <%= "form-group-error" if @contact_position_form.errors[:position].any? %>">
+    <div class="form-group <%= "form-group-error" if @contact_position_form.errors[:contact_position].any? %>">
       <fieldset id="position">
-        <% if @contact_position_form.errors[:position].any? %>
-          <span class="error-message"><%= @contact_position_form.errors[:position].join(", ") %></span>
+        <% if @contact_position_form.errors[:contact_position].any? %>
+          <span class="error-message"><%= @contact_position_form.errors[:contact_position].join(", ") %></span>
         <% end %>
 
-        <%= f.label :position, class: "form-label" do %>
+        <%= f.label :contact_position, class: "form-label" do %>
           <%= t(".position_label") %>
           <span class='form-hint'><%= t(".position_hint") %></span>
         <% end %>
-        <%= f.text_field :position, value: @contact_position_form.position, class: "form-control govuk-input--width-20" %>
+        <%= f.text_field :contact_position, value: @contact_position_form.contact_position, class: "form-control govuk-input--width-20" %>
       </fieldset>
     </div>
 

--- a/spec/forms/waste_exemptions_engine/contact_position_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/contact_position_form_spec.rb
@@ -8,22 +8,22 @@ module WasteExemptionsEngine
 
     it "validates the position using the ContactPositionValidator class" do
       validators = form._validators
-      expect(validators.keys).to include(:position)
-      expect(validators[:position].first.class)
+      expect(validators.keys).to include(:contact_position)
+      expect(validators[:contact_position].first.class)
         .to eq(DefraRuby::Validators::PositionValidator)
     end
 
     it_behaves_like "a validated form", :contact_position_form do
       let(:valid_params) do
         [
-          { token: form.token, position: "Chief Waste Carrier" },
-          { token: form.token, position: "" }
+          { token: form.token, contact_position: "Chief Waste Carrier" },
+          { token: form.token, contact_position: "" }
         ]
       end
       let(:invalid_params) do
         [
-          { token: form.token, position: Helpers::TextGenerator.random_string(71) },
-          { token: form.token, position: "**Invalid_@_Position**" }
+          { token: form.token, contact_position: Helpers::TextGenerator.random_string(71) },
+          { token: form.token, contact_position: "**Invalid_@_Position**" }
         ]
       end
     end
@@ -31,13 +31,13 @@ module WasteExemptionsEngine
     describe "#submit" do
       context "when the form is valid" do
         it "updates the transient registration with the contact position" do
-          position = "Waste Carrier Manager"
-          valid_params = { token: form.token, position: position }
+          contact_position = "Waste Carrier Manager"
+          valid_params = { token: form.token, contact_position: contact_position }
           transient_registration = form.transient_registration
 
           expect(transient_registration.contact_position).to be_blank
           form.submit(valid_params)
-          expect(transient_registration.contact_position).to eq(position)
+          expect(transient_registration.reload.contact_position).to eq(contact_position)
         end
       end
     end

--- a/spec/requests/waste_exemptions_engine/contact_position_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_position_forms_spec.rb
@@ -9,7 +9,7 @@ module WasteExemptionsEngine
 
     empty_form_is_valid = true
     include_examples "POST form", :contact_position_form, "/contact-position", empty_form_is_valid do
-      let(:form_data) { { position: "Chief Waste Carrier" } }
+      let(:form_data) { { contact_position: "Chief Waste Carrier" } }
       let(:invalid_form_data) { [] }
     end
 

--- a/spec/requests/waste_exemptions_engine/contact_position_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/contact_position_forms_spec.rb
@@ -19,7 +19,7 @@ module WasteExemptionsEngine
       it "pre-fills contact position information" do
         get "/waste_exemptions_engine/#{edit_contact_position_form.token}/contact-position"
 
-        expect(response.body).to have_html_escaped_string(edit_contact_position_form.position)
+        expect(response.body).to have_html_escaped_string(edit_contact_position_form.contact_position)
       end
     end
 
@@ -29,7 +29,7 @@ module WasteExemptionsEngine
       it "pre-fills contact position information" do
         get "/waste_exemptions_engine/#{renew_contact_position_form.token}/contact-position"
 
-        expect(response.body).to have_html_escaped_string(renew_contact_position_form.position)
+        expect(response.body).to have_html_escaped_string(renew_contact_position_form.contact_position)
       end
     end
   end


### PR DESCRIPTION
Rename `position` to `contact_position` to be in-line with the models' attribute name.