### PR TITLE
Pre-fill manual address forms with existing answers on error

### DIFF
--- a/app/views/waste_exemptions_engine/shared/_manual_address.html.erb
+++ b/app/views/waste_exemptions_engine/shared/_manual_address.html.erb
@@ -4,7 +4,8 @@
   <% end %>
   <%= f.govuk_text_field :premises,
       label: { text: t(".premises_label") },
-      hint: { text: t(".premises_hint") } %>
+      hint: { text: t(".premises_hint") },
+      value: form.premises %>
 </div>
 
 <div class="govuk-form-group <%= "govuk-form-group--error" if form.errors[:street_address].any? %>">
@@ -12,7 +13,8 @@
     <span class="govuk-error-message"><%= form.errors[:street_address].join(", ") %></span>
   <% end %>
   <%= f.govuk_text_field :street_address,
-      label: { text: t(".street_address_label") } %>
+      label: { text: t(".street_address_label") },
+      value: form.street_address %>
 </div>
 
 <div class="govuk-form-group <%= "govuk-form-group--error" if form.errors[:locality].any? %>">
@@ -20,7 +22,8 @@
     <span class="govuk-error-message"><%= form.errors[:locality].join(", ") %></span>
   <% end %>
   <%= f.govuk_text_field :locality,
-      label: { text: t(".locality_label") } %>
+      label: { text: t(".locality_label") },
+      value: form.locality %>
 </div>
 
 <div class="govuk-form-group <%= "govuk-form-group--error" if form.errors[:city].any? %>">
@@ -28,7 +31,8 @@
     <span class="govuk-error-message"><%= form.errors[:city].join(", ") %></span>
   <% end %>
   <%= f.govuk_text_field :city,
-      label: { text: t(".city_label") } %>
+      label: { text: t(".city_label") },
+      value: form.city %>
 </div>
 
 <%= f.hidden_field :postcode, value: form.postcode %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1627

If there is a validation error, we don't want to lose the previously submitted answers. They should remain so the user can edit them.