### PR TITLE
Refactor request tests to compact them

### DIFF
--- a/spec/requests/waste_exemptions_engine/confirm_edit_cancelled_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/confirm_edit_cancelled_forms_spec.rb
@@ -12,18 +12,11 @@ module WasteExemptionsEngine
       let(:form) { build(:confirm_edit_cancelled_form) }
       let(:request_path) { "/waste_exemptions_engine/#{form.token}/confirm-edit-cancelled" }
 
-      it "renders the appropriate template" do
+      it "renders the appropriate template, returns a 200 status code and W3C valid HTML content" do
         get request_path
+
         expect(response).to render_template("waste_exemptions_engine/confirm_edit_cancelled_forms/new")
-      end
-
-      it "responds to the GET request with a 200 status code" do
-        get request_path
         expect(response.code).to eq("200")
-      end
-
-      it "returns W3C valid HTML content", vcr: true do
-        get request_path
         expect(response.body).to have_valid_html
       end
     end

--- a/spec/requests/waste_exemptions_engine/edit_cancelled_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/edit_cancelled_forms_spec.rb
@@ -13,18 +13,11 @@ module WasteExemptionsEngine
     describe "GET edit_cancelled_form" do
       let(:request_path) { "/waste_exemptions_engine/#{form.token}/edit-cancelled" }
 
-      it "renders the appropriate template" do
+      it "renders the appropriate template, returns a 200 status  code and W3C valid HTML content" do
         get request_path
+
         expect(response).to render_template("waste_exemptions_engine/edit_cancelled_forms/new")
-      end
-
-      it "responds to the GET request with a 200 status code" do
-        get request_path
         expect(response.code).to eq("200")
-      end
-
-      it "returns W3C valid HTML content", vcr: true do
-        get request_path
         expect(response.body).to have_valid_html
       end
 

--- a/spec/requests/waste_exemptions_engine/edit_complete_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/edit_complete_forms_spec.rb
@@ -13,18 +13,11 @@ module WasteExemptionsEngine
     describe "GET edit_complete_form" do
       let(:request_path) { "/waste_exemptions_engine/#{form.token}/edit-complete" }
 
-      it "renders the appropriate template" do
+      it "renders the appropriate template, returns a 200 status code and W3C valid HTML content", vcr: true do
         get request_path
+
         expect(response).to render_template("waste_exemptions_engine/edit_complete_forms/new")
-      end
-
-      it "responds to the GET request with a 200 status code" do
-        get request_path
         expect(response.code).to eq("200")
-      end
-
-      it "returns W3C valid HTML content", vcr: true do
-        get request_path
         expect(response.body).to have_valid_html
       end
 

--- a/spec/requests/waste_exemptions_engine/edit_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/edit_forms_spec.rb
@@ -16,18 +16,11 @@ module WasteExemptionsEngine
       context "when `WasteExemptionsEngine.configuration.edit_enabled` is \"true\"" do
         let(:edit_enabled) { "true" }
 
-        it "renders the appropriate template" do
+        it "renders the appropriate template, returns a 200 status code and W3C valid HTML content", vcr: true do
           get request_path
+
           expect(response).to render_template("waste_exemptions_engine/edit_forms/new")
-        end
-
-        it "responds to the GET request with a 200 status code" do
-          get request_path
           expect(response.code).to eq("200")
-        end
-
-        it "returns W3C valid HTML content", vcr: true do
-          get request_path
           expect(response.body).to have_valid_html
         end
 
@@ -36,18 +29,11 @@ module WasteExemptionsEngine
 
           let(:request_path) { "/waste_exemptions_engine/#{registration.reference}/edit" }
 
-          it "renders the appropriate template" do
+          it "renders the appropriate template, returns a 200 status code and loads the correct page" do
             get request_path
+
             expect(response).to render_template("waste_exemptions_engine/edit_forms/new")
-          end
-
-          it "responds to the GET request with a 200 status code" do
-            get request_path
             expect(response.code).to eq("200")
-          end
-
-          it "loads the edit form for that registration" do
-            get request_path
             expect(response.body).to include(registration.reference)
           end
 

--- a/spec/requests/waste_exemptions_engine/errors_spec.rb
+++ b/spec/requests/waste_exemptions_engine/errors_spec.rb
@@ -6,24 +6,18 @@ module WasteExemptionsEngine
   RSpec.describe "Errors", type: :request do
     describe "#show" do
       %w[401 403 404 422].each do |code|
