### PR TITLE
Move Notify confirmation letter code from BO to engine

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_be_ordered_by_state_and_exemption_id.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_be_ordered_by_state_and_exemption_id.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module CanBeOrderedByStateAndExemptionId
+    extend ActiveSupport::Concern
+
+    included do
+      scope :order_by_state_then_exemption_id, lambda {
+        order(
+          Arel.sql(
+            "CASE
+              WHEN state = 'active'  THEN '1'
+              WHEN state = 'ceased'  THEN '2'
+              WHEN state = 'revoked' THEN '3'
+              WHEN state = 'expired' THEN '4'
+            END"
+          ),
+          :exemption_id
+        )
+      }
+    end
+  end
+end

--- a/app/models/waste_exemptions_engine/registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/registration_exemption.rb
@@ -4,6 +4,8 @@ module WasteExemptionsEngine
   class RegistrationExemption < ApplicationRecord
     self.table_name = "registration_exemptions"
 
+    include CanBeOrderedByStateAndExemptionId
+
     belongs_to :registration
     belongs_to :exemption
 

--- a/app/models/waste_exemptions_engine/transient_registration_exemption.rb
+++ b/app/models/waste_exemptions_engine/transient_registration_exemption.rb
@@ -5,6 +5,7 @@ module WasteExemptionsEngine
     self.table_name = "transient_registration_exemptions"
 
     include CanActivateExemption
+    include CanBeOrderedByStateAndExemptionId
 
     belongs_to :transient_registration
     belongs_to :exemption

--- a/app/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter.rb
+++ b/app/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  # rubocop:disable Metrics/ClassLength
+  class NotifyConfirmationLetterPresenter < BasePresenter
+    def date_registered
+      # Currently you can only add exemptions when you register, so we can assume they expire at the same time
+      registration_exemptions.first.registered_on.to_formatted_s(:day_month_year)
+    end
+
+    def applicant_name
+      "#{applicant_first_name} #{applicant_last_name}"
+    end
+
+    def contact_name
+      "#{contact_first_name} #{contact_last_name}"
+    end
+
+    def business_details_section
+      items = []
+
+      items << business_type_text
+
+      if partnership?
+        people.each_with_index do |person, index|
+          items << partners_text(person, index)
+        end
+      else
+        items << business_name_text
+        items << company_no_text if company_no.present?
+      end
+
+      items << business_address_text
+
+      items
+    end
+
+    def contact_details_section
+      items = []
+
+      items << contact_name_text
+      items << contact_position_text if contact_position.present?
+      items << contact_phone_text
+      items << contact_email_text
+
+      items
+    end
+
+    def location_section
+      items = []
+
+      if site_address.located_by_grid_reference?
+        items << grid_reference_text
+        items << site_details_text
+      else
+        items << site_address_text
+      end
+
+      items
+    end
+
+    def exemptions_section
+      items = []
+
+      sorted_active_registration_exemptions.each do |registration_exemption|
+        items << exemption_text(registration_exemption)
+      end
+
+      items
+    end
+
+    def deregistered_exemptions_section
+      items = []
+
+      sorted_deregistered_registration_exemptions.each do |registration_exemption|
+        items << exemption_text(registration_exemption)
+      end
+
+      items
+    end
+
+    private
+
+    # Business details
+
+    def business_type_text
+      human_business_type = I18n.t("waste_exemptions_engine.pdfs.certificate.busness_types.#{business_type}")
+      label_and_value("business_details.type", human_business_type)
+    end
+
+    def partners_text(person, index)
+      label_text = I18n.t("notify_confirmation_letter.business_details.partner_enumerator", count: index + 1)
+      person_name = "#{person.first_name} #{person.last_name}"
+
+      "#{label_text} #{person_name}"
+    end
+
+    def business_name_text
+      label_and_value("business_details.name.#{business_type}", operator_name)
+    end
+
+    def company_no_text
+      label_and_value("business_details.number.#{business_type}", company_no)
+    end
+
+    def business_address_text
+      address = address_lines(operator_address).join(", ")
+      label_and_value("business_details.address.#{business_type}", address)
+    end
+
+    # Contact details
+
+    def contact_name_text
+      label_and_value("waste_operation_contact.name", contact_name)
+    end
+
+    def contact_position_text
+      label_and_value("waste_operation_contact.position", contact_position)
+    end
+
+    def contact_phone_text
+      label_and_value("waste_operation_contact.telephone", contact_phone)
+    end
+
+    def contact_email_text
+      label_and_value("waste_operation_contact.email", contact_email)
+    end
+
+    # Location
+
+    def grid_reference_text
+      label_and_value("waste_operation_location.ngr", site_address.grid_reference)
+    end
+
+    def site_details_text
+      label_and_value("waste_operation_location.details", site_address.description)
+    end
+
+    def site_address_text
+      address = address_lines(site_address).join(", ")
+      label_and_value("waste_operation_location.address", address)
+    end
+
+    # Exemptions
+
+    def sorted_active_registration_exemptions
+      registration_exemptions_with_exemptions.where(state: "active").order(:exemption_id)
+    end
+
+    def sorted_deregistered_registration_exemptions
+      registration_exemptions_with_exemptions.where("state != ?", "active").order_by_state_then_exemption_id
+    end
+
+    def exemption_text(registration_exemption)
+      status = registration_exemption_status(registration_exemption)
+      "#{registration_exemption.exemption.code}: #{registration_exemption.exemption.summary} – #{status}"
+    end
+
+    # Utility methods
+
+    def label_and_value(label, value)
+      label_text = I18n.t("notify_confirmation_letter.#{label}")
+      "#{label_text} #{value}"
+    end
+
+    def address_lines(address)
+      return [] unless address
+
+      address_fields = %i[organisation premises street_address locality city postcode]
+      address_fields.map { |field| address.public_send(field) }.reject(&:blank?)
+    end
+
+    def registration_exemption_status(registration_exemption)
+      display_date = if %w[active expired].include?(registration_exemption.state)
+                       registration_exemption.expires_on.to_formatted_s(:day_month_year)
+                     else
+                       registration_exemption.deregistered_at.to_formatted_s(:day_month_year)
+                     end
+
+      I18n.t(
+        "notify_confirmation_letter.waste_exemptions.status.#{registration_exemption.state}",
+        display_date: display_date
+      )
+    end
+
+    def registration_exemptions_with_exemptions
+      registration_exemptions.includes(:exemption)
+    end
+  end
+  # rubocop:enable Metrics/ClassLength
+end

