### PR TITLE
Fix main people form routing

### DIFF
--- a/app/views/waste_exemptions_engine/main_people_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/main_people_forms/new.html.erb
@@ -12,7 +12,7 @@
       <%= render("waste_exemptions_engine/shared/person_name", form: @main_people_form, f: f) %>
 
       <% if @main_people_form.transient_people.count < 1 %>
-        <%= f.govuk_submit t(".add_person_link") %>
+        <%= f.submit t(".add_person_link"), class: "govuk-button" %>
       <% else %>
         <div class="govuk-form-group">
           <%= f.submit t(".add_person_link"), class: "button-link" %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1625

For some reason using `govuk_submit` doesn't work when adding another person - it just redirects to the partnership name form instead. This fixes it.