### PR TITLE
Stop feature toggle migration from breaking prod data

### DIFF
--- a/db/migrate/20200629141525_create_feature_toggle.rb
+++ b/db/migrate/20200629141525_create_feature_toggle.rb
@@ -1,6 +1,6 @@
 class CreateFeatureToggle < ActiveRecord::Migration[6.0]
   def change
-    create_table :feature_toggles do |t|
+    create_table :feature_toggles, if_not_exists: true do |t|
       t.string :key
       t.boolean :active
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -73,6 +73,13 @@ ActiveRecord::Schema.define(version: 2020_06_29_141525) do
     t.text "guidance"
   end
 
+  create_table "feature_toggles", force: :cascade do |t|
+    t.string "key"
+    t.boolean "active"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "people", id: :serial, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
@@ -260,13 +267,6 @@ ActiveRecord::Schema.define(version: 2020_06_29_141525) do
     t.datetime "created_at"
     t.json "json"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
-  end
-
-  create_table "feature_toggles", force: :cascade do |t|
-    t.string "key"
-    t.boolean "active"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "addresses", "registrations"


### PR DESCRIPTION
When testing this, we found that if an earlier version of the feature_toggle table existed, the deployment would break.