### PR TITLE
Don't expire VCR cassettes

### DIFF
--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -13,8 +13,6 @@ VCR.configure do |c|
 
   c.ignore_hosts "127.0.0.1", "codeclimate.com"
 
-  c.default_cassette_options = { re_record_interval: 14.days }
-
   # Strip out authorization info
   c.filter_sensitive_data("Basic <API_KEY>") do |interaction|
     auth = interaction.request.headers["Authorization"]


### PR DESCRIPTION
We still want to keep VCR in this project. However, re-recording every fortnight is too big a maintenance overhead,   and we have other ways of detecting breaking changes now.

This change removes the automatic two-week expiry, so cassettes will remain as they are until the request is modified or we decide to update them.