--- a/app/services/waste_exemptions_engine/notify_confirmation_letter_service.rb
+++ b/app/services/waste_exemptions_engine/notify_confirmation_letter_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "notifications/client"
+
+module WasteExemptionsEngine
+  class NotifyConfirmationLetterService < BaseService
+    # So we can use displayable_address()
+    include ApplicationHelper
+
+    def run(registration:)
+      @registration = NotifyConfirmationLetterPresenter.new(registration)
+
+      client = Notifications::Client.new(WasteExemptionsEngine.configuration.notify_api_key)
+
+      client.send_letter(template_id: template,
+                         personalisation: personalisation)
+    end
+
+    private
+
+    def template
+      "81cae4bd-9f4c-4e14-bf3c-44573cee4f5b"
+    end
+
+    def personalisation
+      {
+        reference: @registration.reference,
+        date_registered: @registration.date_registered,
+        applicant_name: @registration.applicant_name,
+        applicant_email: @registration.applicant_email,
+        applicant_phone: @registration.applicant_phone,
+        business_details: @registration.business_details_section,
+        contact_name: @registration.contact_name,
+        contact_details: @registration.contact_details_section,
+        site_details: @registration.location_section,
+        exemption_details: @registration.exemptions_section,
+        deregistered_exemption_details: @registration.deregistered_exemptions_section,
+        show_deregistered_exemption_details: @registration.deregistered_exemptions_section.present?
+      }.merge(address_lines)
+    end
+
+    def address_lines
+      address_values = [
+        @registration.contact_name,
+        displayable_address(@registration.contact_address)
+      ].flatten
+
+      address_hash = {}
+
+      address_values.each_with_index do |value, index|
+        line_number = index + 1
+        address_hash["address_line_#{line_number}"] = value
+      end
+
+      address_hash
+    end
+  end
+end

