### PR TITLE
Update Address scope tests to use match_array

### DIFF
--- a/spec/models/waste_exemptions_engine/address_spec.rb
+++ b/spec/models/waste_exemptions_engine/address_spec.rb
@@ -43,8 +43,7 @@ module WasteExemptionsEngine
 
           valid_address = create(:address, postcode: "BS1 5AH")
 
-          expect(described_class.with_postcode.size).to eq(1)
-          expect(described_class.with_postcode.first).to eq(valid_address)
+          expect(described_class.with_postcode).to match_array([valid_address])
         end
       end
 
@@ -56,21 +55,19 @@ module WasteExemptionsEngine
 
           valid_address = create(:address, x: 123.4, y: 123.4)
 
-          expect(described_class.with_valid_easting_and_northing.size).to eq(1)
-          expect(described_class.with_valid_easting_and_northing.first).to eq(valid_address)
+          expect(described_class.with_valid_easting_and_northing).to match_array([valid_address])
         end
       end
 
       describe ".missing_area" do
         it "returns all addresses with a missing area" do
+          missing_info_records = []
+          missing_info_records << create(:address, area: nil)
+          missing_info_records << create(:address, area: "")
+
           create(:address, area: "West Midlands")
 
-          nil_area = create(:address, area: nil)
-          empty_area = create(:address, area: "")
-
-          expect(described_class.missing_area.size).to eq(2)
-          expect(described_class.missing_area).to include(empty_area)
-          expect(described_class.missing_area).to include(nil_area)
+          expect(described_class.missing_area).to match_array(missing_info_records)
         end
       end
     end


### PR DESCRIPTION
This is just some housekeeping. It was spotted that we were not being consistent in our tests for the scopes on the Address model in a recent commit to add a `with_postcode` scope.

So this change updates all the tests to use `match_array` rather than having separate expectations to check the size and content of the returned result.