### PR TITLE
Update address base url details

### DIFF
--- a/spec/cassettes/postcode_no_matches.yml
+++ b/spec/cassettes/postcode_no_matches.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=AA11AA
+    uri: http://localhost:3002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=AA11AA
     body:
       encoding: US-ASCII
       string: ''
@@ -14,7 +14,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
-      - localhost:9002
+      - localhost:3002
   response:
     status:
       code: 200
@@ -31,6 +31,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalMatches":0,"startMatch":null,"endMatch":null,"uri_to_supplier":"https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=AA11AA&maxresults=100&dataset=DPA","uri_from_client":"stub","results":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 21 Oct 2019 09:26:48 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/postcode_valid.yml
+++ b/spec/cassettes/postcode_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:9002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
+    uri: http://localhost:3002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS15AH
     body:
       encoding: US-ASCII
       string: ''
@@ -14,7 +14,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
-      - localhost:9002
+      - localhost:3002
   response:
     status:
       code: 200
@@ -37,6 +37,6 @@ http_interactions:
         RENEWABLES PLC, DEANERY ROAD, BRISTOL, BS1 5AH","organisation":"THRIVE RENEWABLES
         PLC","premises":null,"street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
         5AH","x":"358130.1","y":"172687.87","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 21 Oct 2019 09:24:03 GMT
 recorded_with: VCR 5.0.0

--- a/spec/dummy/config/initializers/waste_exemptions_engine.rb
+++ b/spec/dummy/config/initializers/waste_exemptions_engine.rb
@@ -10,7 +10,7 @@ WasteExemptionsEngine.configure do |config|
   config.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
 
   # Addressbase facade config
-  config.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:9002"
+  config.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:3002"
 
   # Email config
   config.email_service_email = ENV["EMAIL_SERVICE_EMAIL"] || "wex-local@example.com"


### PR DESCRIPTION
In our local environment we hadn't quite got the configuration of the address base facade correct.

Turns out this was blocking vagrant from using the cassettes when running tests locally, because it could no longer match the requests.

This change fixes the issue.