### PR TITLE
Use Fetch instead of Require when fetching parameters

### DIFF
--- a/app/controllers/waste_exemptions_engine/applicant_email_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/applicant_email_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:applicant_email_form).permit(:confirmed_email, :applicant_email)
+      params.fetch(:applicant_email_form, {}).permit(:confirmed_email, :applicant_email)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/applicant_name_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/applicant_name_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:applicant_name_form).permit(:applicant_first_name, :applicant_last_name)
+      params.fetch(:applicant_name_form, {}).permit(:applicant_first_name, :applicant_last_name)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/applicant_phone_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/applicant_phone_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:applicant_phone_form).permit(:applicant_phone)
+      params.fetch(:applicant_phone_form, {}).permit(:applicant_phone)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/business_type_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/business_type_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:business_type_form).permit(:business_type)
+      params.fetch(:business_type_form, {}).permit(:business_type)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/contact_address_lookup_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_address_lookup_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:contact_address_lookup_form).permit(contact_address: [:uprn])
+      params.fetch(:contact_address_lookup_form, {}).permit(contact_address: [:uprn])
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/contact_address_manual_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_address_manual_forms_controller.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
 
     def transient_registration_attributes
       params
-        .require(:contact_address_manual_form)
+        .fetch(:contact_address_manual_form, {})
         .permit(contact_address: %i[locality postcode city premises street_address mode])
     end
   end

--- a/app/controllers/waste_exemptions_engine/contact_email_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_email_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:contact_email_form).permit(:confirmed_email, :contact_email)
+      params.fetch(:contact_email_form, {}).permit(:confirmed_email, :contact_email)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/contact_name_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_name_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:contact_name_form).permit(:contact_first_name, :contact_last_name)
+      params.fetch(:contact_name_form, {}).permit(:contact_first_name, :contact_last_name)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/contact_phone_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_phone_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:contact_phone_form).permit(:contact_phone)
+      params.fetch(:contact_phone_form, {}).permit(:contact_phone)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/contact_postcode_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_postcode_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:contact_postcode_form).permit(:temp_contact_postcode)
+      params.fetch(:contact_postcode_form, {}).permit(:temp_contact_postcode)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/declaration_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/declaration_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:declaration_form).permit(:declaration)
+      params.fetch(:declaration_form, {}).permit(:declaration)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/is_a_farmer_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/is_a_farmer_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:is_a_farmer_form).permit(:is_a_farmer)
+      params.fetch(:is_a_farmer_form, {}).permit(:is_a_farmer)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/location_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/location_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:location_form).permit(:location)
+      params.fetch(:location_form, {}).permit(:location)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/main_people_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/main_people_forms_controller.rb
@@ -17,7 +17,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:main_people_form).permit(:first_name, :last_name)
+      params.fetch(:main_people_form, {}).permit(:first_name, :last_name)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/on_a_farm_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/on_a_farm_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:on_a_farm_form).permit(:on_a_farm)
+      params.fetch(:on_a_farm_form, {}).permit(:on_a_farm)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/operator_address_lookup_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/operator_address_lookup_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:operator_address_lookup_form).permit(operator_address: [:uprn])
+      params.fetch(:operator_address_lookup_form, {}).permit(operator_address: [:uprn])
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/operator_address_manual_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/operator_address_manual_forms_controller.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
 
     def transient_registration_attributes
       params
-        .require(:operator_address_manual_form)
+        .fetch(:operator_address_manual_form, {})
         .permit(operator_address: %i[locality postcode city premises street_address mode])
     end
   end

--- a/app/controllers/waste_exemptions_engine/operator_name_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/operator_name_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:operator_name_form).permit(:operator_name)
+      params.fetch(:operator_name_form, {}).permit(:operator_name)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/operator_postcode_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/operator_postcode_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:operator_postcode_form).permit(:temp_operator_postcode)
+      params.fetch(:operator_postcode_form, {}).permit(:temp_operator_postcode)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/registration_number_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/registration_number_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:registration_number_form).permit(:company_no)
+      params.fetch(:registration_number_form, {}).permit(:company_no)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/renewal_start_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/renewal_start_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:renewal_start_form).permit(:temp_renew_without_changes)
+      params.fetch(:renewal_start_form, {}).permit(:temp_renew_without_changes)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/site_address_lookup_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/site_address_lookup_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:site_address_lookup_form).permit(site_address: [:uprn])
+      params.fetch(:site_address_lookup_form, {}).permit(site_address: [:uprn])
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/site_address_manual_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/site_address_manual_forms_controller.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
 
     def transient_registration_attributes
       params