--- a/config/locales/confirmation_letters.en.yml
+++ b/config/locales/confirmation_letters.en.yml
@@ -1,0 +1,41 @@
+en:
+  notify_confirmation_letter:
+    business_details:
+      type: "Business or organisation type:"
+      partner_enumerator: "Accountable partner %{count}:"
+      name:
+        soleTrader: "Business or organisation name:"
+        limitedCompany: "Registered name of the company:"
+        partnership: "Business or organisation name:"
+        limitedLiabilityPartnership: "Registered name of the partnership:"
+        localAuthority: "Business or organisation name:"
+        charity: "Business or organisation name:"
+      number:
+        soleTrader: "Registration number of the business or organisation:"
+        limitedCompany: "Registration number of the company:"
+        partnership: "Registration number of the business or organisation:"
+        limitedLiabilityPartnership: "Registration number of the partnership:"
+        localAuthority: "Registration number of the business or organisation:"
+        charity: "Registration number of the business or organisation:"
+      address:
+        soleTrader: "Business or organisation address:"
+        limitedCompany: "Registered address of the company:"
+        partnership: "Partnership address:"
+        limitedLiabilityPartnership: "Registered address of the partnership:"
+        localAuthority: "Business or organisation address:"
+        charity: "Business or organisation address:"
+    waste_operation_contact:
+      name: "Name:"
+      position: "Position:"
+      telephone: "Telephone:"
+      email: "Email:"
+    waste_operation_location:
+      address: "Waste operation location:"
+      ngr: "Grid reference:"
+      details: "Site details:"
+    waste_exemptions:
+      status:
+        active: "Expires on %{display_date}"
+        ceased: "Ceased on %{display_date}"
+        revoked: "Revoked on %{display_date}"
+        expired: "Expired on %{display_date}"

