### PR TITLE
Optionally use applicant email as contact email

### DIFF
--- a/app/controllers/waste_exemptions_engine/check_contact_email_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/check_contact_email_forms_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class CheckContactEmailFormsController < FormsController
+    def new
+      super(CheckContactEmailForm, "check_contact_email_form")
+    end
+
+    def create
+      super(CheckContactEmailForm, "check_contact_email_form")
+    end
+
+    private
+
+    def transient_registration_attributes
+      params.fetch(:check_contact_email_form, {}).permit(:temp_reuse_applicant_email)
+    end
+  end
+end

--- a/app/forms/waste_exemptions_engine/check_contact_email_form.rb
+++ b/app/forms/waste_exemptions_engine/check_contact_email_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class CheckContactEmailForm < BaseForm
+    delegate :applicant_email, to: :transient_registration
+    delegate :contact_email, to: :transient_registration
+    delegate :temp_reuse_applicant_email, to: :transient_registration
+
+    validates :temp_reuse_applicant_email, "defra_ruby/validators/true_false": true
+
+    def submit(params)
+      params[:contact_email] = applicant_email if params[:temp_reuse_applicant_email] == "true"
+      super(params)
+    end
+  end
+end

--- a/app/models/concerns/waste_exemptions_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_new_registration_workflow.rb
@@ -46,6 +46,7 @@ module WasteExemptionsEngine
         state :contact_name_form
         state :contact_position_form
         state :check_contact_phone_form
+        state :check_contact_email_form
         state :contact_phone_form
         state :contact_email_form
         state :contact_postcode_form
@@ -159,11 +160,19 @@ module WasteExemptionsEngine
                       unless: :temp_reuse_applicant_phone?
 
           transitions from: :check_contact_phone_form,
-                      to: :contact_email_form,
+                      to: :check_contact_email_form,
                       if: :temp_reuse_applicant_phone?
 
           transitions from: :contact_phone_form,
-                      to: :contact_email_form
+                      to: :check_contact_email_form
+
+          transitions from: :check_contact_email_form,
+                      to: :contact_email_form,
+                      unless: :temp_reuse_applicant_email?
+
+          transitions from: :check_contact_email_form,
+                      to: :contact_postcode_form,
+                      if: :temp_reuse_applicant_email?
 
           transitions from: :contact_email_form,
                       to: :contact_postcode_form
@@ -303,16 +312,24 @@ module WasteExemptionsEngine
           transitions from: :check_contact_phone_form,
                       to: :contact_position_form
 
-          transitions from: :contact_email_form,
+          transitions from: :check_contact_email_form,
                       to: :contact_phone_form,
                       unless: :temp_reuse_applicant_phone?
 
-          transitions from: :contact_email_form,
+          transitions from: :check_contact_email_form,
                       to: :check_contact_phone_form,
                       if: :temp_reuse_applicant_phone?
 
+          transitions from: :contact_email_form,
+                      to: :check_contact_email_form
+
           transitions from: :contact_postcode_form,
-                      to: :contact_email_form
+                      to: :contact_email_form,
+                      unless: :temp_reuse_applicant_email?
+
+          transitions from: :contact_postcode_form,
+                      to: :check_contact_email_form,
+                      if: :temp_reuse_applicant_email?
 
           transitions from: :contact_address_lookup_form,
                       to: :contact_postcode_form

--- a/app/models/waste_exemptions_engine/transient_registration.rb
+++ b/app/models/waste_exemptions_engine/transient_registration.rb
@@ -44,6 +44,7 @@ module WasteExemptionsEngine
                               temp_contact_postcode
                               temp_grid_reference
                               temp_reuse_applicant_phone
+                              temp_reuse_applicant_email
                               temp_site_description
                               temp_site_postcode
                               temp_renew_without_changes

