### PR TITLE
Bump defra_ruby_email from 0.1.0 to 0.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)
       rest-client (~> 2.0)
-    defra_ruby_email (0.1.0)
+    defra_ruby_email (0.2.0)
       rails (~> 4.2.11.1)
     defra_ruby_style (0.1.4)
       rubocop (~> 0.79)


### PR DESCRIPTION
This replaces PR #435 dependabot opened which for some reason is updating a bunch of other stuff as well as defra_ruby_email.

The main issue is its updated sprockets to 4.0.0 but that version requires a minimum ruby version of 2.5.0