### PR TITLE
Manual address forms delegate refactoring

### DIFF
--- a/app/forms/concerns/waste_exemptions_engine/can_clear_address_finder_error.rb
+++ b/app/forms/concerns/waste_exemptions_engine/can_clear_address_finder_error.rb
@@ -11,15 +11,11 @@ module WasteExemptionsEngine
 
       private
 
+      # Check if the user reached this page through an Address finder error.
+      # Then wipe the temp attribute as we only need it for routing
       def clear_address_finder_error(selected_address_uprn, type)
-        return if selected_address_uprn.blank?
-
-        data = temp_addresses.detect { |address| address["uprn"] == selected_address_uprn.to_i }
-        return unless data
-
-        address = TransientAddress.create_from_address_finder_data(data, type)
-
-        address
+        self.address_finder_error = transient_registration.address_finder_error
+        transient_registration.update_attributes(address_finder_error: nil)
       end
     end
   end

--- a/app/forms/concerns/waste_exemptions_engine/can_clear_address_finder_error.rb
+++ b/app/forms/concerns/waste_exemptions_engine/can_clear_address_finder_error.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module CanClearAddressFinderError
+    extend ActiveSupport::Concern
+
+    included do
+      attr_accessor :address_finder_error
+
+      after_initialize :clear_address_finder_error
+
+      private
+
+      def clear_address_finder_error(selected_address_uprn, type)
+        return if selected_address_uprn.blank?
+
+        data = temp_addresses.detect { |address| address["uprn"] == selected_address_uprn.to_i }
+        return unless data
+
+        address = TransientAddress.create_from_address_finder_data(data, type)
+
+        address
+      end
+    end
+  end
+end

--- a/app/forms/concerns/waste_exemptions_engine/can_clear_address_finder_error.rb
+++ b/app/forms/concerns/waste_exemptions_engine/can_clear_address_finder_error.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
 
       # Check if the user reached this page through an Address finder error.
       # Then wipe the temp attribute as we only need it for routing
-      def clear_address_finder_error(selected_address_uprn, type)
+      def clear_address_finder_error
         self.address_finder_error = transient_registration.address_finder_error
         transient_registration.update_attributes(address_finder_error: nil)
       end

--- a/app/forms/waste_exemptions_engine/contact_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_address_manual_form.rb
@@ -2,7 +2,10 @@
 
 module WasteExemptionsEngine
   class ContactAddressManualForm < BaseForm
-    attr_accessor :address_finder_error, :postcode
+    include CanClearAddressFinderError
+
+    attr_accessor :postcode
+
     delegate :contact_address, to: :transient_registration
     delegate :premises, :street_address, :locality, :postcode, :city, to: :contact_address, allow_nil: true
 
@@ -21,11 +24,6 @@ module WasteExemptionsEngine
 
     def setup_postcode
       self.postcode = transient_registration.temp_contact_postcode
-
-      # Check if the user reached this page through an Address finder error.
-      # Then wipe the temp attribute as we only need it for routing
-      self.address_finder_error = transient_registration.address_finder_error
-      transient_registration.update_attributes(address_finder_error: nil)
 
       # Prefill the existing address unless the postcode has changed from the existing address's postcode
       transient_registration.contact_address = nil unless saved_address_still_valid?

--- a/app/forms/waste_exemptions_engine/contact_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_address_manual_form.rb
@@ -2,9 +2,9 @@
 
 module WasteExemptionsEngine
   class ContactAddressManualForm < BaseForm
-    attr_accessor :address_finder_error
-    attr_accessor :contact_address
-    attr_accessor :premises, :street_address, :locality, :postcode, :city
+    attr_accessor :address_finder_error, :postcode
+    delegate :contact_address, to: :transient_registration
+    delegate :premises, :street_address, :locality, :postcode, :city, to: :contact_address, allow_nil: true
 
     validates :contact_address, "waste_exemptions_engine/manual_address": true
 
@@ -14,9 +14,6 @@ module WasteExemptionsEngine
       permitted_attributes = params.require(:contact_address)
       permitted_attributes = permitted_attributes.permit(:locality, :postcode, :city, :premises, :street_address, :mode)
 
-      # Needed for validation
-      assign_params(permitted_attributes)
-
       super(contact_address_attributes: permitted_attributes)
     end
 
@@ -25,39 +22,19 @@ module WasteExemptionsEngine
     def setup_postcode
       self.postcode = transient_registration.temp_contact_postcode
 