--- a/app/views/waste_exemptions_engine/check_contact_email_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/check_contact_email_forms/new.html.erb
@@ -1,0 +1,29 @@
+<%= render("waste_exemptions_engine/shared/back", back_path: back_check_contact_email_forms_path(@check_contact_email_form.token)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @check_contact_email_form do |f| %>
+      <%= render partial: "waste_exemptions_engine/shared/error_summary", locals: { f: f } %>
+
+      <%=
+        f.govuk_collection_radio_buttons :temp_reuse_applicant_email,
+        [
+          OpenStruct.new(
+            id: true,
+            name: t(".options.yes")
+          ),
+          OpenStruct.new(
+            id: false,
+            name: t(".options.no")
+          )
+        ],
+        :id,
+        :name,
+        inline: true,
+        legend: { text: t(".heading"), size: "l", tag: "h1" },
+        hint: { text: @check_contact_email_form.applicant_email } %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/forms/check_contact_email_forms/en.yml
+++ b/config/locales/forms/check_contact_email_forms/en.yml
@@ -1,0 +1,16 @@
+en:
+  waste_exemptions_engine:
+    check_contact_email_forms:
+      new:
+        title: &title Do you want to use this email address as a contact?
+        heading: *title
+        options:
+          "yes": "Yes"
+          "no": "No"
+  activemodel:
+    errors:
+      models:
+        waste_exemptions_engine/check_contact_email_form:
+          attributes:
+            temp_reuse_applicant_email:
+              inclusion: "You must select yes or no"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,6 +213,16 @@ WasteExemptionsEngine::Engine.routes.draw do
                     on: :collection
               end
 
+    resources :check_contact_email_forms,
+              only: %i[new create],
+              path: "check-contact-email",
+              path_names: { new: "" } do
+                get "back",
+                    to: "check_contact_email_forms#go_back",
+                    as: "back",
+                    on: :collection
+              end
+
     resources :contact_email_forms,
               only: %i[new create],
               path: "contact-email",

--- a/db/migrate/20220401131927_add_temp_reuse_applicant_email_to_transient_registrations.rb
+++ b/db/migrate/20220401131927_add_temp_reuse_applicant_email_to_transient_registrations.rb
@@ -1,0 +1,5 @@
+class AddTempReuseApplicantEmailToTransientRegistrations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :transient_registrations, :temp_reuse_applicant_email, :boolean, default: nil
+  end
+end

--- a/spec/cassettes/w3c_valid_content/check_contact_email_forms_spec/when-the-registration-is-in-the-correct-state.yml
+++ b/spec/cassettes/w3c_valid_content/check_contact_email_forms_spec/when-the-registration-is-in-the-correct-state.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://validator.w3.org/nu/?out=json&parser=html&showsource=yes
+    body:
+      encoding: UTF-8
+      string: "<!DOCTYPE html>\n<html>\n<head>\n  <title>Dummy</title>\n  <link rel=\"stylesheet\"
+        media=\"all\" href=\"/assets/application-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.css\"
+        data-turbolinks-track=\"true\" />\n  <script src=\"/assets/application-f9d8e5ce8f528d997d58156ff5f8c1d4b0741ac22b367a6a6294b3c7e9758e96.js\"
+        data-turbolinks-track=\"true\"></script>\n  \n</head>\n<body>\n\n\n\n<div
+        class=\"govuk-grid-row\">\n  <div class=\"govuk-grid-column-two-thirds\">\n
+        \   <form class=\"new_check_contact_email_form\" id=\"new_check_contact_email_form\"
+        action=\"/waste_exemptions_engine/DUK97EPMpb4yzZHK1i1wCFB5/check-contact-email\"
+        accept-charset=\"UTF-8\" method=\"post\">\n      <div class=\"govuk-grid-row\">\n
+        \ <div class=\"govuk-grid-column-two-thirds\">\n    \n  </div>\n</div>\n\n\n
+        \     <div class=\"govuk-form-group\"><fieldset class=\"govuk-fieldset\" aria-describedby=\"check-contact-email-form-temp-reuse-applicant-email-hint\"><legend
+        class=\"govuk-fieldset__legend govuk-fieldset__legend--l\"><h1 class=\"govuk-fieldset__heading\">Do
+        you want to use this email address as a contact?</h1></legend><input value=\"\"
+        autocomplete=\"off\" type=\"hidden\" name=\"check_contact_email_form[temp_reuse_applicant_email]\"
+        id=\"check_contact_email_form_temp_reuse_applicant_email\" /><div class=\"govuk-hint\"
+        id=\"check-contact-email-form-temp-reuse-applicant-email-hint\">carlton_hilll@hickle-weber.net</div><div
+        class=\"govuk-radios govuk-radios--inline\" data-module=\"govuk-radios\"><div
+        class=\"govuk-radios__item\"><input id=\"check-contact-email-form-temp-reuse-applicant-email-true-field\"
+        class=\"govuk-radios__input\" type=\"radio\" value=\"true\" name=\"check_contact_email_form[temp_reuse_applicant_email]\"
+        /><label for=\"check-contact-email-form-temp-reuse-applicant-email-true-field\"
+        class=\"govuk-label govuk-radios__label\">Yes</label></div><div class=\"govuk-radios__item\"><input
+        id=\"check-contact-email-form-temp-reuse-applicant-email-field\" class=\"govuk-radios__input\"
+        type=\"radio\" value=\"false\" name=\"check_contact_email_form[temp_reuse_applicant_email]\"
+        /><label for=\"check-contact-email-form-temp-reuse-applicant-email-field\"
+        class=\"govuk-label govuk-radios__label\">No</label></div></div></fieldset></div>\n\n
+        \     <button type=\"submit\" formnovalidate=\"formnovalidate\" class=\"govuk-button\"
+        data-module=\"govuk-button\" data-prevent-double-click=\"true\">Continue</button>\n</form>
+        \ </div>\n</div>\n\n\n</body>\n</html>\n"
+    headers:
+      Content-Type:
+      - text/html; charset=utf-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 01 Apr 2022 14:14:11 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - gzip
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - content-type
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept-Encoding, User-Agent
+      Strict-Transport-Security:
+      - max-age=15552015; preload
+      Public-Key-Pins:
+      - pin-sha256="cN0QSpPIkuwpT6iP2YjEo1bEwGpH/yiUn6yhdy+HNto="; pin-sha256="WGJkyYjx1QMdMe0UqlyOKXtydPDVrk7sl2fV+nNm1r4=";
+        pin-sha256="LrKdTxZLRTvyHM4/atX2nquX9BeHRZMCxg3cf4rhc2I="; max-age=864000
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - 6f51ee02cddb76d2
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6f51ee02cddb76d2-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9hc3NldHMvYXBwbGljYXRpb24tZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NS5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvYXNzZXRzL2FwcGxpY2F0aW9uLWY5ZDhlNWNlOGY1MjhkOTk3ZDU4MTU2ZmY1ZjhjMWQ0YjA3NDFhYzIyYjM2N2E2YTYyOTRiM2M3ZTk3NThlOTYuanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cblxuXG48ZGl2IGNsYXNzPVwiZ292dWstZ3JpZC1yb3dcIj5cbiAgPGRpdiBjbGFzcz1cImdvdnVrLWdyaWQtY29sdW1uLXR3by10aGlyZHNcIj5cbiAgICA8Zm9ybSBjbGFzcz1cIm5ld19jaGVja19jb250YWN0X2VtYWlsX2Zvcm1cIiBpZD1cIm5ld19jaGVja19jb250YWN0X2VtYWlsX2Zvcm1cIiBhY3Rpb249XCIvd2FzdGVfZXhlbXB0aW9uc19lbmdpbmUvRFVLOTdFUE1wYjR5elpISzFpMXdDRkI1L2NoZWNrLWNvbnRhY3QtZW1haWxcIiBhY2NlcHQtY2hhcnNldD1cIlVURi04XCIgbWV0aG9kPVwicG9zdFwiPlxuICAgICAgPGRpdiBjbGFzcz1cImdvdnVrLWdyaWQtcm93XCI+XG4gIDxkaXYgY2xhc3M9XCJnb3Z1ay1ncmlkLWNvbHVtbi10d28tdGhpcmRzXCI+XG4gICAgXG4gIDwvZGl2PlxuPC9kaXY+XG5cblxuICAgICAgPGRpdiBjbGFzcz1cImdvdnVrLWZvcm0tZ3JvdXBcIj48ZmllbGRzZXQgY2xhc3M9XCJnb3Z1ay1maWVsZHNldFwiIGFyaWEtZGVzY3JpYmVkYnk9XCJjaGVjay1jb250YWN0LWVtYWlsLWZvcm0tdGVtcC1yZXVzZS1hcHBsaWNhbnQtZW1haWwtaGludFwiPjxsZWdlbmQgY2xhc3M9XCJnb3Z1ay1maWVsZHNldF9fbGVnZW5kIGdvdnVrLWZpZWxkc2V0X19sZWdlbmQtLWxcIj48aDEgY2xhc3M9XCJnb3Z1ay1maWVsZHNldF9faGVhZGluZ1wiPkRvIHlvdSB3YW50IHRvIHVzZSB0aGlzIGVtYWlsIGFkZHJlc3MgYXMgYSBjb250YWN0PzwvaDE+PC9sZWdlbmQ+PGlucHV0IHZhbHVlPVwiXCIgYXV0b2NvbXBsZXRlPVwib2ZmXCIgdHlwZT1cImhpZGRlblwiIG5hbWU9XCJjaGVja19jb250YWN0X2VtYWlsX2Zvcm1bdGVtcF9yZXVzZV9hcHBsaWNhbnRfZW1haWxdXCIgaWQ9XCJjaGVja19jb250YWN0X2VtYWlsX2Zvcm1fdGVtcF9yZXVzZV9hcHBsaWNhbnRfZW1haWxcIiAvPjxkaXYgY2xhc3M9XCJnb3Z1ay1oaW50XCIgaWQ9XCJjaGVjay1jb250YWN0LWVtYWlsLWZvcm0tdGVtcC1yZXVzZS1hcHBsaWNhbnQtZW1haWwtaGludFwiPmNhcmx0b25faGlsbGxAaGlja2xlLXdlYmVyLm5ldDwvZGl2PjxkaXYgY2xhc3M9XCJnb3Z1ay1yYWRpb3MgZ292dWstcmFkaW9zLS1pbmxpbmVcIiBkYXRhLW1vZHVsZT1cImdvdnVrLXJhZGlvc1wiPjxkaXYgY2xhc3M9XCJnb3Z1ay1yYWRpb3NfX2l0ZW1cIj48aW5wdXQgaWQ9XCJjaGVjay1jb250YWN0LWVtYWlsLWZvcm0tdGVtcC1yZXVzZS1hcHBsaWNhbnQtZW1haWwtdHJ1ZS1maWVsZFwiIGNsYXNzPVwiZ292dWstcmFkaW9zX19pbnB1dFwiIHR5cGU9XCJyYWRpb1wiIHZhbHVlPVwidHJ1ZVwiIG5hbWU9XCJjaGVja19jb250YWN0X2VtYWlsX2Zvcm1bdGVtcF9yZXVzZV9hcHBsaWNhbnRfZW1haWxdXCIgLz48bGFiZWwgZm9yPVwiY2hlY2stY29udGFjdC1lbWFpbC1mb3JtLXRlbXAtcmV1c2UtYXBwbGljYW50LWVtYWlsLXRydWUtZmllbGRcIiBjbGFzcz1cImdvdnVrLWxhYmVsIGdvdnVrLXJhZGlvc19fbGFiZWxcIj5ZZXM8L2xhYmVsPjwvZGl2PjxkaXYgY2xhc3M9XCJnb3Z1ay1yYWRpb3NfX2l0ZW1cIj48aW5wdXQgaWQ9XCJjaGVjay1jb250YWN0LWVtYWlsLWZvcm0tdGVtcC1yZXVzZS1hcHBsaWNhbnQtZW1haWwtZmllbGRcIiBjbGFzcz1cImdvdnVrLXJhZGlvc19faW5wdXRcIiB0eXBlPVwicmFkaW9cIiB2YWx1ZT1cImZhbHNlXCIgbmFtZT1cImNoZWNrX2NvbnRhY3RfZW1haWxfZm9ybVt0ZW1wX3JldXNlX2FwcGxpY2FudF9lbWFpbF1cIiAvPjxsYWJlbCBmb3I9XCJjaGVjay1jb250YWN0LWVtYWlsLWZvcm0tdGVtcC1yZXVzZS1hcHBsaWNhbnQtZW1haWwtZmllbGRcIiBjbGFzcz1cImdvdnVrLWxhYmVsIGdvdnVrLXJhZGlvc19fbGFiZWxcIj5ObzwvbGFiZWw+PC9kaXY+PC9kaXY+PC9maWVsZHNldD48L2Rpdj5cblxuICAgICAgPGJ1dHRvbiB0eXBlPVwic3VibWl0XCIgZm9ybW5vdmFsaWRhdGU9XCJmb3Jtbm92YWxpZGF0ZVwiIGNsYXNzPVwiZ292dWstYnV0dG9uXCIgZGF0YS1tb2R1bGU9XCJnb3Z1ay1idXR0b25cIiBkYXRhLXByZXZlbnQtZG91YmxlLWNsaWNrPVwidHJ1ZVwiPkNvbnRpbnVlPC9idXR0b24+XG48L2Zvcm0+ICA8L2Rpdj5cbjwvZGl2PlxuXG5cbjwvYm9keT5cbjwvaHRtbD4ifX0K
+  recorded_at: Fri, 01 Apr 2022 14:13:45 GMT
+recorded_with: VCR 6.1.0

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_30_095115) do
+ActiveRecord::Schema.define(version: 2022_04_01_131927) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -198,6 +198,7 @@ ActiveRecord::Schema.define(version: 2022_03_30_095115) do
     t.string "type", null: false
     t.boolean "temp_renew_without_changes"
     t.boolean "temp_reuse_applicant_phone"
