### PR TITLE
Add initial test implementation of Notify

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
       defra_ruby_validators
       has_secure_token
       high_voltage (~> 3.1)
+      notifications-ruby-client
       os_map_ref (~> 0.5)
       paper_trail (~> 10.2.0)
       pg
@@ -161,6 +162,7 @@ GEM
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
+    jwt (2.2.1)
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -182,6 +184,8 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (5.3.0)
+      jwt (>= 1.5, < 3)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -332,7 +336,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.7.2)
+    websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     wicked_pdf (2.1.0)

--- a/app/services/waste_exemptions_engine/notify_service.rb
+++ b/app/services/waste_exemptions_engine/notify_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "notifications/client"
+
+module WasteExemptionsEngine
+  class NotifyService < BaseService
+    def run(email:, name:)
+      client.send_email(email_address: email,
+                        template_id: template,
+                        personalisation: personalisation(name: name))
+    end
+
+    private
+
+    def client
+      @_client ||= Notifications::Client.new(WasteExemptionsEngine.configuration.notify_api_key)
+    end
+
+    def template
+      "4ea25669-1203-4ed7-8f0f-45f0dcaa8199"
+    end
+
+    def personalisation(name:)
+      {
+        name: name
+      }
+    end
+  end
+end

--- a/lib/waste_exemptions_engine.rb
+++ b/lib/waste_exemptions_engine.rb
@@ -43,6 +43,9 @@ module WasteExemptionsEngine
     # Companies house API config
     attr_reader :companies_house_host, :companies_house_api_key
 
+    # Notify config
+    attr_accessor :notify_api_key
+
     def initialize
       @service_name = "Waste Exemptions Service"
       @years_before_expiry = 3

--- a/spec/cassettes/notify_test.yml
+++ b/spec/cassettes/notify_test.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notifications.service.gov.uk/v2/notifications/email
+    body:
+      encoding: UTF-8
+      string: '{"email_address":"foo@example.com","template_id":"4ea25669-1203-4ed7-8f0f-45f0dcaa8199","personalisation":{"name":"Foo"}}'
+    headers:
+      User-Agent:
+      - NOTIFY-API-RUBY-CLIENT/5.3.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic <API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 11 Aug 2020 13:28:58 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-B3-Spanid:
+      - b964a5388a07c6d5
+      X-B3-Traceid:
+      - b964a5388a07c6d5
+      X-Vcap-Request-Id:
+      - 338c0ecb-2a9d-486c-5ddc-05ea5e1bb670
+      Content-Length:
+      - '547'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"content":{"body":"This is a test message for Foo.","from_email":"waste.exemptions@notifications.service.gov.uk","subject":"This
+        is a test message"},"id":"eeaaccb2-68bb-4e18-8bc4-30d80d08dbdb","reference":null,"scheduled_for":null,"template":{"id":"4ea25669-1203-4ed7-8f0f-45f0dcaa8199","uri":"https://api.notifications.service.gov.uk/services/367ec8d8-ae34-4e85-bb3e-870659f93c43/templates/4ea25669-1203-4ed7-8f0f-45f0dcaa8199","version":2},"uri":"https://api.notifications.service.gov.uk/v2/notifications/eeaaccb2-68bb-4e18-8bc4-30d80d08dbdb"}
+
+'
+  recorded_at: Tue, 11 Aug 2020 13:28:58 GMT
+recorded_with: VCR 6.0.0

--- a/spec/dummy/config/initializers/waste_exemptions_engine.rb
+++ b/spec/dummy/config/initializers/waste_exemptions_engine.rb
@@ -30,5 +30,8 @@ WasteExemptionsEngine.configure do |config|
   config.airbrake_host = "http://localhost"
   config.airbrake_project_key = "abcde12345"
   config.airbrake_blocklist = [/password/i, /authorization/i]
+
+  # Notify config
+  config.notify_api_key = ENV["NOTIFY_API_KEY"]
 end
 WasteExemptionsEngine.start_airbrake

--- a/spec/services/waste_exemptions_engine/notify_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/notify_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe NotifyService do
+    describe "run" do
+      let(:email) { "foo@example.com" }
+      let(:name) { "Foo" }
+      let(:service) { NotifyService.run(email: email, name: name) }
+
+      it "sends an email" do
+        VCR.use_cassette("notify_test") do
+          args = {
+            email_address: email,
+            template_id: "4ea25669-1203-4ed7-8f0f-45f0dcaa8199",
+            personalisation: { name: name }
+          }
+          expect_any_instance_of(Notifications::Client).to receive(:send_email).with(args).and_call_original
+
+          response = service
+
+          expect(response).to be_a(Notifications::Client::ResponseNotification)
+          expect(response.content["body"]).to eq("This is a test message for Foo.")
+        end
+      end
+    end
+  end
+end

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -49,6 +49,9 @@ Gem::Specification.new do |s|
   # details of the last email sent by the app can be accessed
   s.add_dependency "defra_ruby_email"
 
+  # Use Notify to send emails and letters
+  s.add_dependency "notifications-ruby-client"
+
   s.add_dependency "pg"
 
   s.add_development_dependency "rails-controller-testing"


### PR DESCRIPTION
This PR installs the Notify gem for Ruby and adds a test class to send basic test emails.