### PR TITLE
Refactor the site address trait in Factories

### DIFF
--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
 
     trait :site_address do
       address_type { address_types[:site] }
+    end
+
+    trait :site_using_grid_reference do
+      site_address
       description { Faker::Lorem.sentence }
       grid_reference { "ST 58337 72855" }
     end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -92,7 +92,7 @@ FactoryBot.define do
         [
           build(:address, :operator_address, :postal),
           build(:address, :contact_address, :postal),
-          build(:address, :site_address, :auto)
+          build(:address, :site_using_grid_reference, :auto)
         ]
       end
     end

--- a/spec/factories/transient_address.rb
+++ b/spec/factories/transient_address.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
 
     trait :site_address do
       address_type { address_types[:site] }
+    end
+
+    trait :site_using_grid_reference do
+      site_address
       description { Faker::Lorem.sentence }
       grid_reference { "ST 58337 72855" }
     end


### PR DESCRIPTION
Ahead of the need to add some tests specific to site addresses we spotted that the current `:site_address` trait sets a couple of other fields, not just the address type. This is different to the `:operator_address` and ':contact_address` traits which just set the address type

We need to set the address type as part of some tests we are looking to add. But we also need to be able to specify creating the 3 different kinds of site address; from grid reference, from address lookup, and from address manual.

In its current state we would not have been able to reuse the trait. With this refactor we can, plus

- its now consistent with the other address type traits
- the new trait is more descriptive of what is actually going on