### PR TITLE
Configure AD email in engine initialiser

### DIFF
--- a/lib/waste_exemptions_engine.rb
+++ b/lib/waste_exemptions_engine.rb
@@ -24,6 +24,8 @@ module WasteExemptionsEngine
   end
 
   class Configuration
+    # AD config
+    attr_accessor :assisted_digital_email
     # General config
     attr_accessor :service_name, :application_name, :git_repository_url, :years_before_expiry, :default_assistance_mode
     # Edit config

--- a/spec/dummy/config/initializers/waste_exemptions_engine.rb
+++ b/spec/dummy/config/initializers/waste_exemptions_engine.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 WasteExemptionsEngine.configure do |config|
+  # Assisted digital config
+  config.assisted_digital_email = ENV["WEX_ASSISTED_DIGITAL_EMAIL"] || "wex-ad@example.com"
+
   # General config
   config.application_name = "waste-exemptions-front-office"
   config.git_repository_url = "https://github.com/DEFRA/waste-exemptions-front-office"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1208

Previously the AD email address was hardcoded into the back office.

This is a pain for testing and flexibility, and inconsistent with waste carriers, so we should allow it to be configured in the engine initialiser instead. This will let us set a default if we like or override it with an environment variable.