### PR TITLE
Updgrade Feature Toggle to proper model

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -3,8 +3,8 @@
 # installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path('..', __dir__)
-ENGINE_PATH = File.expand_path('../lib/waste/exemptions/engine/engine', __dir__)
-APP_PATH = File.expand_path('../test/dummy/config/application', __dir__)
+ENGINE_PATH = File.expand_path('../lib/waste_exemptions_engine/engine', __dir__)
+APP_PATH = File.expand_path('../spec/dummy/config/application', __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)

--- a/db/migrate/20200629141525_create_feature_toggle.rb
+++ b/db/migrate/20200629141525_create_feature_toggle.rb
@@ -1,0 +1,10 @@
+class CreateFeatureToggle < ActiveRecord::Migration[6.0]
+  def change
+    create_table :feature_toggles do |t|
+      t.string :key
+      t.boolean :active
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_19_114115) do
+ActiveRecord::Schema.define(version: 2020_06_29_141525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -260,6 +260,13 @@ ActiveRecord::Schema.define(version: 2020_05_19_114115) do
     t.datetime "created_at"
     t.json "json"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+  end
+
+  create_table "feature_toggles", force: :cascade do |t|
+    t.string "key"
+    t.boolean "active"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "addresses", "registrations"

--- a/spec/factories/feature_toggle.rb
+++ b/spec/factories/feature_toggle.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :feature_toggle, class: WasteExemptionsEngine::FeatureToggle do
+    key { "test-feature" }
+
+    active { false }
+  end
+end

--- a/spec/models/waste_exemptions_engine/feature_toggle_spec.rb
+++ b/spec/models/waste_exemptions_engine/feature_toggle_spec.rb
@@ -5,53 +5,79 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe FeatureToggle do
     describe ".active?" do
-      context "when a feature toggle config exist" do
-        context "when it is configured as active" do
+      context "when the feature toggle is persisted in the database" do
+        let(:key) { "toggle_1" }
+
+        before do
+          create(:feature_toggle, key: key, active: active)
+        end
+
+        context "when the toggle is active" do
+          let(:active) { "true" }
+
           it "returns true" do
-            expect(described_class.active?("active_test_feature")).to be_truthy
-          end
-
-          it "accept either strings or syms" do
-            expect(described_class.active?(:active_test_feature)).to be_truthy
+            expect(described_class.active?(key)).to eq(true)
           end
         end
 
-        context "when it is configured as not active" do
+        context "when the toggle is not active" do
+          let(:active) { false }
+
           it "returns false" do
-            expect(described_class.active?("not_active_test_feature")).to be_falsey
-          end
-        end
-
-        context "when the feature toggle contains a typo in the return value" do
-          it "returns false" do
-            expect(described_class.active?("broken_test_feature")).to be_falsey
-          end
-        end
-
-        context "when the feature toggle contains a typo in the structure level" do
-          it "returns false" do
-            expect(described_class.active?("broken_test_feature_2")).to be_falsey
-          end
-        end
-
-        context "when the feature toggle is a string containing 'true'" do
-          it "returns true" do
-            expect(described_class.active?("string_true_test_feature")).to be_truthy
-          end
-        end
-
-        context "when the feature toggle is an environment variable" do
-          it "returns true" do
-            ENV["ENV_VARIABLE_TEST_FEATURE"] = "true"
-
-            expect(described_class.active?("env_variable_test_feature")).to be_truthy
+            expect(described_class.active?(key)).to eq(false)
           end
         end
       end
 
-      context "when a feature toggle config does not exist" do
-        it "returns false" do
-          expect(described_class.active?("i_do_not_exist")).to be_falsey
+      context "when there is no matching for the feature key in the database" do
+        context "when a feature toggle config exist" do
+          context "when it is configured as active" do
+            it "returns true" do
+              expect(described_class.active?("active_test_feature")).to be_truthy
+            end
+
+            it "accept either strings or syms" do
+              expect(described_class.active?(:active_test_feature)).to be_truthy
+            end
+          end
+
+          context "when it is configured as not active" do
+            it "returns false" do
+              expect(described_class.active?("not_active_test_feature")).to be_falsey
+            end
+          end
+
+          context "when the feature toggle contains a typo in the return value" do
+            it "returns false" do
+              expect(described_class.active?("broken_test_feature")).to be_falsey
+            end
+          end
+
+          context "when the feature toggle contains a typo in the structure level" do
+            it "returns false" do
+              expect(described_class.active?("broken_test_feature_2")).to be_falsey
+            end
+          end
+
+          context "when the feature toggle is a string containing 'true'" do
+            it "returns true" do
+              expect(described_class.active?("string_true_test_feature")).to be_truthy
+            end
+          end
+
+          context "when the feature toggle is an environment variable" do
+            it "returns true" do
+              ENV["ENV_VARIABLE_TEST_FEATURE"] = "true"
+
+              expect(described_class.active?("env_variable_test_feature")).to be_truthy
+            end
+          end
+        end
+
+        context "when a feature toggle config does not exist" do
+          it "returns false" do
+            expect(described_class.active?("i_do_not_exist")).to be_falsey
+          end
         end
       end
     end

--- a/spec/models/waste_exemptions_engine/feature_toggle_spec.rb
+++ b/spec/models/waste_exemptions_engine/feature_toggle_spec.rb
@@ -5,14 +5,14 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe FeatureToggle do
     describe ".active?" do
-      context "when the feature toggle is persisted in the database" do
+      context "when a record exists with the given key" do
         let(:key) { "toggle_1" }
 
         before do
           create(:feature_toggle, key: key, active: active)
         end
 
-        context "when the toggle is active" do
+        context "and the toggle is active" do
           let(:active) { "true" }
 
           it "returns true" do
@@ -20,7 +20,7 @@ module WasteExemptionsEngine
           end
         end
 
-        context "when the toggle is not active" do
+        context "and the toggle is not active" do
           let(:active) { false }
 
           it "returns false" do
@@ -29,43 +29,43 @@ module WasteExemptionsEngine
         end
       end
 
-      context "when there is no matching for the feature key in the database" do
-        context "when a feature toggle config exist" do
-          context "when it is configured as active" do
+      context "when a record does not exist with the given key" do
+        context "but a feature toggle exists in 'config/feature_toggles.yml'" do
+          context "and it is configured as active" do
             it "returns true" do
               expect(described_class.active?("active_test_feature")).to be_truthy
             end
 
-            it "accept either strings or syms" do
+            it "accepts either strings or symbols" do
               expect(described_class.active?(:active_test_feature)).to be_truthy
             end
           end
 
-          context "when it is configured as not active" do
+          context "and it is configured as not active" do
             it "returns false" do
               expect(described_class.active?("not_active_test_feature")).to be_falsey
             end
           end
 
-          context "when the feature toggle contains a typo in the return value" do
+          context "and the feature toggle contains a typo in the return value" do
             it "returns false" do
               expect(described_class.active?("broken_test_feature")).to be_falsey
             end
           end
 
-          context "when the feature toggle contains a typo in the structure level" do
+          context "and the feature toggle contains a typo in the structure level" do
             it "returns false" do
               expect(described_class.active?("broken_test_feature_2")).to be_falsey
             end
           end
 
-          context "when the feature toggle is a string containing 'true'" do
+          context "and the feature toggle is a string containing 'true'" do
             it "returns true" do
               expect(described_class.active?("string_true_test_feature")).to be_truthy
             end
           end
 
-          context "when the feature toggle is an environment variable" do
+          context "and the feature toggle is an environment variable" do
             it "returns true" do
               ENV["ENV_VARIABLE_TEST_FEATURE"] = "true"
 
@@ -74,7 +74,7 @@ module WasteExemptionsEngine
           end
         end
 
-        context "when a feature toggle config does not exist" do
+        context "and a feature toggle does not exist in 'config/feature_toggles.yml'" do
           it "returns false" do
             expect(described_class.active?("i_do_not_exist")).to be_falsey
           end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1139

This upgrade the feature toggle to be a proper model.
It also fixes the content of the `bin/rails` file which was pointing to the wrong files.
The old Feature Toggle functionality and interface as stayied the same. To achieve 0 downtime we will fall back to the content of the yml if we can't find a match for a given feature on the database. Once this is merged and deployed, we can create the records using the back-office interface and then at the subsequent deploy we can cleanup the code in the model that fallsback to the content of the config file.