+    t.boolean "temp_reuse_applicant_email"
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
   end
 

--- a/spec/factories/forms/check_contact_email_form.rb
+++ b/spec/factories/forms/check_contact_email_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :check_contact_email_form, class: WasteExemptionsEngine::CheckContactEmailForm do
+    initialize_with do
+      new(create(:new_registration, workflow_state: "check_contact_email_form", applicant_email: Faker::Internet.email))
+    end
+  end
+end

--- a/spec/forms/waste_exemptions_engine/check_contact_email_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/check_contact_email_form_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe CheckContactEmailForm, type: :model do
+    it_behaves_like "a validated form", :check_contact_email_form do
+      let(:valid_params) do
+        [
+          { temp_reuse_applicant_email: "true" },
+          { temp_reuse_applicant_email: "false" }
+        ]
+      end
+      let(:invalid_params) do
+        [
+          { temp_reuse_applicant_email: "" }
+        ]
+      end
+    end
+
+    describe "#submit" do
+      let(:form) { build(:check_contact_email_form) }
+
+      subject do
+        form.submit(temp_reuse_applicant_email: temp_reuse_applicant_email)
+      end
+
+      context "when temp_reuse_applicant_email is true" do
+        let(:temp_reuse_applicant_email) { "true" }
+
+        it "assigns the applicant_email as the contact_email" do
+          subject
+
+          expect(form.contact_email).to eq(form.applicant_email)
+        end
+      end
+
+      context "when temp_reuse_applicant_email is false" do
+        let(:temp_reuse_applicant_email) { "false" }
+
+        it "does not assign the contact_email" do
+          subject
+
+          expect(form.transient_registration.contact_email).to be_blank
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/check_contact_email_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/check_contact_email_form_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe NewRegistration, type: :model do
+    describe "#workflow_state" do
+      let(:new_registration) do
+        create(:new_registration,
+               workflow_state: :check_contact_email_form,
+               temp_reuse_applicant_email: temp_reuse_applicant_email)
+      end
+
+      context "when temp_reuse_applicant_email is true" do
+        let(:temp_reuse_applicant_email) { "true" }
+
+        it "transitions to :contact_postcode_form" do
+          expect(new_registration)
+            .to transition_from(:check_contact_email_form)
+            .to(:contact_postcode_form)
+            .on_event(:next)
+        end
+      end
+
+      context "when temp_reuse_applicant_email is false" do
+        let(:temp_reuse_applicant_email) { "false" }
+
+        it "transitions to :contact_email_form" do
+          expect(new_registration)
+            .to transition_from(:check_contact_email_form)
+            .to(:contact_email_form)
+            .on_event(:next)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/check_contact_phone_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/check_contact_phone_form_spec.rb
@@ -14,10 +14,10 @@ module WasteExemptionsEngine
       context "when temp_reuse_applicant_phone is true" do
         let(:temp_reuse_applicant_phone) { true }
 