-        it "renders the error_#{code} template" do
+        it "renders the error_#{code} template, responds with a status of #{code}, returns W3C valid HTML content", vcr: true do
           get error_path(code)
+
           expect(response).to render_template("error_#{code}")
-        end
-
-        it "responds with a status of #{code}" do
-          get error_path(code)
           expect(response.code).to eq(code)
-        end
-
-        it "returns W3C valid HTML content", vcr: true do
-          get error_path(code)
           expect(response.body).to have_valid_html
         end
       end
 
       it "renders the generic error template when no matching error template exists" do
         get error_path("601")
+
         expect(response.code).to eq("500")
         expect(response).to render_template(:error_generic)
       end

--- a/spec/requests/waste_exemptions_engine/main_people_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/main_people_forms_spec.rb
@@ -30,13 +30,10 @@ module WasteExemptionsEngine
       let(:trans_reg_id) { form.transient_registration.id }
 
       describe "submit and add another" do
-        it "re-renders the form template" do
+        it "re-renders the form template and returns a #{status_code} status code" do
           post add_person_post_request_path, person_one_request_body
-          expect(response.location).to include(form_path)
-        end
 
-        it "responds to the POST request with a #{status_code} status code" do
-          post add_person_post_request_path, person_one_request_body
+          expect(response.location).to include(form_path)
           expect(response.code).to eq(status_code.to_s)
         end
 
@@ -63,13 +60,10 @@ module WasteExemptionsEngine
 
         before(:each) { form.transient_registration.people = [person_one, person_two] }
 
-        it "re-renders the form template" do
+        it "re-renders the form template and returns a #{status_code} status code" do
           delete delete_person_main_people_forms_path(token: form.token, id: person_one.id)
-          expect(response.location).to include(form_path)
-        end
 
-        it "responds to the DELETE request with a #{status_code} status code" do
-          delete delete_person_main_people_forms_path(token: form.token, id: person_one.id)
+          expect(response.location).to include(form_path)
           expect(response.code).to eq(status_code.to_s)
         end
 

--- a/spec/requests/waste_exemptions_engine/renew_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renew_spec.rb
@@ -11,21 +11,17 @@ module WasteExemptionsEngine
       context "with a valid renew token" do
         let(:token) { registration.renew_token }
 
-        it "redirects to the start renewal page" do
-          get request_path
-          follow_redirect!
+        it "redirects to the start renewal page, creates a new RenewingRegistration and returns a 303 status code" do
+          expected_count = RenewingRegistration.count + 1
 
-          expect(response).to render_template("waste_exemptions_engine/renewal_start_forms/new")
-        end
-
-        it "creates a new RenewingRegistration" do
-          expect { get request_path }.to change { RenewingRegistration.count }.by(1)
-        end
-
-        it "responds to the GET request with a 303 status code" do
           get request_path
 
           expect(response.code).to eq("303")
+
+          follow_redirect!
+
+          expect(response).to render_template("waste_exemptions_engine/renewal_start_forms/new")
+          expect(RenewingRegistration.count).to eq(expected_count)
         end
 
         context "when a renewal was left in progress" do
@@ -52,21 +48,11 @@ module WasteExemptionsEngine
           create(:registration, referring_registration_id: registration.id)
         end
 
-        it "respond with a 200 status" do
+        it "respond with a 200 status, renders the appropriate template and returns W3C valid HTML content", vcr: true do
           get request_path
 
           expect(response.code).to eq("200")
-        end
-
-        it "renders the appropriate template" do
-          get request_path
-
           expect(response).to render_template("waste_exemptions_engine/renews/already_renewed")
-        end
-
-        it "returns W3C valid HTML content", vcr: true do
-          get request_path
-
           expect(response.body).to have_valid_html
         end
       end
@@ -75,21 +61,11 @@ module WasteExemptionsEngine
         let(:registration) { create(:registration, :complete, :past_renewal_window) }
         let(:token) { registration.renew_token }
 
-        it "respond with a 200 status" do
+        it "respond with a 200 status, renders the appropriate template and returns W3C valid HTML content", vcr: true do
           get request_path
 
           expect(response.code).to eq("200")
-        end
-
-        it "renders the appropriate template" do
-          get request_path
-
           expect(response).to render_template("waste_exemptions_engine/renews/past_renewal_window")
