### PR TITLE
Switch airbrake mgmt to defra-ruby-alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,3 @@ gemspec
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
-
-# TODO: Remove this and add a proper reference to defra_ruby_alert 1.0.0 in
-# the gemspec once we have confirmed it works with WEX and released it to
-# rubygems
-gem "defra_ruby_alert",
-    git: "https://github.com/DEFRA/defra-ruby-alert",
-    branch: "use-wex-and-wcr-compatible-airbrake"

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,10 @@ gemspec
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
+
+# TODO: Remove this and add a proper reference to defra_ruby_alert 1.0.0 in
+# the gemspec once we have confirmed it works with WEX and released it to
+# rubygems
+gem "defra_ruby_alert",
+    git: "https://github.com/DEFRA/defra-ruby-alert",
+    branch: "use-wex-and-wcr-compatible-airbrake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,16 @@
+GIT
+  remote: https://github.com/DEFRA/defra-ruby-alert
+  revision: 503087106b8c086c4612222820e8ecd1b59f8d6f
+  branch: use-wex-and-wcr-compatible-airbrake
+  specs:
+    defra_ruby_alert (1.0.0)
+      airbrake (~> 5.8.1)
+
 PATH
   remote: .
   specs:
     waste_exemptions_engine (0.0.1)
       aasm (~> 4.12)
-      airbrake (= 5.8.1)
       defra_ruby_address
       defra_ruby_area
       defra_ruby_validators (~> 2.2.0)
@@ -139,7 +146,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
-    mime-types (3.3)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     mini_mime (1.0.2)
@@ -205,7 +212,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (13.0.0)
-    request_store (1.4.1)
+    request_store (1.5.0)
       rack (>= 1.4)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -286,6 +293,7 @@ PLATFORMS
 DEPENDENCIES
   bullet
   database_cleaner
+  defra_ruby_alert!
   defra_ruby_style
   dotenv-rails
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,10 @@
-GIT
-  remote: https://github.com/DEFRA/defra-ruby-alert
-  revision: 503087106b8c086c4612222820e8ecd1b59f8d6f
-  branch: use-wex-and-wcr-compatible-airbrake
-  specs:
-    defra_ruby_alert (1.0.0)
-      airbrake (~> 5.8.1)
-
 PATH
   remote: .
   specs:
     waste_exemptions_engine (0.0.1)
       aasm (~> 4.12)
       defra_ruby_address
+      defra_ruby_alert (~> 1.0.0)
       defra_ruby_area
       defra_ruby_validators (~> 2.2.0)
       has_secure_token
@@ -87,6 +80,8 @@ GEM
     database_cleaner (1.8.2)
     defra_ruby_address (0.1.0)
       rest-client (~> 2.0)
+    defra_ruby_alert (1.0.0)
+      airbrake (~> 5.8.1)
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)
       rest-client (~> 2.0)
@@ -293,7 +288,6 @@ PLATFORMS
 DEPENDENCIES
   bullet
   database_cleaner
-  defra_ruby_alert!
   defra_ruby_style
   dotenv-rails
   factory_bot_rails

--- a/lib/waste_exemptions_engine.rb
+++ b/lib/waste_exemptions_engine.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "defra_ruby/alert"
 require "waste_exemptions_engine/engine"
 
 module WasteExemptionsEngine
@@ -17,6 +18,10 @@ module WasteExemptionsEngine
 
   def self.configure
     yield(configuration)
+  end
+
+  def self.start_airbrake
+    DefraRuby::Alert.start
   end
 
   class Configuration
@@ -47,6 +52,8 @@ module WasteExemptionsEngine
       @edit_enabled = false
       @use_xvfb_for_wickedpdf = true
       @use_last_email_cache = false
+
+      configure_airbrake_rails_properties
     end
 
     def edit_enabled
@@ -80,10 +87,45 @@ module WasteExemptionsEngine
       end
     end
 
+    # Airbrake configuration properties (viia defra_ruby_alert gem)
+    def airbrake_enabled=(value)
+      DefraRuby::Alert.configure do |configuration|
+        configuration.enabled = change_string_to_boolean_for(value)
+      end
+    end
+
+    def airbrake_host=(value)
+      DefraRuby::Alert.configure do |configuration|
+        configuration.host = value
+      end
+    end
+
+    def airbrake_project_key=(value)
+      DefraRuby::Alert.configure do |configuration|
+        configuration.project_key = value
+      end
+    end
+
+    def airbrake_blacklist=(value)
+      DefraRuby::Alert.configure do |configuration|
+        configuration.blacklist = value
+      end
+    end
+
+    private
+
     # If the setting's value is "true", then set to a boolean true. Otherwise, set it to false.
     def change_string_to_boolean_for(setting)
       setting = setting == "true" if setting.is_a?(String)
       setting
