### PR TITLE
Fix true/false type checking in check-contact-phone form

### DIFF
--- a/app/forms/waste_exemptions_engine/check_contact_phone_form.rb
+++ b/app/forms/waste_exemptions_engine/check_contact_phone_form.rb
@@ -9,8 +9,7 @@ module WasteExemptionsEngine
     validates :temp_reuse_applicant_phone, "defra_ruby/validators/true_false": true
 
     def submit(params)
-      params[:contact_phone] = applicant_phone if params[:temp_reuse_applicant_phone] == true
-
+      params[:contact_phone] = applicant_phone if params[:temp_reuse_applicant_phone] == "true"
       super(params)
     end
   end

--- a/spec/forms/waste_exemptions_engine/check_contact_phone_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/check_contact_phone_form_spec.rb
@@ -26,7 +26,7 @@ module WasteExemptionsEngine
       end
 
       context "when temp_reuse_applicant_phone is true" do
-        let(:temp_reuse_applicant_phone) { true }
+        let(:temp_reuse_applicant_phone) { "true" }
 
         it "assigns the applicant_phone as the contact_phone" do
           subject
@@ -36,7 +36,7 @@ module WasteExemptionsEngine
       end
 
       context "when temp_reuse_applicant_phone is false" do
-        let(:temp_reuse_applicant_phone) { false }
+        let(:temp_reuse_applicant_phone) { "false" }
 
         it "does not assign the contact_phone" do
           subject


### PR DESCRIPTION
This change fixes a comparison type error in the check-contact-phone form.
https://eaflood.atlassian.net/browse/RUBY-1840