### PR TITLE
Set version of defra_ruby_validators

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       aasm (~> 4.12)
       airbrake (= 5.8.1)
       defra_ruby_area
-      defra_ruby_validators
+      defra_ruby_validators (~> 2.1.2)
       has_secure_token
       high_voltage (~> 3.1)
       os_map_ref (~> 0.5)

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
 
   # Validations
   # A defra created gem of shared validators
-  s.add_dependency "defra_ruby_validators"
+  s.add_dependency "defra_ruby_validators", "~> 2.1.2"
   # Use to ensure phone numbers are in a valid and recognised format
   s.add_dependency "phonelib"
   # UK postcode parsing and validation for Ruby


### PR DESCRIPTION
https://github.com/DEFRA/waste-exemptions-front-office/pull/256
https://github.com/DEFRA/waste-exemptions-back-office/pull/435

We just had Dependabot update the version of [defra_ruby_validators](https://github.com/DEFRA/defra-ruby-validators) used by the front and back office under the guise of updating the engine.

This broke the apps, so to protect against this in future we are using pessimistic versioning for the gem to ensure the apps don't try and take a version they're not ready for.