--- a/spec/cassettes/notify_confirmation_letter.yml
+++ b/spec/cassettes/notify_confirmation_letter.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notifications.service.gov.uk/v2/notifications/letter
+    body:
+      encoding: UTF-8
+      string: '{"template_id":"81cae4bd-9f4c-4e14-bf3c-44573cee4f5b","personalisation":{"reference":"WEX000001","date_registered":"12
+        February 2021","applicant_name":"Lashaun Predovic","applicant_email":"merideth@example.com","applicant_phone":"01234567890","business_details":["Business
+        or organisation type: Limited company","Registered name of the company: Harvey,
+        Crona and Oberbrunner","Registration number of the company: 09360070","Registered
+        address of the company: Park Estates, 95738 Corkery Pine, United States of
+        America, Nienowchester, BS1 1AA"],"contact_name":"Veronika Frami","contact_details":["Name:
+        Veronika Frami","Position: attorney","Telephone: 01234567890","Email: kandy.jones@example.net"],"site_details":["Grid
+        reference: ST 58337 72855","Site details: Veritatis quia autem deserunt."],"exemption_details":["U1:
+        Dolore magnam consequatur autem. – Expires on 12 February 2024","U2: Quasi
+        nostrum unde vitae. – Expires on 12 February 2024","U3: Eligendi et hic pariatur.
+        – Expires on 12 February 2024"],"deregistered_exemption_details":[],"show_deregistered_exemption_details":false,"address_line_1":"Veronika
+        Frami","address_line_2":"Royal Place","address_line_3":"780 Antonetta Village","address_line_4":"Cape
+        Verde","address_line_5":"Vandervortstad","address_line_6":"BS1 1AA"}}'
+    headers:
+      User-Agent:
+      - NOTIFY-API-RUBY-CLIENT/5.3.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic <API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Feb 2021 17:53:42 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-B3-Spanid:
+      - c9491bd20455024c
+      X-B3-Traceid:
+      - c9491bd20455024c
+      X-Vcap-Request-Id:
+      - 03e60a1c-7872-4c92-6a84-040ed504d28d
+      Content-Length:
+      - '2670'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"content":{"body":"Dear Veronika Frami\r\n\r\n# Your reference: WEX000001\r\n\r\nCheck
+        on the back of this sheet as this may print on more than one page.\r\n\r\n#
+        Your responsibilities\r\n\r\nThe business or organisation responsible for
+        carrying out the exempt waste operations agrees to:\r\n\r\n- comply with all
+        conditions governing how waste must be stored, handled and treated\r\n- carry
+        out the operations without endangering human health or harming the environment\r\n\r\nFor
+        the operations to remain exempt they must be carried out without:\r\n\r\n-
+        causing risk to water, air, soil, plants or animals\r\n- causing a nuisance
+        through noise and odours\r\n- negatively affecting the countryside or places
+        of special interest\r\n\r\nIn sensitive locations extra controls may be needed
+        over and above those set out in the exemptions to make sure this happens.\r\n\r\n#
+        Registration details\r\n\r\n- Reference number: WEX000001\r\n- Activation
+        date: 12 February 2021\r\n\r\n# Registration completed by\r\n\r\n- Name: Lashaun
+        Predovic\r\n- Business telephone number: 01234567890\r\n- Business email:
+        merideth@example.com\r\n\r\n# Business details\r\n\r\n\n\n* Business or organisation
+        type: Limited company\n* Registered name of the company: Harvey, Crona and
+        Oberbrunner\n* Registration number of the company: 09360070\n* Registered
+        address of the company: Park Estates, 95738 Corkery Pine, United States of
+        America, Nienowchester, BS1 1AA\r\n\r\n# Waste operation contact\r\n\r\n\n\n*
+        Name: Veronika Frami\n* Position: attorney\n* Telephone: 01234567890\n* Email:
+        kandy.jones@example.net\r\n\r\n# Waste operation location or site\r\n\r\n\n\n*
+        Grid reference: ST 58337 72855\n* Site details: Veritatis quia autem deserunt.\r\n\r\n#
+        Waste exemptions\r\n\r\n\n\n* U1: Dolore magnam consequatur autem. \u2013
+        Expires on 12 February 2024\n* U2: Quasi nostrum unde vitae. \u2013 Expires
+        on 12 February 2024\n* U3: Eligendi et hic pariatur. \u2013 Expires on 12
+        February 2024\r\n\r\n\r\n\r\n\r\n\r\n# If you need to contact us\r\n\r\nIf
+        you need help or advice call the Environment Agency helpline: 03708 506506\r\n\r\nIt''s
+        open Monday to Friday, between 8am and 6pm.\r\n\r\nYours sincerely,\r\nWaste
+        Exemptions Team","subject":"Confirmation of waste exemption registration"},"id":"eed576dd-6749-43c1-8398-9bc9967ec69c","reference":null,"scheduled_for":null,"template":{"id":"81cae4bd-9f4c-4e14-bf3c-44573cee4f5b","uri":"https://api.notifications.service.gov.uk/services/367ec8d8-ae34-4e85-bb3e-870659f93c43/templates/81cae4bd-9f4c-4e14-bf3c-44573cee4f5b","version":9},"uri":"https://api.notifications.service.gov.uk/v2/notifications/eed576dd-6749-43c1-8398-9bc9967ec69c"}
+
+'
+  recorded_at: Fri, 12 Feb 2021 17:53:42 GMT
+recorded_with: VCR 6.0.0

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
 
     trait :site_using_grid_reference do
       site_address
+      mode { modes[:auto] }
       description { Faker::Lorem.sentence }
       grid_reference { "ST 58337 72855" }
       x { 358_337.0 }
@@ -49,6 +50,14 @@ FactoryBot.define do
 
     trait :auto do
       mode { modes[:auto] }
+    end
+
+    trait :short_description do
+      description { Faker::Lorem.sentence(word_count: 3) }
+    end
+
+    trait :long_description do
+      description { Faker::Lorem.sentence(word_count: 100) }
     end
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -12,15 +12,15 @@ FactoryBot.define do
     end
 
     trait :with_active_exemptions do
-      registration_exemptions { build_list(:registration_exemption, 5, state: :active) }
+      registration_exemptions { build_list(:registration_exemption, 3, state: :active) }
     end
 
     trait :with_expired_exemptions do
-      registration_exemptions { build_list(:registration_exemption, 5, state: :expired) }
+      registration_exemptions { build_list(:registration_exemption, 3, state: :expired) }
     end
 
     trait :with_expired_and_active_exemptions do
-      registration_exemptions { build_list(:registration_exemption, 5, state: %i[expired active].sample) }
+      registration_exemptions { build_list(:registration_exemption, 3, state: %i[expired active].sample) }
     end
 
     trait :limited_company do
@@ -46,6 +46,7 @@ FactoryBot.define do
 
     trait :sole_trader do
       business_type { WasteExemptionsEngine::Registration::BUSINESS_TYPES[:sole_trader] }
+      company_no { nil }
     end
 
     trait :with_manual_site_address do
@@ -94,6 +95,22 @@ FactoryBot.define do
           build(:address, :contact_address, :postal),
           build(:address, :site_using_grid_reference, :auto)
         ]
