### PR TITLE
Display correct text about confirmation letter or email

### DIFF
--- a/app/helpers/waste_exemptions_engine/plurals_helper.rb
+++ b/app/helpers/waste_exemptions_engine/plurals_helper.rb
@@ -2,8 +2,20 @@
 
 module WasteExemptionsEngine
   module PluralsHelper
-    def emails_plural(form)
-      form.applicant_email == form.contact_email ? "one" : "many"
+    def confirmation_comms(form)
+      emails = [form.applicant_email, form.contact_email]
+      emails.uniq!
+      emails.delete(WasteExemptionsEngine.configuration.assisted_digital_email)
+
+      if emails.empty?
+        "letter"
+      elsif emails == [form.contact_email]
+        "contact_email"
+      elsif emails == [form.applicant_email]
+        "applicant_email"
+      else
+        "both_emails"
+      end
     end
 
     def exemptions_plural(form)

--- a/app/views/waste_exemptions_engine/registration_complete_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/registration_complete_forms/new.html.erb
@@ -17,7 +17,7 @@
         <p class="font-large"><%= t(".highlight_text") %><br><span class="strong"><%= @registration.reference %></span></p>
       </div>
 
-      <p><%= t(".confirmation_email_text.#{emails_plural(@registration_complete_form)}", applicant: @registration_complete_form.applicant_email, contact: @registration_complete_form.contact_email) %></p>
+      <p><%= t(".confirmation_email_text.#{confirmation_comms(@registration_complete_form)}", applicant: @registration_complete_form.applicant_email, contact: @registration_complete_form.contact_email) %></p>
 
       <h2 class="heading-medium"><%= t(".what_happens_next.subheading") %></h2>
 

--- a/app/views/waste_exemptions_engine/renewal_complete_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/renewal_complete_forms/new.html.erb
@@ -7,7 +7,7 @@
       <p class="font-large"><%= t(".highlight_text") %><br><span class="strong"><%= @registration.reference %></span></p>
     </div>
 
-    <p><%= t(".confirmation_email_text.#{emails_plural(@renewal_complete_form)}", applicant: @renewal_complete_form.applicant_email, contact: @renewal_complete_form.contact_email) %></p>
+    <p><%= t(".confirmation_email_text.#{confirmation_comms(@renewal_complete_form)}", applicant: @renewal_complete_form.applicant_email, contact: @renewal_complete_form.contact_email) %></p>
 
     <p><%= t(".what_happens_next.paragraph_1", expire_month_year: registration_expires_month_year(@registration)) %></p>
     <p><%= t(".what_happens_next.paragraph_2") %></p>

--- a/config/locales/forms/registration_complete_forms/en.yml
+++ b/config/locales/forms/registration_complete_forms/en.yml
@@ -6,8 +6,10 @@ en:
         heading: Registration complete
         highlight_text: "Your registration number is"
         confirmation_email_text:
-          one: "We have sent a confirmation email to %{contact}."
-          many: "We have sent a confirmation email to %{applicant} and %{contact}."
+          letter: "We have sent a confirmation letter to your contact address."
+          contact_email: "We have sent a confirmation email to %{contact}."
+          applicant_email: "We have sent a confirmation email to %{applicant} and a confirmation letter to your contact address."
+          both_emails: "We have sent a confirmation email to %{applicant} and %{contact}."
         what_happens_next:
           subheading: What happens next
           bullet_1: |

--- a/config/locales/forms/renewal_complete_forms/en.yml
+++ b/config/locales/forms/renewal_complete_forms/en.yml
@@ -6,8 +6,10 @@ en:
         heading: "You have renewed your exemptions for 3 years"
         highlight_text: "Your new registration number is"
         confirmation_email_text:
-          one: "We have sent a confirmation email to %{contact}."
-          many: "We have sent a confirmation email to %{applicant} and %{contact}."
+          letter: "We have sent a confirmation letter to your contact address."
+          contact_email: "We have sent a confirmation email to %{contact}."
+          applicant_email: "We have sent a confirmation email to %{applicant} and a confirmation letter to your contact address."
+          both_emails: "We have sent a confirmation email to %{applicant} and %{contact}."
         what_happens_next:
           paragraph_1: These exemptions will expire in %{expire_month_year}. We will send you a reminder 1 month before they are due to expire.
           paragraph_2: We will add your registration to the public register. This includes the name and address of the individual or organisation responsible, the site address and the exemptions you have registered. We will not include other names, or your email or telephone number.

--- a/spec/helpers/waste_exemptions_engine/plurals_helper_spec.rb
+++ b/spec/helpers/waste_exemptions_engine/plurals_helper_spec.rb
@@ -24,15 +24,33 @@ module WasteExemptionsEngine
       end
     end
 
-    describe "#emails_plural" do
+    describe "#confirmation_comms" do
       let(:form) { double(:form, applicant_email: applicant_email, contact_email: contact_email) }
 
       context "when applicant and contact emails are different" do
         let(:applicant_email) { "applicant_email@test.com" }
         let(:contact_email) { "contact_email@test.com" }
 
-        it "returns the string `many`" do
-          expect(helper.emails_plural(form)).to eq("many")
+        context "when the applicant email is the AD email" do
+          let(:applicant_email) { WasteExemptionsEngine.configuration.assisted_digital_email }
+
+          it "returns the string `contact_email`" do
+            expect(helper.confirmation_comms(form)).to eq("contact_email")
+          end
+        end
+
+        context "when the contact email is the AD email" do
+          let(:contact_email) { WasteExemptionsEngine.configuration.assisted_digital_email }
+
+          it "returns the string `applicant_email`" do
+            expect(helper.confirmation_comms(form)).to eq("applicant_email")
+          end
+        end
+
+        context "when neither email is the AD email" do
+          it "returns the string `both_emails`" do
+            expect(helper.confirmation_comms(form)).to eq("both_emails")
+          end
         end
       end
 
@@ -40,8 +58,18 @@ module WasteExemptionsEngine
         let(:applicant_email) { "applicant_email@test.com" }
         let(:contact_email) { applicant_email }
 
-        it "returns the string `one`" do
-          expect(helper.emails_plural(form)).to eq("one")
+        context "when both emails are the AD email" do
+          let(:applicant_email) { WasteExemptionsEngine.configuration.assisted_digital_email }
+
+          it "returns the string `letter`" do
+            expect(helper.confirmation_comms(form)).to eq("letter")
+          end
+        end
+
+        context "when neither email is the AD email" do
+          it "returns the string `both_emails`" do
+            expect(helper.confirmation_comms(form)).to eq("contact_email")
+          end
         end
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1248

The registration and renewal confirmation pages always said that we had sent a confirmation email, even when we sent a letter instead. This PR fixes that.