### PR TITLE
Bump loofah gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.5.1)
     jwt (2.2.3)
-    loofah (2.13.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)


### PR DESCRIPTION
- In response to:
`loofah gem 2.13.0 is vulnerable (CVE-2018-8048). Upgrade to 2.2.1`