### PR TITLE
Switch to EA Address Facade v1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       ENV_VARIABLE_TEST_FEATURE: true
+      ADDRESS_FACADE_CLIENT_ID: ${{ secrets.ACTIONS_ADDRESS_FACADE_CLIENT_ID }}
+      ADDRESS_FACADE_CLIENT_KEY: ${{ secrets.ACTIONS_ADDRESS_FACADE_CLIENT_KEY }}
       NOTIFY_API_KEY: ${{ secrets.ACTIONS_NOTIFY_API_KEY }}
       PG_HOST: localhost
       PG_PASSWORD: pinafore

--- a/app/services/waste_exemptions_engine/address_lookup_service.rb
+++ b/app/services/waste_exemptions_engine/address_lookup_service.rb
@@ -3,7 +3,7 @@
 module WasteExemptionsEngine
   class AddressLookupService < BaseService
     def run(postcode)
-      DefraRuby::Address::EaAddressFacadeV1Service.run(postcode)
+      DefraRuby::Address::EaAddressFacadeV11Service.run(postcode)
     end
   end
 end

--- a/config/initializers/defra_ruby_address.rb
+++ b/config/initializers/defra_ruby_address.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+DefraRuby::Address.configure do |configuration|
+  configuration.key = ENV["ADDRESS_FACADE_CLIENT_KEY"]
+  configuration.client_id = ENV["ADDRESS_FACADE_CLIENT_ID"]
+end

--- a/spec/cassettes/postcode_no_matches.yml
+++ b/spec/cassettes/postcode_no_matches.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=AA1%201AA
+    uri: http://localhost:3002/address-service/v1/addresses/postcode?client-id=<CLIENT_ID>&key=<CLIENT_KEY>&query-string=AA1%201AA
     body:
       encoding: US-ASCII
       string: ''
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Apr 2020 10:55:18 GMT
+      - Tue, 11 May 2021 16:38:45 GMT
       Content-Type:
       - application/json
       Vary:
@@ -32,5 +32,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"totalMatches":0,"startMatch":null,"endMatch":null,"uri_to_supplier":"https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=AA1%201AA&maxresults=100&dataset=DPA","uri_from_client":"stub","results":[]}'
     http_version: null
-  recorded_at: Mon, 20 Apr 2020 10:55:18 GMT
+  recorded_at: Tue, 11 May 2021 16:38:45 GMT
 recorded_with: VCR 5.1.0

--- a/spec/cassettes/postcode_valid.yml
+++ b/spec/cassettes/postcode_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3002/address-service/v1/addresses/postcode?client-id=0&key=client1&postcode=BS1%205AH
+    uri: http://localhost:3002/address-service/v1/addresses/postcode?client-id=<CLIENT_ID>&key=<CLIENT_KEY>&query-string=BS1%205AH
     body:
       encoding: US-ASCII
       string: ''
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Apr 2020 10:55:08 GMT
+      - Tue, 11 May 2021 16:38:40 GMT
       Content-Type:
       - application/json
       Vary:
@@ -38,5 +38,5 @@ http_interactions:
         PLC","premises":null,"street_address":"DEANERY ROAD","locality":null,"city":"BRISTOL","postcode":"BS1
         5AH","x":"358130.1","y":"172687.87","coordinate_system":null,"state_date":"12/10/2009","blpu_state_code":null,"postal_address_code":null,"logical_status_code":null,"source_data_type":"dpa"}]}'
     http_version: null
-  recorded_at: Mon, 20 Apr 2020 10:55:09 GMT
+  recorded_at: Tue, 11 May 2021 16:38:40 GMT
 recorded_with: VCR 5.1.0

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -19,6 +19,9 @@ VCR.configure do |c|
     auth.first unless auth.nil? || auth.empty?
   end
 
+  c.filter_sensitive_data("<CLIENT_ID>") { ENV["ADDRESS_FACADE_CLIENT_ID"] }
+  c.filter_sensitive_data("<CLIENT_KEY>") { ENV["ADDRESS_FACADE_CLIENT_KEY"] }
+
   c.register_request_matcher :html_body_content do |request_one, request_two|
     HtmlBodyContentMatcher.new(request_one, request_two).match?
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1340

As part of updating our OS Places API Endpoint, we needed to update to the later version of the address facade.

This requires some additional config, which this update adds.