### PR TITLE
Send confirmation letter to fully AD users on completion

### DIFF
--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -74,11 +74,9 @@ module WasteExemptionsEngine
     end
 
     def send_confirmation_messages
-      if @registration.contact_email == WasteExemptionsEngine.configuration.assisted_digital_email
-        send_confirmation_letter
-      else
-        send_confirmation_emails
-      end
+      send_confirmation_letter if ad_email_address?(@registration.contact_email)
+
+      send_confirmation_emails
     end
 
     def send_confirmation_letter
@@ -90,7 +88,7 @@ module WasteExemptionsEngine
 
     def send_confirmation_emails
       distinct_recipients.each do |recipient|
-        send_confirmation_email(recipient)
+        send_confirmation_email(recipient) unless ad_email_address?(recipient)
       end
     end
 
@@ -103,6 +101,10 @@ module WasteExemptionsEngine
 
     def distinct_recipients
       [@registration.applicant_email, @registration.contact_email].map(&:downcase).uniq
+    end
+
+    def ad_email_address?(email)
+      email == WasteExemptionsEngine.configuration.assisted_digital_email
     end
   end
 end

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
       contact_email { applicant_email }
     end
 
+    trait :has_ad_contact_email do
+      contact_email { WasteExemptionsEngine.configuration.assisted_digital_email }
+    end
+
     trait :has_people do
       people { build_list(:transient_person, 2) }
     end

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -109,21 +109,43 @@ module WasteExemptionsEngine
           expect(NewRegistration.where(reference: new_registration.reference).count).to eq(0)
         end
 
-        it "sends a confirmation email to both the applicant and the contact emails" do
-          expect(ConfirmationEmailService).to receive(:run).with(registration: instance_of(Registration),
-                                                                 recipient: new_registration.applicant_email)
-          expect(ConfirmationEmailService).to receive(:run).with(registration: instance_of(Registration),
-                                                                 recipient: new_registration.contact_email)
+        context "when the contact email is not the NCCC email" do
+          it "sends a confirmation email to both the applicant and the contact emails" do
+            expect(ConfirmationEmailService).to receive(:run).with(registration: instance_of(Registration),
+                                                                   recipient: new_registration.applicant_email)
+            expect(ConfirmationEmailService).to receive(:run).with(registration: instance_of(Registration),
+                                                                   recipient: new_registration.contact_email)
 
-          run_service
+            run_service
+          end
+
+          it "does not send a confirmation letter" do
+            expect(NotifyConfirmationLetterService).to_not receive(:run)
+          end
+
+          context "when applicant and contact emails coincide" do
+            let(:new_registration) { create(:new_registration, :complete, :same_applicant_and_contact_email) }
+
+            it "only sends one confirmation email" do
+              expect(ConfirmationEmailService).to receive(:run).with(registration: instance_of(Registration),
+                                                                     recipient: new_registration.applicant_email).once
+
+              run_service
+            end
+          end
         end
 
-        context "when applicant and contact emails coincide" do
-          let(:new_registration) { create(:new_registration, :complete, :same_applicant_and_contact_email) }
+        context "when the contact email is the NCCC email" do
+          let(:new_registration) { create(:new_registration, :complete, :has_ad_contact_email) }
 
-          it "only sends one confirmation email" do
-            expect(ConfirmationEmailService).to receive(:run).with(registration: instance_of(Registration),
-                                                                   recipient: new_registration.applicant_email).once
+          it "sends a confirmation letter" do
+            expect(NotifyConfirmationLetterService).to receive(:run).with(registration: instance_of(Registration)).once
+
+            run_service
+          end
+
+          it "does not send any confirmation emails" do
+            expect(ConfirmationEmailService).to_not receive(:run)
 
             run_service
           end

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -138,16 +138,37 @@ module WasteExemptionsEngine
         context "when the contact email is the NCCC email" do
           let(:new_registration) { create(:new_registration, :complete, :has_ad_contact_email) }
 
-          it "sends a confirmation letter" do
-            expect(NotifyConfirmationLetterService).to receive(:run).with(registration: instance_of(Registration)).once
+          context "when the applicant email is the NCCC email" do
+            before { new_registration.update(applicant_email: new_registration.contact_email) }
 
-            run_service
+            it "sends a confirmation letter" do
+              expect(NotifyConfirmationLetterService).to receive(:run).with(registration: instance_of(Registration)).once
+
+              run_service
+            end
+
+            it "does not send any confirmation emails" do
+              expect(ConfirmationEmailService).to_not receive(:run)
+
+              run_service
+            end
           end
 
-          it "does not send any confirmation emails" do
-            expect(ConfirmationEmailService).to_not receive(:run)
+          context "when the applicant email is not the NCCC email" do
+            it "sends a confirmation letter" do
+              expect(NotifyConfirmationLetterService).to receive(:run).with(registration: instance_of(Registration)).once
 
-            run_service
+              run_service
+            end
+
+            it "only emails the applicant email" do
+              expect(ConfirmationEmailService).to receive(:run).with(registration: instance_of(Registration),
+                                                                     recipient: new_registration.applicant_email).once
+              expect(ConfirmationEmailService).to_not receive(:run).with(registration: instance_of(Registration),
+                                                                         recipient: new_registration.contact_email)
+
+              run_service
+            end
           end
         end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1248

When a user registers and does not have their own contact email, we should send a confirmation letter through Notify instead.

This only applies if the registration's contact email is set to the AD WEX email.
