### PR TITLE
Drop letter export tables

### DIFF
--- a/db/migrate/20210308160306_remove_ad_letter_exports.rb
+++ b/db/migrate/20210308160306_remove_ad_letter_exports.rb
@@ -1,6 +1,6 @@
 class RemoveAdLetterExports < ActiveRecord::Migration[6.0]
   def change
-    drop_table :ad_confirmation_letters_exports
-    drop_table :ad_renewal_letters_exports
+    drop_table :ad_confirmation_letters_exports, if_exists: true
+    drop_table :ad_renewal_letters_exports, if_exists: true
   end
 end

--- a/db/migrate/20210308160306_remove_ad_letter_exports.rb
+++ b/db/migrate/20210308160306_remove_ad_letter_exports.rb
@@ -1,0 +1,6 @@
+class RemoveAdLetterExports < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :ad_confirmation_letters_exports
+    drop_table :ad_renewal_letters_exports
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,32 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_29_141525) do
+ActiveRecord::Schema.define(version: 2021_03_08_160306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "ad_confirmation_letters_exports", id: :serial, force: :cascade do |t|
-    t.date "created_on"
-    t.string "file_name"
-    t.integer "number_of_letters"
-    t.string "printed_by"
-    t.date "printed_on"
-    t.integer "status", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "ad_renewal_letters_exports", id: :serial, force: :cascade do |t|
-    t.date "expires_on"
-    t.string "file_name"
-    t.integer "number_of_letters"
-    t.string "printed_by"
-    t.date "printed_on"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "status", default: 0
-  end
 
   create_table "addresses", id: :serial, force: :cascade do |t|
     t.integer "address_type", default: 0


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1272

We are removing the old letter export functionality since we now have Notify in place. This means we no longer need to keep these tables and models for storing letter info.