-      self.contact_address = transient_registration.contact_address
-
       # Check if the user reached this page through an Address finder error.
       # Then wipe the temp attribute as we only need it for routing
       self.address_finder_error = transient_registration.address_finder_error
       transient_registration.update_attributes(address_finder_error: nil)
 
       # Prefill the existing address unless the postcode has changed from the existing address's postcode
-      prefill_contact_address_params if saved_address_still_valid?
-    end
-
-    def assign_params(permitted_attributes)
-      self.contact_address = transient_registration.build_contact_address(permitted_attributes)
-
-      prefill_contact_address_params
+      transient_registration.contact_address = nil unless saved_address_still_valid?
     end
 
     def saved_address_still_valid?
-      return false unless contact_address
       return true if postcode.blank?
-      return true if postcode == contact_address.postcode
 
-      false
-    end
-
-    def prefill_contact_address_params
-      return unless contact_address
-
-      self.premises = contact_address.premises&.strip
-      self.street_address = contact_address.street_address&.strip
-      self.locality = contact_address.locality&.strip
-      self.city = contact_address.city&.strip
-      self.postcode = contact_address.postcode&.strip
+      postcode == contact_address.postcode
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
@@ -2,11 +2,9 @@
 
 module WasteExemptionsEngine
   class OperatorAddressManualForm < BaseForm
-    attr_accessor :address_finder_error
-    attr_accessor :operator_address
-    attr_accessor :premises, :street_address, :locality, :postcode, :city, :business_type
-
-    delegate :business_type, to: :transient_registration
+    attr_accessor :address_finder_error, :postcode
+    delegate :operator_address, :business_type, to: :transient_registration
+    delegate :premises, :street_address, :locality, :postcode, :city, to: :operator_address, allow_nil: true
 
     validates :operator_address, "waste_exemptions_engine/manual_address": true
 
@@ -16,18 +14,13 @@ module WasteExemptionsEngine
       permitted_attributes = params.require(:operator_address)
       permitted_attributes = permitted_attributes.permit(:locality, :postcode, :city, :premises, :street_address, :mode)
 
-      # Needed for validation
-      assign_params(permitted_attributes)
-
       super(operator_address_attributes: permitted_attributes)
     end
 
     private
 
     def setup_postcode
-      self.postcode = transient_registration.temp_operator_postcode
-
-      self.operator_address = transient_registration.operator_address
+      self.postcode = transient_registration.temp_contact_postcode
 
       # Check if the user reached this page through an Address finder error.
       # Then wipe the temp attribute as we only need it for routing
@@ -35,31 +28,13 @@ module WasteExemptionsEngine
       transient_registration.update_attributes(address_finder_error: nil)
 
       # Prefill the existing address unless the postcode has changed from the existing address's postcode
-      prefill_operator_address_params if saved_address_still_valid?
-    end
-
-    def assign_params(permitted_attributes)
-      self.operator_address = transient_registration.build_operator_address(permitted_attributes)
-
-      prefill_operator_address_params
+      transient_registration.operator_address = nil unless saved_address_still_valid?
     end
 
     def saved_address_still_valid?
-      return false unless operator_address
       return true if postcode.blank?
-      return true if postcode == operator_address.postcode
 
-      false
-    end
-
-    def prefill_operator_address_params
-      return unless operator_address
-
-      self.premises = operator_address.premises&.strip
-      self.street_address = operator_address.street_address&.strip
-      self.locality = operator_address.locality&.strip
-      self.city = operator_address.city&.strip
-      self.postcode = operator_address.postcode&.strip
+      postcode == operator_address.postcode
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
@@ -2,7 +2,10 @@
 
 module WasteExemptionsEngine
   class OperatorAddressManualForm < BaseForm
-    attr_accessor :address_finder_error, :postcode
+    include CanClearAddressFinderError
+
+    attr_accessor :postcode
+
     delegate :operator_address, :business_type, to: :transient_registration
     delegate :premises, :street_address, :locality, :postcode, :city, to: :operator_address, allow_nil: true
 
@@ -21,11 +24,6 @@ module WasteExemptionsEngine
 
     def setup_postcode
       self.postcode = transient_registration.temp_contact_postcode