+      end
+    end
+
+    trait :with_short_site_description do
+      addresses do
+        [build(:address, :operator_address),
+         build(:address, :contact_address),
+         build(:address, :site_using_grid_reference, :short_description)]
+      end
+    end
+
+    trait :with_long_site_description do
+      addresses do
+        [build(:address, :operator_address),
+         build(:address, :contact_address),
+         build(:address, :site_using_grid_reference, :long_description)]
       end
     end
   end

--- a/spec/factories/registration_exemption.rb
+++ b/spec/factories/registration_exemption.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :registration_exemption, class: WasteExemptionsEngine::RegistrationExemption do
     expires_on { 3.years.from_now }
+    registered_on { Date.today }
 
     exemption
 

--- a/spec/models/waste_exemptions_engine/registration_exemption_spec.rb
+++ b/spec/models/waste_exemptions_engine/registration_exemption_spec.rb
@@ -15,5 +15,41 @@ module WasteExemptionsEngine
         end
       end
     end
+
+    describe "#order_by_state_then_id" do
+      let(:registration) do
+        registration = create(:registration, registration_exemptions: [])
+        5.times do
+          %i[active ceased revoked expired].each do |state|
+            create(
+              :registration_exemption,
+              registration: registration,
+              exemption: build(:exemption),
+              state: state
+            )
+          end
+        end
+        registration
+      end
+
+      it "returns the registration exemptions in a specific order of states and then by exemption id" do
+        sorted_registration_exemptions = registration.registration_exemptions.order_by_state_then_exemption_id
+        # --- Confirm the States are in the expected order ---
+        # We need to use chunk_while instead of uniq to confirm the states are sorted as uniq could
+        # pass the test but fail the expectation.
+        grouped_states = sorted_registration_exemptions.map(&:state).chunk_while { |a, b| a == b }.to_a
+        expect(grouped_states.count).to eq(4) # This can only be the case if the states are ordered.
+        expect(grouped_states.flatten.uniq).to eq(%w[active ceased revoked expired]) # The correct order
+
+        # --- Confirm the IDs are sequential for each state ---
+        sorted_states_and_ids = sorted_registration_exemptions.map { |re| [re.state, re.exemption_id] }
+        # Group the IDs for each state so we confirm the ids for each group are sequential
+        grouped_ids = sorted_states_and_ids.group_by(&:first).map { |_state, state_id_pairs| state_id_pairs.map(&:last) }
+        expect(grouped_ids.count).to eq(4) # Confirm there are the same number of groups as states
+        grouped_ids.each do |ids|
+          expect(ids.sort).to eq(ids)
+        end
+      end
+    end
   end
 end