-        it "transitions to :contact_email_form" do
+        it "transitions to :check_contact_email_form" do
           expect(new_registration)
             .to transition_from(:check_contact_phone_form)
-            .to(:contact_email_form)
+            .to(:check_contact_email_form)
             .on_event(:next)
         end
       end

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/contact_email_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/contact_email_form_spec.rb
@@ -6,7 +6,7 @@ module WasteExemptionsEngine
   RSpec.describe NewRegistration, type: :model do
     describe "#workflow_state" do
       it_behaves_like "a simple bidirectional transition",
-                      previous_state: :contact_phone_form,
+                      previous_state: :check_contact_email_form,
                       current_state: :contact_email_form,
                       next_state: :contact_postcode_form,
                       factory: :new_registration

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/contact_phone_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/contact_phone_form_spec.rb
@@ -8,7 +8,7 @@ module WasteExemptionsEngine
       it_behaves_like "a simple bidirectional transition",
                       previous_state: :check_contact_phone_form,
                       current_state: :contact_phone_form,
-                      next_state: :contact_email_form,
+                      next_state: :check_contact_email_form,
                       factory: :new_registration
     end
   end

--- a/spec/requests/waste_exemptions_engine/check_contact_email_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/check_contact_email_forms_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe "Check Contact Email Forms", type: :request do
+    include_examples "GET form", :check_contact_email_form, "/check-contact-email"
+    include_examples "go back", :check_contact_email_form, "/check-contact-email/back"
+    include_examples "POST form", :check_contact_email_form, "/check-contact-email" do
+      let(:form_data) { { temp_reuse_applicant_email: "true" } }
+      let(:invalid_form_data) { [{ temp_reuse_applicant_email: "" }] }
+    end
+  end
+end


### PR DESCRIPTION
This change introduces a step in the new exemption registration journey to allow the user to reuse the applicant email address as the contact email address.
https://eaflood.atlassian.net/browse/RUBY-1841