### PR TITLE
Force github to run apt-get update before installing dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       # Install various other dependencies
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install xvfb -y
           sudo apt-get install wkhtmltopdf -y
 


### PR DESCRIPTION
This change forces GitHub CI to run apt-get update before trying to install dependencies. It is currently failing to find the required versions of some ubuntu libraries, possibly because of a stale mirror site. It may be desirable to revert this change in future if the GitHub / ubuntu issue is resolved.

https://eaflood.atlassian.net/browse/RUBY-1872