-        end
-
-        it "returns W3C valid HTML content", vcr: true do
-          get request_path
-
           expect(response.body).to have_valid_html
         end
       end
@@ -97,21 +73,11 @@ module WasteExemptionsEngine
       context "when a token is invalid" do
         let(:token) { "FooBarBaz" }
 
-        it "returns a 404 status" do
+        it "returns a 404 status, renders the correct template and returns W3C valid HTML content", vcr: true do
           get request_path
 
           expect(response.code).to eq("404")
-        end
-
-        it "returns the correct template" do
-          get request_path
-
           expect(response).to render_template("waste_exemptions_engine/renews/invalid_magic_link")
-        end
-
-        it "returns W3C valid HTML content", vcr: true do
-          get request_path
-
           expect(response.body).to have_valid_html
         end
       end

--- a/spec/requests/waste_exemptions_engine/renew_with_changes_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renew_with_changes_forms_spec.rb
@@ -9,18 +9,11 @@ module WasteExemptionsEngine
     describe "GET renew_with_changes_form" do
       let(:request_path) { "/waste_exemptions_engine/#{form.token}/renew-with-changes" }
 
-      it "renders the appropriate template" do
+      it "renders the appropriate template, returns a 200 status code and W3C valid HTML content", vcr: true do
         get request_path
+
         expect(response).to render_template("waste_exemptions_engine/renew_with_changes_forms/new")
-      end
-
-      it "responds to the GET request with a 200 status code" do
-        get request_path
         expect(response.code).to eq("200")
-      end
-
-      it "returns W3C valid HTML content", vcr: true do
-        get request_path
         expect(response.body).to have_valid_html
       end
     end

--- a/spec/requests/waste_exemptions_engine/renew_without_changes_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renew_without_changes_forms_spec.rb
@@ -9,18 +9,11 @@ module WasteExemptionsEngine
     describe "GET renew_without_changes_form" do
       let(:request_path) { "/waste_exemptions_engine/#{form.token}/renew-without-changes" }
 
-      it "renders the appropriate template" do
+      it "renders the appropriate template, returns a 200 status code and W3C valid HTML content", vcr: true do
         get request_path
+
         expect(response).to render_template("waste_exemptions_engine/renew_without_changes_forms/new")
-      end
-
-      it "responds to the GET request with a 200 status code" do
-        get request_path
         expect(response.code).to eq("200")
-      end
-
-      it "returns W3C valid HTML content", vcr: true do
-        get request_path
         expect(response.body).to have_valid_html
       end
     end

--- a/spec/requests/waste_exemptions_engine/renewal_complete_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renewal_complete_forms_spec.rb
@@ -9,38 +9,20 @@ module WasteExemptionsEngine
     describe "GET renewal_complete_form" do
       let(:request_path) { "/waste_exemptions_engine/#{form.token}/renewal-complete" }
 
-      it "renders the appropriate template" do
-        get request_path
-        expect(response).to render_template("waste_exemptions_engine/renewal_complete_forms/new")
-      end
-
-      it "responds to the GET request with a 200 status code" do
-        get request_path
-        expect(response.code).to eq("200")
-      end
-
-      it "creates a new registration" do
+      it "renders the appropriate template, returns a 200 status code, creates a new registration, removes the renewing registration, display the correct reference number and returns W3C valid HTML content", vcr: true do
         # Execute let variable as the factory will generate a registration to renew which should be counted separately
         form
 
         initial_count = Registration.count
+        expect(RenewingRegistration.where(token: form.token).count).to eq(1)
 
         get request_path
 
+        expect(response).to render_template("waste_exemptions_engine/renewal_complete_forms/new")
+        expect(response.code).to eq("200")
         expect(Registration.count).to eq(initial_count + 1)
-      end
-
-      it "removes the renewing_registration" do
-        expect { get request_path }.to change { RenewingRegistration.where(token: form.token).count }.from(1).to(0)
-      end
-
-      it "displays the new registration reference number" do
-        get request_path
+        expect(RenewingRegistration.where(token: form.token).count).to eq(0)
         expect(response.body).to include(Registration.last.reference)
-      end
-
-      it "returns W3C valid HTML content", vcr: true do
-        get request_path
         expect(response.body).to have_valid_html
       end
     end

--- a/spec/requests/waste_exemptions_engine/renewal_start_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/renewal_start_forms_spec.rb
@@ -9,19 +9,11 @@ module WasteExemptionsEngine
     describe "GET renewal_start_form" do
       let(:request_path) { "/waste_exemptions_engine/#{form.token}/renewal-start" }
 
