### PR TITLE
Fix typo: site instead of contact

### DIFF
--- a/app/forms/waste_exemptions_engine/site_address_manual_form.rb
+++ b/app/forms/waste_exemptions_engine/site_address_manual_form.rb
@@ -20,7 +20,7 @@ module WasteExemptionsEngine
     private
 
     def setup_postcode
-      self.postcode = transient_registration.temp_contact_postcode
+      self.postcode = transient_registration.temp_site_postcode
 
       # Prefill the existing address unless the postcode has changed from the existing address's postcode
       transient_registration.site_address = nil unless saved_address_still_valid?


### PR DESCRIPTION
This is a little bug for which we are pre-populating the site address with contact address temp postcode. 