--- a/spec/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter_spec.rb
+++ b/spec/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter_spec.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe NotifyConfirmationLetterPresenter do
+    let(:registration) { create(:registration, :complete, :with_active_exemptions) }
+    subject { described_class.new(registration) }
+
+    describe "#date_registered" do
+      it "returns the correct value" do
+        expect(registration.registration_exemptions.first).to receive(:registered_on).and_return(Date.new(2020, 1, 1))
+        expect(subject.date_registered).to eq("1 January 2020")
+      end
+    end
+
+    describe "#applicant_name" do
+      it "returns the correct value" do
+        expect(subject.applicant_name).to eq("#{registration.applicant_first_name} #{registration.applicant_last_name}")
+      end
+    end
+
+    describe "#contact_name" do
+      it "returns the correct value" do
+        expect(subject.contact_name).to eq("#{registration.contact_first_name} #{registration.contact_last_name}")
+      end
+    end
+
+    describe "#business_details_section" do
+      context "when the registration is a sole trader" do
+        let(:registration) { create(:registration, :complete, :sole_trader, :with_active_exemptions) }
+
+        it "returns an array with the correct data and labels" do
+          address = registration.operator_address
+          address_text = [
+            address.organisation,
+            address.premises,
+            address.street_address,
+            address.locality,
+            address.city,
+            address.postcode
+          ].reject(&:blank?).join(", ")
+
+          expected_array = [
+            "Business or organisation type: Individual or sole trader",
+            "Business or organisation name: #{registration.operator_name}",
+            "Business or organisation address: #{address_text}"
+          ]
+
+          expect(subject.business_details_section).to eq(expected_array)
+        end
+      end
+
+      context "when the registration is a partnership" do
+        let(:registration) { create(:registration, :complete, :partnership, :with_active_exemptions) }
+
+        it "returns an array with the correct data and labels" do
+          first_partner = "#{registration.people.first.first_name} #{registration.people.first.last_name}"
+          second_partner = "#{registration.people.last.first_name} #{registration.people.last.last_name}"
+          address = registration.operator_address
+          address_text = [
+            address.organisation,
+            address.premises,
+            address.street_address,
+            address.locality,
+            address.city,
+            address.postcode
+          ].reject(&:blank?).join(", ")
+
+          expected_array = [
+            "Business or organisation type: Partnership",
+            "Accountable partner 1: #{first_partner}",
+            "Accountable partner 2: #{second_partner}",
+            "Partnership address: #{address_text}"
+          ]
+
+          expect(subject.business_details_section).to eq(expected_array)
+        end
+      end
+
+      context "when the registration is a limited company" do
+        let(:registration) { create(:registration, :complete, :limited_company, :with_active_exemptions) }
+
+        it "returns an array with the correct data and labels" do
+          address = registration.operator_address
+          address_text = [
+            address.organisation,
+            address.premises,
+            address.street_address,
+            address.locality,
+            address.city,
+            address.postcode
+          ].reject(&:blank?).join(", ")
+
+          expected_array = [
+            "Business or organisation type: Limited company",
+            "Registered name of the company: #{registration.operator_name}",
+            "Registration number of the company: #{registration.company_no}",
+            "Registered address of the company: #{address_text}"
+          ]
+
+          expect(subject.business_details_section).to eq(expected_array)
+        end
+      end
+    end
+
+    describe "#contact_details_section" do
+      let(:registration) { create(:registration, :complete, :with_active_exemptions, contact_position: position) }
+
+      context "when a contact position is not specified" do
+        let(:position) { nil }
+
+        it "returns an array with the correct data and labels" do
+          expected_array = [
+            "Name: #{registration.contact_first_name} #{registration.contact_last_name}",
+            "Telephone: #{registration.contact_phone}",
+            "Email: #{registration.contact_email}"
+          ]
+
+          expect(subject.contact_details_section).to eq(expected_array)
+        end
+      end
+
+      context "when a contact position is specified" do
+        let(:position) { "Head of Waste" }
+
+        it "returns an array with the correct data and labels" do
+          expected_array = [
+            "Name: #{registration.contact_first_name} #{registration.contact_last_name}",
+            "Position: Head of Waste",
+            "Telephone: #{registration.contact_phone}",
+            "Email: #{registration.contact_email}"
+          ]
+
+          expect(subject.contact_details_section).to eq(expected_array)
+        end
+      end
+    end
+
+    describe "#location_section" do
+      context "when the site location is an address" do
+        let(:registration) { create(:registration, :complete, :with_lookup_site_address, :with_active_exemptions) }
+
+        it "returns an array with the correct data and labels" do
+          address = registration.site_address
+          address_text = [
+            address.organisation,
+            address.premises,
+            address.street_address,
+            address.locality,
+            address.city,
+            address.postcode
+          ].reject(&:blank?).join(", ")
+
+          expected_array = [
+            "Waste operation location: #{address_text}"
+          ]
+
+          expect(subject.location_section).to eq(expected_array)
+        end
+      end
+
+      context "when the site location is a grid reference" do
+        let(:registration) { create(:registration, :complete, :with_active_exemptions, :with_short_site_description) }
+
+        it "returns an array with the correct data and labels" do
+          expected_array = [
+            "Grid reference: #{registration.site_address.grid_reference}",
+            "Site details: #{registration.site_address.description}"
+          ]
+
+          expect(subject.location_section).to eq(expected_array)
+        end
+      end
+    end
+
+    describe "#exemptions_section" do
+      let(:registration) { create(:registration, :complete, :with_active_exemptions) }
+
+      before do
+        allow_any_instance_of(RegistrationExemption).to receive(:expires_on).and_return(Date.new(2099, 1, 1))
+      end
+
+      it "returns an array with the correct exemptions" do
+        expected_array = []
+        registration.registration_exemptions.each do |re|
+          expected_array << "#{re.exemption.code}: #{re.exemption.summary} – Expires on 1 January 2099"
+        end
+
+        expect(subject.exemptions_section).to eq(expected_array)
+      end
+
+      context "when some exemptions are not active" do
+        before do
+          registration.registration_exemptions[1].update(state: "ceased")
+          registration.registration_exemptions[2].update(state: "revoked")
+        end
+
+        it "only lists active exemptions" do
+          active_exemption = registration.registration_exemptions[0].exemption
+          expected_array = [
+            "#{active_exemption.code}: #{active_exemption.summary} – Expires on 1 January 2099"
+          ]
+
+          expect(subject.exemptions_section).to eq(expected_array)
+        end
+      end
+    end
+
+    describe "#deregistered_exemptions_section" do
+      let(:registration) { create(:registration, :complete, :with_active_exemptions) }
+
+      before do
+        allow_any_instance_of(RegistrationExemption).to receive(:deregistered_at).and_return(Date.new(2000, 1, 1))
+
+        registration.registration_exemptions[1].update(state: "ceased")
+        registration.registration_exemptions[2].update(state: "revoked")
+      end
+
+      it "only lists inactive exemptions" do
+        ceased_exemption = registration.registration_exemptions[1].exemption
+        revoked_exemption = registration.registration_exemptions[2].exemption
+        expected_array = [
+          "#{ceased_exemption.code}: #{ceased_exemption.summary} – Ceased on 1 January 2000",
+          "#{revoked_exemption.code}: #{revoked_exemption.summary} – Revoked on 1 January 2000"
+        ]
+
+        expect(subject.deregistered_exemptions_section).to eq(expected_array)
+      end
+    end
+  end
+end