+    end
+
+    def configure_airbrake_rails_properties
+      DefraRuby::Alert.configure do |configuration|
+        configuration.root_directory = Rails.root
+        configuration.logger = Rails.logger
+        configuration.environment = Rails.env
+      end
     end
   end
 end

--- a/lib/waste_exemptions_engine.rb
+++ b/lib/waste_exemptions_engine.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "defra_ruby/alert"
 require "waste_exemptions_engine/engine"
 
 module WasteExemptionsEngine

--- a/lib/waste_exemptions_engine/engine.rb
+++ b/lib/waste_exemptions_engine/engine.rb
@@ -6,6 +6,7 @@ require "high_voltage"
 require "paper_trail"
 require "defra_ruby_validators"
 require "defra_ruby/address"
+require "defra_ruby/alert"
 require "defra_ruby/area"
 require "wicked_pdf"
 

--- a/spec/dummy/config/initializers/waste_exemptions_engine.rb
+++ b/spec/dummy/config/initializers/waste_exemptions_engine.rb
@@ -24,4 +24,10 @@ WasteExemptionsEngine.configure do |config|
   # Renewing config
   config.renewal_window_before_expiry_in_days = ENV["RENEWAL_WINDOW_BEFORE_EXPIRY_IN_DAYS"] || 28
   config.renewal_window_after_expiry_in_days = ENV["RENEWAL_WINDOW_AFTER_EXPIRY_IN_DAYS"] || 30
+
+  # Airbrake config
+  config.airbrake_enabled = false
+  config.airbrake_host = "http://localhost"
+  config.airbrake_project_key = "abcde12345"
+  config.airbrake_blacklist = [/password/i]
 end

--- a/spec/dummy/config/initializers/waste_exemptions_engine.rb
+++ b/spec/dummy/config/initializers/waste_exemptions_engine.rb
@@ -31,3 +31,4 @@ WasteExemptionsEngine.configure do |config|
   config.airbrake_project_key = "abcde12345"
   config.airbrake_blacklist = [/password/i]
 end
+WasteExemptionsEngine.start_airbrake

--- a/spec/dummy/config/initializers/waste_exemptions_engine.rb
+++ b/spec/dummy/config/initializers/waste_exemptions_engine.rb
@@ -29,6 +29,6 @@ WasteExemptionsEngine.configure do |config|
   config.airbrake_enabled = false
   config.airbrake_host = "http://localhost"
   config.airbrake_project_key = "abcde12345"
-  config.airbrake_blacklist = [/password/i]
+  config.airbrake_blacklist = [/password/i, /authorization/i]
 end
 WasteExemptionsEngine.start_airbrake

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -22,9 +22,6 @@ Gem::Specification.new do |s|
   # Use AASM to manage states and transitions
   s.add_dependency "aasm", "~> 4.12"
 
-  # Use Airbrake for error reporting to Errbit
-  # Version 6 and above cause errors with Errbit, so use 5.8.1 for now
-  s.add_dependency "airbrake", "5.8.1"
   s.add_dependency "has_secure_token"
   s.add_dependency "high_voltage", "~> 3.1"
   s.add_dependency "rails", "~> 4.2.11"

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -35,6 +35,9 @@ Gem::Specification.new do |s|
   # EA Address Facade v1)
   s.add_dependency "defra_ruby_address"
 
+  # defra_ruby_alert is a gem we created to manage airbrake across projects
+  s.add_dependency "defra_ruby_alert", "~> 1.0.0"
+
   # Used to identify the EA area for a registration
   s.add_dependency "defra_ruby_area"
 


### PR DESCRIPTION
Whilst working on an issue for the [Flood Risk Activity Exemptions service](https://github.com/DEFRA/ruby-services-team/tree/master/services/frae) we came across an [issue](https://github.com/DEFRA/flood-risk-engine/pull/312) with Airbrake.

We wanted to add a new Rake task, and we wanted to apply our new pattern of ensuring Airbrake is closed when the task exits to ensure any errors are reported. The problem was due to the age of the Airbrake gem being used this caused an error in FRAE we hadn't seen in WEX and WCR.

So for reasons outlined in [FRAE PR 312](https://github.com/DEFRA/flood-risk-engine/pull/312) we came up with [defra-ruby-alert](https://github.com/DEFRA/defra-ruby-alert). The idea is going forward this will provide a single interface for configuring Airbrake and ensure the pattern of making sure all exceptions are reported before an app closes is applied consistently in all scenarios.

These changes are the first step in switching the WEX service to using it.