-        .require(:site_address_manual_form)
+        .fetch(:site_address_manual_form, {})
         .permit(site_address: %i[locality postcode city premises street_address mode])
     end
   end

--- a/app/controllers/waste_exemptions_engine/site_grid_reference_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/site_grid_reference_forms_controller.rb
@@ -21,7 +21,7 @@ module WasteExemptionsEngine
 
     def transient_registration_attributes
       params
-        .require(:site_grid_reference_form)
+        .fetch(:site_grid_reference_form, {})
         .permit(:description, :grid_reference)
     end
   end

--- a/app/controllers/waste_exemptions_engine/site_postcode_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/site_postcode_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:site_postcode_form).permit(:temp_site_postcode)
+      params.fetch(:site_postcode_form, {}).permit(:temp_site_postcode)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/start_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/start_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.require(:start_form).permit(:start_option)
+      params.fetch(:start_form, {}).permit(:start_option)
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/contact_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_address_lookup_form.rb
@@ -10,7 +10,8 @@ module WasteExemptionsEngine
     validates :contact_address, "waste_exemptions_engine/address": true
 
     def submit(params)
-      contact_address_attributes = get_address_data(params[:contact_address][:uprn], :contact)
+      contact_address_params = params.fetch(:contact_address, {})
+      contact_address_attributes = get_address_data(contact_address_params[:uprn], :contact)
 
       super(contact_address_attributes: contact_address_attributes)
     end

--- a/app/forms/waste_exemptions_engine/contact_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_address_manual_form.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
     after_initialize :setup_postcode
 
     def submit(params)
-      super(contact_address_attributes: params[:contact_address])
+      super(contact_address_attributes: params[:contact_address] || {})
     end
 
     private

--- a/app/forms/waste_exemptions_engine/operator_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_lookup_form.rb
@@ -10,7 +10,8 @@ module WasteExemptionsEngine
     validates :operator_address, "waste_exemptions_engine/address": true
 
     def submit(params)
-      operator_address_attributes = get_address_data(params[:operator_address][:uprn], :operator)
+      operator_address_params = params.fetch(:operator_address, {})
+      operator_address_attributes = get_address_data(operator_address_params[:uprn], :operator)
 
       super(operator_address_attributes: operator_address_attributes)
     end

--- a/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/operator_address_manual_form.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
     after_initialize :setup_postcode
 
     def submit(params)
-      super(operator_address_attributes: params[:operator_address])
+      super(operator_address_attributes: params[:operator_address] || {})
     end
 
     private

--- a/app/forms/waste_exemptions_engine/site_address_lookup_form.rb
+++ b/app/forms/waste_exemptions_engine/site_address_lookup_form.rb
@@ -10,7 +10,8 @@ module WasteExemptionsEngine
     validates :site_address, "waste_exemptions_engine/address": true
 
     def submit(params)
-      site_address_attributes = get_address_data(params[:site_address][:uprn], :site)
+      site_address_params = params.fetch(:site_address, {})
+      site_address_attributes = get_address_data(site_address_params[:uprn], :site)
 
       super(site_address_attributes: site_address_attributes)
     end

--- a/app/forms/waste_exemptions_engine/site_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/site_address_manual_form.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
     after_initialize :setup_postcode
 
     def submit(params)
-      super(site_address_attributes: params[:site_address])
+      super(site_address_attributes: params[:site_address] || {})
     end
 
     private

--- a/spec/support/shared_examples/requests/post_form.rb
+++ b/spec/support/shared_examples/requests/post_form.rb
@@ -8,6 +8,20 @@ RSpec.shared_examples "POST form" do |form_factory, path, empty_form_is_valid = 
 
   describe "POST #{form_factory}" do
     context "when the form is not valid", unless: empty_form_is_valid do
+      context "when the form is empty" do
+        context "for a form that performs validations" do
+          it "renders the same template" do
+            post post_request_path
+            expect(response).to render_template("waste_exemptions_engine/#{form_factory}s/new")
+          end
+
+          it "responds to the POST request with a 200 status code" do
+            post post_request_path
+            expect(response.code).to eq("200")
+          end
+        end
+      end
+
       it "includes validation errors for the form data" do
         invalid_form_data.each do |invalid_data|
           post post_request_path, form_factory => invalid_data


### PR DESCRIPTION
Given that: https://github.com/rails/strong_parameters/issues/162 is an issue for us, as we want to allow people to submit empty forms, this changes the strategy of fetching parameters from `require` to `fetch` as suggested by the official Rails documentation: https://guides.rubyonrails.org/action_controller_overview.html#more-examples