-      it "renders the appropriate template" do
+      it "renders the appropriate template, returns a 200 status code and W3C valid HTML content", vcr: true do
         get request_path
+
         expect(response).to render_template("waste_exemptions_engine/renewal_start_forms/new")
-      end
-
-      it "responds to the GET request with a 200 status code" do
-        get request_path
         expect(response.code).to eq("200")
-      end
-
-      it "returns W3C valid HTML content", vcr: true do
-        get request_path
-
         expect(response.body).to have_valid_html
       end
     end

--- a/spec/requests/waste_exemptions_engine/site_grid_reference_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_grid_reference_forms_spec.rb
@@ -29,13 +29,10 @@ module WasteExemptionsEngine
       let(:site_address_request_path) { skip_to_address_site_grid_reference_forms_path(token: form.token) }
 
       describe "GET site_address_request_path" do
-        it "renders the appropriate template" do
+        it "renders the appropriate template and returns a 303 status code" do
           get site_address_request_path
-          expect(response.location).to include(site_postcode_forms_path(token: form.token))
-        end
 
-        it "responds to the GET request with a 303 status code" do
-          get site_address_request_path
+          expect(response.location).to include(site_postcode_forms_path(token: form.token))
           expect(response.code).to eq("303")
         end
       end

--- a/spec/requests/waste_exemptions_engine/start_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/start_forms_spec.rb
@@ -9,18 +9,11 @@ module WasteExemptionsEngine
     describe "GET start_form" do
       let(:request_path) { "/waste_exemptions_engine/start" }
 
-      it "renders the appropriate template" do
+      it "renders the appropriate template, returns a 200 status code and W3C valid HTML content", vcr: true do
         get request_path
+
         expect(response).to render_template("waste_exemptions_engine/start_forms/new")
-      end
-
-      it "responds to the GET request with a 200 status code" do
-        get request_path
         expect(response.code).to eq("200")
-      end
-
-      it "returns W3C valid HTML content", vcr: true do
-        get request_path
         expect(response.body).to have_valid_html
       end
     end

--- a/spec/support/shared_examples/requests/go_back.rb
+++ b/spec/support/shared_examples/requests/go_back.rb
@@ -8,13 +8,9 @@ RSpec.shared_examples "go back" do |form_factory, path|
   status_code = WasteExemptionsEngine::ApplicationController::SUCCESSFUL_REDIRECTION_CODE
 
   describe "GET #{form_factory} back" do
-    it "renders the appropriate template" do
+    it "renders the appropriate template and returns a #{status_code} status code" do
       get back_request_path
       expect(response.location).to include(redirection_path)
-    end
-
-    it "responds to the GET request with a #{status_code} status code" do
-      get back_request_path
       expect(response.code).to eq(status_code.to_s)
     end
   end

--- a/spec/support/shared_examples/requests/skip_to_manual_address.rb
+++ b/spec/support/shared_examples/requests/skip_to_manual_address.rb
@@ -7,13 +7,10 @@ RSpec.shared_examples "skip to manual address" do |form_factory, address_type:|
   status_code = WasteExemptionsEngine::ApplicationController::SUCCESSFUL_REDIRECTION_CODE
 
   describe "GET #{form_factory} skip to manual address" do
-    it "renders the appropriate template" do
+    it "renders the appropriate template and returns a #{status_code} status code" do
       get manual_address_request_path
-      expect(response.location).to include(manual_address_form_path)
-    end
 
-    it "responds to the GET request with a #{status_code} status code" do
-      get manual_address_request_path
+      expect(response.location).to include(manual_address_form_path)
       expect(response.code).to eq(status_code.to_s)
     end
   end


### PR DESCRIPTION
We decided a while ago that we whould compact all scenarios in the same context to one, in order to make only one request per context and so speed up our test suite. This apply this principle to the test suite.

Before: 
<img width="679" alt="Screenshot 2020-05-13 at 11 59 15" src="https://user-images.githubusercontent.com/1385397/81804537-2e2e7280-9511-11ea-8c0f-4d411bd814e3.png">
After: 
<img width="709" alt="Screenshot 2020-05-13 at 11 59 32" src="https://user-images.githubusercontent.com/1385397/81804566-37b7da80-9511-11ea-8ab2-7920ec20fc9c.png">
