### PR TITLE
Fix visual bug on error message

### DIFF
--- a/app/views/waste_exemptions_engine/start_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/start_forms/new.html.erb
@@ -4,7 +4,7 @@
 
     <h1 class="heading-large"><%= t(".heading") %></h1>
 
-    <div class="form-group <%= "form-group-error" if @start_form.errors[:start].any? %>">
+    <div class="form-group <%= "form-group-error" if @start_form.errors[:start_option].any? %>">
       <fieldset id="start_option">
         <legend class="visuallyhidden">
           <%= t(".heading") %>


### PR DESCRIPTION
This fixes a bug for which we are failing to apply the correct form error group class to the form group in the start form page