### PR TITLE
Update validator error message syntax with concern

### DIFF
--- a/app/validators/concerns/waste_exemptions_engine/can_add_validation_errors.rb
+++ b/app/validators/concerns/waste_exemptions_engine/can_add_validation_errors.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module CanAddValidationErrors
+    private
+
+    def add_validation_error(record, attribute, error)
+      record.errors.add(attribute,
+                        error,
+                        message: error_message(record, attribute, error))
+    end
+
+    def error_message(record, attribute, error)
+      class_name = record.class.to_s.underscore
+      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
+    end
+  end
+end

--- a/app/validators/concerns/waste_exemptions_engine/can_validate_length.rb
+++ b/app/validators/concerns/waste_exemptions_engine/can_validate_length.rb
@@ -10,7 +10,7 @@ module WasteExemptionsEngine
       def value_is_not_too_long?(record, attribute, value, max_length)
         return true if value.length <= max_length
 
-        record.errors[attribute] << error_message(record, attribute, "too_long")
+        add_validation_error(record, attribute, :too_long)
         false
       end
     end

--- a/app/validators/concerns/waste_exemptions_engine/can_validate_presence.rb
+++ b/app/validators/concerns/waste_exemptions_engine/can_validate_presence.rb
@@ -10,7 +10,7 @@ module WasteExemptionsEngine
       def value_is_present?(record, attribute, value)
         return true if value.present?
 
-        record.errors[attribute] << error_message(record, attribute, "blank")
+        add_validation_error(record, attribute, :blank)
         false
       end
     end

--- a/app/validators/concerns/waste_exemptions_engine/can_validate_selection.rb
+++ b/app/validators/concerns/waste_exemptions_engine/can_validate_selection.rb
@@ -10,7 +10,7 @@ module WasteExemptionsEngine
       def value_is_included?(record, attribute, value, valid_options)
         return true if value.present? && valid_options.include?(value)
 
-        record.errors[attribute] << error_message(record, attribute, "inclusion")
+        add_validation_error(record, attribute, :inclusion)
         false
       end
     end

--- a/app/validators/waste_exemptions_engine/address_validator.rb
+++ b/app/validators/waste_exemptions_engine/address_validator.rb
@@ -5,8 +5,7 @@ module WasteExemptionsEngine
     def validate_each(record, attribute, value)
       return true if value && (value[:uprn].present? || value[:postcode].present?)
 
-      record.errors[attribute] << error_message(record, attribute, "blank")
-
+      add_validation_error(record, attribute, :blank)
       false
     end
   end

--- a/app/validators/waste_exemptions_engine/base_validator.rb
+++ b/app/validators/waste_exemptions_engine/base_validator.rb
@@ -2,12 +2,6 @@
 
 module WasteExemptionsEngine
   class BaseValidator < ActiveModel::EachValidator
-
-    protected
-
-    def error_message(record, attribute, error)
-      class_name = record.class.to_s.underscore
-      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
-    end
+    include CanAddValidationErrors
   end
 end

--- a/app/validators/waste_exemptions_engine/exemptions_validator.rb
+++ b/app/validators/waste_exemptions_engine/exemptions_validator.rb
@@ -5,7 +5,7 @@ module WasteExemptionsEngine
     def validate_each(record, attribute, value)
       return true if value.present? && value.length.positive?
 
-      record.errors[attribute] << error_message(record, attribute, "inclusion")
+      add_validation_error(record, attribute, :inclusion)
       false
     end
   end

--- a/app/validators/waste_exemptions_engine/manual_address_validator.rb
+++ b/app/validators/waste_exemptions_engine/manual_address_validator.rb
@@ -2,6 +2,7 @@
 
 module WasteExemptionsEngine
   class ManualAddressValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
     include CanValidatePresence
     include CanValidateLength
 
@@ -21,13 +22,6 @@ module WasteExemptionsEngine
       end
 
       record.errors.empty?
-    end
-
-    private
-
-    def error_message(record, attribute, error)
-      class_name = record.class.to_s.underscore
-      I18n.t("activemodel.errors.models.#{class_name}.attributes.#{attribute}.#{error}")
     end
   end
 end

--- a/app/validators/waste_exemptions_engine/matching_email_validator.rb
+++ b/app/validators/waste_exemptions_engine/matching_email_validator.rb
@@ -8,7 +8,7 @@ module WasteExemptionsEngine
       email_address_to_confirm = record.send(options[:compare_to])
       return true if value == email_address_to_confirm
 
-      record.errors[attribute] << error_message(record, attribute, "does_not_match")
+      add_validation_error(record, attribute, :does_not_match)
       false
     end
   end

--- a/app/validators/waste_exemptions_engine/person_name_validator.rb
+++ b/app/validators/waste_exemptions_engine/person_name_validator.rb
@@ -19,7 +19,7 @@ module WasteExemptionsEngine
       # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
       return true if value.match?(/\A[-a-z\s,.']+\z/i)
 
-      record.errors[attribute] << error_message(record, attribute, "invalid")
+      add_validation_error(record, attribute, :invalid)
       false
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1138

This update fixes a bug introduced with the Rails 6 upgrade that was preventing the postcode lookup page from displaying the 'skip to manual address' link when the right error was triggered.

The fix follows the same model as used in waste carriers here: https://github.com/DEFRA/waste-carriers-engine/pull/875