### PR TITLE
Delegate business type to transient registration

### DIFF
--- a/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
@@ -6,6 +6,8 @@ module WasteExemptionsEngine
     attr_accessor :operator_address
     attr_accessor :premises, :street_address, :locality, :postcode, :city, :business_type
 
+    delegate :business_type, to: :transient_registration
+
     validates :operator_address, "waste_exemptions_engine/manual_address": true
 
     def initialize(registration)


### PR DESCRIPTION
Closes: https://eaflood.atlassian.net/browse/RUBY-713

While doing the forms refactoring I forgot to delegate or populate the business type that is needed on the operator address.