-
-      # Check if the user reached this page through an Address finder error.
-      # Then wipe the temp attribute as we only need it for routing
-      self.address_finder_error = transient_registration.address_finder_error
-      transient_registration.update_attributes(address_finder_error: nil)
 
       # Prefill the existing address unless the postcode has changed from the existing address's postcode
       transient_registration.operator_address = nil unless saved_address_still_valid?

--- a/app/forms/waste_exemptions_engine/site_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/site_address_manual_form.rb
@@ -2,7 +2,10 @@
 
 module WasteExemptionsEngine
   class SiteAddressManualForm < BaseForm
-    attr_accessor :address_finder_error, :postcode
+    include CanClearAddressFinderError
+
+    attr_accessor :postcode
+
     delegate :site_address, to: :transient_registration
     delegate :premises, :street_address, :locality, :postcode, :city, to: :site_address, allow_nil: true
 
@@ -21,11 +24,6 @@ module WasteExemptionsEngine
 
     def setup_postcode
       self.postcode = transient_registration.temp_contact_postcode
-
-      # Check if the user reached this page through an Address finder error.
-      # Then wipe the temp attribute as we only need it for routing
-      self.address_finder_error = transient_registration.address_finder_error
-      transient_registration.update_attributes(address_finder_error: nil)
 
       # Prefill the existing address unless the postcode has changed from the existing address's postcode
       transient_registration.site_address = nil unless saved_address_still_valid?

--- a/app/forms/waste_exemptions_engine/site_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/site_address_manual_form.rb
@@ -2,18 +2,25 @@
 
 module WasteExemptionsEngine
   class SiteAddressManualForm < BaseForm
-    attr_accessor :address_finder_error
-    attr_accessor :site_address
-    attr_accessor :premises, :street_address, :locality, :postcode, :city
+    attr_accessor :address_finder_error, :postcode
+    delegate :site_address, to: :transient_registration
+    delegate :premises, :street_address, :locality, :postcode, :city, to: :site_address, allow_nil: true
 
     validates :site_address, "waste_exemptions_engine/manual_address": true
 
-    def initialize(registration)
-      super
+    after_initialize :setup_postcode
 
-      self.postcode = transient_registration.temp_site_postcode
+    def submit(params)
+      permitted_attributes = params.require(:site_address)
+      permitted_attributes = permitted_attributes.permit(:locality, :postcode, :city, :premises, :street_address, :mode)
 
-      self.site_address = transient_registration.site_address
+      super(site_address_attributes: permitted_attributes)
+    end
+
+    private
+
+    def setup_postcode
+      self.postcode = transient_registration.temp_contact_postcode
 
       # Check if the user reached this page through an Address finder error.
       # Then wipe the temp attribute as we only need it for routing
@@ -21,43 +28,13 @@ module WasteExemptionsEngine
       transient_registration.update_attributes(address_finder_error: nil)
 
       # Prefill the existing address unless the postcode has changed from the existing address's postcode
-      prefill_site_address_params if saved_address_still_valid?
-    end
-
-    def submit(params)
-      permitted_attributes = params.require(:site_address)
-      permitted_attributes = permitted_attributes.permit(:locality, :postcode, :city, :premises, :street_address, :mode)
-
-      # Needed for validation
-      assign_params(permitted_attributes)
-
-      super(site_address_attributes: permitted_attributes)
-    end
-
-    private
-
-    def assign_params(permitted_attributes)
-      self.site_address = transient_registration.build_site_address(permitted_attributes)
-
-      prefill_site_address_params
+      transient_registration.site_address = nil unless saved_address_still_valid?
     end
 
     def saved_address_still_valid?
-      return false unless site_address
       return true if postcode.blank?
-      return true if postcode == site_address.postcode
 
-      false
-    end
-
-    def prefill_site_address_params
-      return unless site_address
-
-      self.premises = site_address.premises&.strip
-      self.street_address = site_address.street_address&.strip
-      self.locality = site_address.locality&.strip
-      self.city = site_address.city&.strip
-      self.postcode = site_address.postcode&.strip
+      postcode == site_address.postcode
     end
   end
 end


### PR DESCRIPTION
Our manual addres forms have a couple of peculiarities, all to deal with the transient nature of the postcode.
Since the postcode is captured in a different screen, the address manual form has to decide wheter or not to show the in-store manual address depending on the fact that the postcode has changed or has remained the same. For this reson, in this cases, we are setting the attribute on the in-memory transient registration to `nil` wheter the postcode doesn't match the stored one, so that we can be consistent and delegate everything else.