### PR TITLE
Refresh service for companies house name

### DIFF
--- a/app/models/waste_exemptions_engine/transient_registration.rb
+++ b/app/models/waste_exemptions_engine/transient_registration.rb
@@ -41,6 +41,7 @@ module WasteExemptionsEngine
                               id
                               start_option
                               temp_use_registered_company_details
+                              companies_house_updated_at
                               temp_operator_postcode
                               temp_contact_postcode
                               temp_grid_reference

--- a/app/services/waste_exemptions_engine/refresh_companies_house_name_service.rb
+++ b/app/services/waste_exemptions_engine/refresh_companies_house_name_service.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "defra_ruby_companies_house"
+
+module WasteExemptionsEngine
+  class RefreshCompaniesHouseNameService < WasteExemptionsEngine::BaseService
+    def run(company_reference)
+      registration = Registration.find_by(reference: company_reference)
+      company_name = DefraRubyCompaniesHouse.new(registration.company_no).company_name
+      registration.operator_name = company_name
+      registration.companies_house_updated_at = Time.current
+      registration.save!
+
+      true
+    end
+  end
+end

--- a/db/migrate/20220510134655_add_temp_use_registered_company_details_to_transient_registrations.rb
+++ b/db/migrate/20220510134655_add_temp_use_registered_company_details_to_transient_registrations.rb
@@ -1,6 +1,5 @@
 class AddTempUseRegisteredCompanyDetailsToTransientRegistrations < ActiveRecord::Migration[6.1]
   def change
     add_column :transient_registrations, :temp_use_registered_company_details, :boolean, default: nil
-
   end
 end

--- a/db/migrate/20220524150518_add_companies_house_updated_at_to_transient_registrations.rb
+++ b/db/migrate/20220524150518_add_companies_house_updated_at_to_transient_registrations.rb
@@ -1,0 +1,5 @@
+class AddCompaniesHouseUpdatedAtToTransientRegistrations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :registrations, :companies_house_updated_at, :datetime
+  end
+end

--- a/lib/defra_ruby_companies_house.rb
+++ b/lib/defra_ruby_companies_house.rb
@@ -4,7 +4,7 @@ require "rest-client"
 
 class DefraRubyCompaniesHouse
   def initialize(company_no)
-    @company_url = "#{Rails.configuration.companies_house_host}#{company_no}"
+    @company_url = "#{Rails.configuration.companies_house_host}#{company_no.to_s.rjust(8, '0')}"
     @api_key = Rails.configuration.companies_house_api_key
 
     load_company

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_10_134655) do
+ActiveRecord::Schema.define(version: 2022_05_24_150518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 2022_05_10_134655) do
     t.string "assistance_mode"
     t.string "renew_token"
     t.integer "referring_registration_id"
+    t.datetime "companies_house_updated_at"
     t.index ["reference"], name: "index_registrations_on_reference", unique: true
     t.index ["renew_token"], name: "index_registrations_on_renew_token", unique: true
   end
@@ -202,6 +203,7 @@ ActiveRecord::Schema.define(version: 2022_05_10_134655) do
     t.boolean "temp_reuse_operator_address"
     t.string "temp_reuse_address_for_site_location"
     t.boolean "temp_use_registered_company_details"
+    t.datetime "companies_house_updated_at"
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
   end
 

--- a/spec/lib/defra_ruby_companies_house_spec.rb
+++ b/spec/lib/defra_ruby_companies_house_spec.rb
@@ -6,15 +6,18 @@ require "defra_ruby_companies_house"
 RSpec.describe DefraRubyCompaniesHouse do
 
   let(:valid_company_no) { "00987654" }
+  let(:short_company_no) { "1987654" }
   let(:invalid_company_no) { "-" }
 
   before do
-    stub_request(:get, "#{Rails.configuration.companies_house_host}#{valid_company_no}").to_return(
-      status: 200,
-      body: File.read("./spec/fixtures/files/companies_house_response.json")
-    )
-    stub_request(:get, "#{Rails.configuration.companies_house_host}#{invalid_company_no}").to_return(
+    # stub all calls to fail first....
+    stub_request(:get, /#{Rails.configuration.companies_house_host}*/).to_return(
       status: 404
+    )
+    # ... then add a stub to cover valid company_no values
+    stub_request(:get, /#{Rails.configuration.companies_house_host}[a-zA-Z\d]{8}/).to_return(
+      status: 200,
+      body: File.read("spec/fixtures/files/companies_house_response.json")
     )
   end
 
@@ -34,6 +37,13 @@ RSpec.describe DefraRubyCompaniesHouse do
         expect(subject).to eq "BOGUS LIMITED"
       end
     end
+
+    context "with a short company number" do
+      let(:company_no) { short_company_no }
+      it "returns the company name" do
+        expect(subject).to eq "BOGUS LIMITED"
+      end
+    end
   end
 
   describe "#registered_office_address_lines" do
@@ -48,6 +58,13 @@ RSpec.describe DefraRubyCompaniesHouse do
 
     context "with a valid company number" do
       let(:company_no) { valid_company_no }
+      it "returns the address lines" do
+        expect(subject).to eq ["R House", "Middle Street", "Thereabouts", "HD1 2BN"]
+      end
+    end
+
+    context "with a short company number" do
+      let(:company_no) { short_company_no }
       it "returns the address lines" do
         expect(subject).to eq ["R House", "Middle Street", "Thereabouts", "HD1 2BN"]
       end

--- a/spec/services/waste_exemptions_engine/refresh_companies_house_name_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/refresh_companies_house_name_service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "defra_ruby_companies_house"
+
+RSpec.describe WasteExemptionsEngine::RefreshCompaniesHouseNameService do
+
+  let(:new_registration_name) { Faker::Company.name }
+  let(:registration) { create(:registration, :complete, operator_name: old_registered_name) }
+  let(:reference) { registration.reference }
+  let(:companies_house_name) { new_registration_name }
+
+  before do
+    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company)
+    allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:company_name).and_return(companies_house_name)
+  end
+
+  subject { described_class.run(reference) }
+
+  context "with no previous companies house name" do
+    let(:old_registered_name) { nil }
+
+    it "stores the companies house name" do
+      expect { subject }.to change { registration_data(registration).operator_name }
+        .from(nil)
+        .to(new_registration_name)
+    end
+  end
+
+  context "with an existing registered company name" do
+    let(:old_registered_name) { Faker::Company.name }
+
+    context "when the new company name is the same as the old one" do
+      let(:new_registration_name) { old_registered_name }
+
+      it "does not change companies house name" do
+        expect { subject }.not_to change { registration_data(registration).operator_name }
+      end
+    end
+
+    context "when the new company name is different to the old one" do
+      it "updates the registered company name" do
+        expect { subject }
+          .to change { registration_data(registration).operator_name }
+          .from(old_registered_name)
+          .to(new_registration_name)
+      end
+    end
+  end
+end
+
+def registration_data(registration)
+  WasteExemptionsEngine::Registration.find_by(reference: registration.reference)
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1877

Here we have the refresh service for the company house API. This allows the back office users to manually refresh the registered company name without manually entering a name in