### PR TITLE
Feature/title heading revised

### DIFF
--- a/app/views/waste_exemptions_engine/main_people_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/main_people_forms/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t(".heading.#{@main_people_form.business_type}") %>
+<% content_for :title, t(".heading.#{@main_people_form.business_type}").try(:html_safe) %>
 
 <%= render("waste_exemptions_engine/shared/back", back_path: back_main_people_forms_path(@main_people_form.token)) %>
 

--- a/app/views/waste_exemptions_engine/operator_address_lookup_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_address_lookup_forms/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t(".heading.#{@operator_address_lookup_form.business_type}") %>
+<% content_for :title, t(".heading.#{@operator_address_lookup_form.business_type}").try(:html_safe) %>
 
 <%= render("waste_exemptions_engine/shared/back", back_path: back_operator_address_lookup_forms_path(@operator_address_lookup_form.token)) %>
 

--- a/app/views/waste_exemptions_engine/operator_address_manual_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_address_manual_forms/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t(".heading.#{@operator_address_manual_form.business_type}") %>
+<% content_for :title, t(".heading.#{@operator_address_manual_form.business_type}").try(:html_safe) %>
 
 <%= render("waste_exemptions_engine/shared/back", back_path: back_operator_address_manual_forms_path(@operator_address_manual_form.token)) %>
 

--- a/app/views/waste_exemptions_engine/operator_name_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_name_forms/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t(".heading.#{@operator_name_form.business_type}") %>
+<% content_for :title, t(".heading.#{@operator_name_form.business_type}").try(:html_safe) %>
 
 <%= render("waste_exemptions_engine/shared/back", back_path: back_operator_name_forms_path(@operator_name_form.token)) %>
 

--- a/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/operator_postcode_forms/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t(".heading.#{@operator_postcode_form.business_type}") %>
+<% content_for :title, t(".heading.#{@operator_postcode_form.business_type}").try(:html_safe) %>
 
 <%= render("waste_exemptions_engine/shared/back", back_path: back_operator_postcode_forms_path(@operator_postcode_form.token)) %>
 

--- a/app/views/waste_exemptions_engine/registration_number_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/registration_number_forms/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t(".heading.#{@registration_number_form.business_type}") %>
+<% content_for :title, t(".heading.#{@registration_number_form.business_type}").try(:html_safe) %>
 
 <%= render("waste_exemptions_engine/shared/back", back_path: back_registration_number_forms_path(@registration_number_form.token)) %>
 

--- a/config/locales/forms/applicant_name_forms/en.yml
+++ b/config/locales/forms/applicant_name_forms/en.yml
@@ -4,7 +4,7 @@ en:
       new:
         title: Who is filling in this form?
         heading: Who is filling in this form?
-        description: Enter your name, even if you’re an agent, employee or other third-party
+        description: Enter your name, even if you're an agent, employee or other third-party
         applicant_first_name_label: First name
         applicant_last_name_label: Last name
         error_heading: A problem to fix

--- a/config/locales/forms/operator_address_lookup_forms/en.yml
+++ b/config/locales/forms/operator_address_lookup_forms/en.yml
@@ -4,12 +4,12 @@ en:
       new:
         title: Operator address selection
         heading:
-          localAuthority: What’s the address of the local authority or public body?
-          limitedCompany: What’s the company address?
-          limitedLiabilityPartnership: What’s the address of the limited liability partnership?
-          partnership: What’s the address of the partnership?
-          soleTrader: What’s the address of the business?
-          charity: What’s the address of the charity or trust?
+          localAuthority: What's the address of the local authority or public body?
+          limitedCompany: What's the company address?
+          limitedLiabilityPartnership: What's the address of the limited liability partnership?
+          partnership: What's the address of the partnership?
+          soleTrader: What's the address of the business?
+          charity: What's the address of the charity or trust?
         postcode_label: Postcode
         postcode_change_link: "Change postcode"
         manual_address_link: "I cannot find the address in the list"

--- a/config/locales/forms/operator_address_manual_forms/en.yml
+++ b/config/locales/forms/operator_address_manual_forms/en.yml
@@ -4,12 +4,12 @@ en:
       new:
         title: Operator address
         heading:
-          localAuthority: What’s the address of the local authority or public body?
-          limitedCompany: What’s the company address?
-          limitedLiabilityPartnership: What’s the address of the limited liability partnership?
-          partnership: What’s the address of the partnership?
-          soleTrader: What’s the address of the business?
-          charity: What’s the address of the charity or trust?
+          localAuthority: What's the address of the local authority or public body?
+          limitedCompany: What's the company address?
+          limitedLiabilityPartnership: What's the address of the limited liability partnership?
+          partnership: What's the address of the partnership?
+          soleTrader: What's the address of the business?
+          charity: What's the address of the charity or trust?
         postcode_label: Postcode
         postcode_change_link: "Change postcode"
         address_finder_error_heading: Our address finder is not working

--- a/config/locales/forms/operator_name_forms/en.yml
+++ b/config/locales/forms/operator_name_forms/en.yml
@@ -4,12 +4,12 @@ en:
       new:
         title: Operator name
         heading:
-          localAuthority: What’s the name of the local authority or public body?
-          limitedCompany: What’s the registered name of the company?
-          limitedLiabilityPartnership: What’s the registered name of the limited liability partnership?
-          partnership: What’s the name of the partnership?
-          soleTrader: Who’s carrying out the waste operation?
-          charity: What’s the name of the charity or trust?
+          localAuthority: What's the name of the local authority or public body?
+          limitedCompany: What's the registered name of the company?
+          limitedLiabilityPartnership: What's the registered name of the limited liability partnership?
+          partnership: What's the name of the partnership?
+          soleTrader: Who's carrying out the waste operation?
+          charity: What's the name of the charity or trust?
         description: This is the name of the operator responsible for the waste operation
         operator_name_label:
           localAuthority: Local authority or public body name

--- a/config/locales/forms/operator_postcode_forms/en.yml
+++ b/config/locales/forms/operator_postcode_forms/en.yml
@@ -4,12 +4,12 @@ en:
       new:
         title: Business address postcode
         heading:
-          localAuthority: What’s the address of the local authority or public body?
-          limitedCompany: What’s the company address?
-          limitedLiabilityPartnership: What’s the address of the limited liability partnership?
-          partnership: What’s the address of the partnership?
-          soleTrader: What’s the address of the business?
-          charity: What’s the address of the charity or trust?
+          localAuthority: What's the address of the local authority or public body?
+          limitedCompany: What's the company address?
+          limitedLiabilityPartnership: What's the address of the limited liability partnership?
+          partnership: What's the address of the partnership?
+          soleTrader: What's the address of the business?
+          charity: What's the address of the charity or trust?
         postcode_label: Please enter a UK postcode
         postcode_hint: For example, BS1 5AH
         error_heading: A problem to fix

--- a/config/locales/forms/registration_number_forms/en.yml
+++ b/config/locales/forms/registration_number_forms/en.yml
@@ -4,8 +4,8 @@ en:
       new:
         title: Companies House registration number
         heading:
-          limitedCompany: What’s the company registration number?
-          limitedLiabilityPartnership: What’s the registration number of the limited liability partnership?
+          limitedCompany: What's the company registration number?
+          limitedLiabilityPartnership: What's the registration number of the limited liability partnership?
         company_no_label: Registration number
         company_no_hint: An 8 digit number, or 2 letters followed by a 6 digit number
         detail_subheading: What's a registration number?


### PR DESCRIPTION
This change revises page title handling to work with regular apostrophes and to prevent unit tests failing on multi-option forms when an option has not been specified as part of test setup.