### PR TITLE
Adding 'Error' in the page title when an error is generated 

### DIFF
--- a/app/helpers/waste_exemptions_engine/application_helper.rb
+++ b/app/helpers/waste_exemptions_engine/application_helper.rb
@@ -3,9 +3,9 @@
 module WasteExemptionsEngine
   module ApplicationHelper
     def title
-      title_elements = [title_text, "Register your waste exemptions", "GOV.UK"]
+      title_elements = [error_title, title_text, "Register your waste exemptions", "GOV.UK"]
       # Remove empty elements, for example if no specific title is set
-      title_elements.delete_if(&:empty?)
+      title_elements.delete_if(&:blank?)
       title_elements.join(" - ")
     end
 
@@ -69,6 +69,10 @@ module WasteExemptionsEngine
 
       # Default to title for "new" action if the current action doesn't return anything
       t("#{controller_path.tr('/', '.')}.new.title", default: "")
+    end
+
+    def error_title
+      return content_for :error_title if content_for?(:error_title)
     end
   end
 end

--- a/app/views/waste_exemptions_engine/shared/_error_summary.html.erb
+++ b/app/views/waste_exemptions_engine/shared/_error_summary.html.erb
@@ -1,5 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= f.govuk_error_summary %>
+    <% content_for :error_title, "Error" if f.govuk_error_summary %>
   </div>
 </div>

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.

--- a/spec/helpers/waste_exemptions_engine/application_helper_spec.rb
+++ b/spec/helpers/waste_exemptions_engine/application_helper_spec.rb
@@ -9,5 +9,35 @@ module WasteExemptionsEngine
         expect(helper.format_names("Fiona", "Laurel")).to eq("Fiona Laurel")
       end
     end
+
+    describe "title" do
+      context "when a specific title is provided" do
+        before do
+          allow(helper).to receive(:content_for?).and_return(true)
+          allow(helper).to receive(:content_for).with(:title).and_return("Foo")
+          allow(helper).to receive(:content_for).with(:error_title).and_return("")
+        end
+
+        it "returns the correct full title" do
+          expect(helper.title).to eq("Foo - Register your waste exemptions - GOV.UK")
+        end
+
+        context "when the page is displaying an error message" do
+          before do
+            allow(helper).to receive(:content_for).with(:error_title).and_return("Error")
+          end
+
+          it "returns the correct full title" do
+            expect(helper.title).to eq("Error - Foo - Register your waste exemptions - GOV.UK")
+          end
+        end
+      end
+
+        context "when no specific title is provided" do
+          it "returns the correct full title" do
+            expect(helper.title).to eq("Register your waste exemptions - GOV.UK")
+          end
+        end
+    end 
   end
 end

--- a/spec/helpers/waste_exemptions_engine/application_helper_spec.rb
+++ b/spec/helpers/waste_exemptions_engine/application_helper_spec.rb
@@ -33,11 +33,11 @@ module WasteExemptionsEngine
         end
       end
 
-        context "when no specific title is provided" do
-          it "returns the correct full title" do
-            expect(helper.title).to eq("Register your waste exemptions - GOV.UK")
-          end
+      context "when no specific title is provided" do
+        it "returns the correct full title" do
+          expect(helper.title).to eq("Register your waste exemptions - GOV.UK")
         end
-    end 
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/RUBY/boards/374?selectedIssue=RUBY-1727

Here we have updated the page titles to change when an error is generated. This allows screen readers to give a better description to the user on the pages status.

The titles will now read <% Error - What do you want to do? - Register your waste exemptions - GOV.UK %> when an error has been generated.
Four test has been written in application_helper_spec to check the helper method for titles and to check the errors in titles.