--- a/spec/services/waste_exemptions_engine/notify_confirmation_letter_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/notify_confirmation_letter_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe NotifyConfirmationLetterService do
+    describe "run" do
+      let(:registration) { create(:registration, :complete, :with_active_exemptions) }
+      let(:service) do
+        NotifyConfirmationLetterService.run(registration: registration)
+      end
+
+      it "sends a letter" do
+        VCR.use_cassette("notify_confirmation_letter") do
+          # Make sure it's a real postcode for Notify validation purposes
+          allow_any_instance_of(Address).to receive(:postcode).and_return("BS1 1AA")
+
+          expect_any_instance_of(Notifications::Client).to receive(:send_letter).and_call_original
+
+          response = service
+
+          expect(response).to be_a(Notifications::Client::ResponseNotification)
+          expect(response.template["id"]).to eq("81cae4bd-9f4c-4e14-bf3c-44573cee4f5b")
+          expect(response.content["subject"]).to include("Confirmation of waste exemption registration")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1248

In order to send letters when registrations are completed, rather than on an overnight schedule, we need to be able to send them from *wherever* they are completed. This means both front and back office, so it's time to move this code into the engine.

This had a lot of dependencies on other bits of code so I had to move that over too, along with some slight refactoring to avoid deprecation warnings.