### PR TITLE
Allow contact position form to persist data

### DIFF
--- a/app/controllers/waste_exemptions_engine/contact_position_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_position_forms_controller.rb
@@ -9,5 +9,11 @@ module WasteExemptionsEngine
     def create
       super(ContactPositionForm, "contact_position_form")
     end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:contact_position_form, {}).permit(:contact_position)
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1263

The controller for the contact position form did not have the `contact_position` attribute set as an allowed param. This meant that it was not saved when the form was submitted. This didn't raise an error because leaving the form blank is also a valid response.