### PR TITLE
Company house inactive error

### DIFF
--- a/app/controllers/waste_exemptions_engine/check_registered_name_and_address_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/check_registered_name_and_address_forms_controller.rb
@@ -6,6 +6,7 @@ module WasteExemptionsEngine
   class CheckRegisteredNameAndAddressFormsController < FormsController
     def new
       super(CheckRegisteredNameAndAddressForm, "check_registered_name_and_address_form")
+      company_number_active?
     end
 
     def create
@@ -16,6 +17,10 @@ module WasteExemptionsEngine
 
     def transient_registration_attributes
       params.fetch(:check_registered_name_and_address_form, {}).permit(:temp_use_registered_company_details)
+    end
+
+    def company_number_active?
+      return render(:inactive_company) unless @check_registered_name_and_address_form.validate_company_status
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/check_registered_name_and_address_form.rb
+++ b/app/forms/waste_exemptions_engine/check_registered_name_and_address_form.rb
@@ -17,6 +17,15 @@ module WasteExemptionsEngine
       companies_house_service.registered_office_address_lines
     end
 
+    def validate_company_status
+      case companies_house_service.status
+      when :active
+        true
+      when :inactive
+        false
+      end
+    end
+
     def submit(params)
       params[:operator_name] = registered_company_name if params[:temp_use_registered_company_details] == "true"
       super(params)

--- a/app/forms/waste_exemptions_engine/check_registered_name_and_address_form.rb
+++ b/app/forms/waste_exemptions_engine/check_registered_name_and_address_form.rb
@@ -23,6 +23,11 @@ module WasteExemptionsEngine
         true
       when :inactive
         false
+      when :not_found
+        raise StandardError "Failed to find company status"
+      else
+        # Sonarcloud suggested that not having an `else` is a code smell
+        raise StandardError "Failed to find company status"
       end
     end
 

--- a/app/views/waste_exemptions_engine/check_registered_name_and_address_forms/inactive_company.html.erb
+++ b/app/views/waste_exemptions_engine/check_registered_name_and_address_forms/inactive_company.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+    <p class="govuk-body"><%= t(".paragraph_1") %></p>
+
+    <p class="govuk-body">
+      <%= t(".paragraph_2.line_1") %> <br/>
+      <%= t(".paragraph_2.line_2") %> <br/>
+      <a href="mailto:<%= t(".enquiries_email") %>"><%= t(".enquiries_email") %></a>
+    </p>
+      <%= link_to t(".continue"), start_forms_path, class: "govuk-button" %>
+  </div>
+</div>

--- a/config/locales/forms/check_registered_name_and_address_forms/en.yml
+++ b/config/locales/forms/check_registered_name_and_address_forms/en.yml
@@ -9,6 +9,15 @@ en:
           "no": "No"
         company_number: "Companies House Number - %{company_no}"
         enter_a_different_number: "Enter a different number"
+      inactive_company:
+        title: We could not validate your Companies House number
+        heading: We could not validate your Companies House number
+        paragraph_1: There is an issue with your Companies House number (it is possible that your company is no longer active). You must either create a new registration, or speak to our contact centre.
+        paragraph_2:
+          line_1: Environment Agency
+          line_2: Telephone 03708 506 506, Monday to Friday (8am to 6pm)
+        enquiries_email: enquiries@environment-agency.gov.uk
+        continue: Continue
   activemodel:
     errors:
       models:

--- a/lib/defra_ruby_companies_house.rb
+++ b/lib/defra_ruby_companies_house.rb
@@ -27,7 +27,17 @@ class DefraRubyCompaniesHouse
     ].compact
   end
 
+  def status
+    status_is_allowed?(load_company) ? :active : :inactive
+  rescue RestClient::ResourceNotFound
+    :not_found
+  end
+
   private
+
+  def status_is_allowed?(load_company)
+    %w[active voluntary-arrangement].include?(load_company[:company_status])
+  end
 
   def load_company
     @company =

--- a/spec/cassettes/w3c_valid_content/check_registered_name_and_address_forms_spec/when-the-company-status-is-no-longer-active.yml
+++ b/spec/cassettes/w3c_valid_content/check_registered_name_and_address_forms_spec/when-the-company-status-is-no-longer-active.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://validator.w3.org/nu/?out=json&parser=html&showsource=yes
+    body:
+      encoding: UTF-8
+      string: "<!DOCTYPE html>\n<html>\n<head>\n  <title>Dummy</title>\n  <link rel=\"stylesheet\"
+        media=\"all\" href=\"/assets/application-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.css\"
+        data-turbolinks-track=\"true\" />\n  <script src=\"/assets/application-f9d8e5ce8f528d997d58156ff5f8c1d4b0741ac22b367a6a6294b3c7e9758e96.js\"
+        data-turbolinks-track=\"true\"></script>\n  \n</head>\n<body>\n\n<div class=\"govuk-grid-row\">\n
+        \ <div class=\"govuk-grid-column-two-thirds\">\n    <h1 class=\"govuk-heading-l\">We
+        could not validate your Companies House number</h1>\n    <p class=\"govuk-body\">There
+        is an issue with your Companies House number (it is possible that your company
+        is no longer active). You must either create a new registration, or speak
+        to our contact centre.</p>\n\n    <p class=\"govuk-body\">\n      Environment
+        Agency <br/>\n      Telephone 03708 506 506, Monday to Friday (8am to 6pm)
+        <br/>\n      <a href=\"mailto:enquiries@environment-agency.gov.uk\">enquiries@environment-agency.gov.uk</a>\n
+        \   </p>\n      <a class=\"govuk-button\" href=\"/waste_exemptions_engine/start\">Continue</a>\n
+        \ </div>\n</div>\n\n</body>\n</html>\n"
+    headers:
+      Content-Type:
+      - text/html; charset=utf-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 Jul 2022 15:18:46 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - gzip
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - content-type
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept-Encoding, User-Agent
+      Strict-Transport-Security:
+      - max-age=15552015; preload
+      Public-Key-Pins:
+      - pin-sha256="cN0QSpPIkuwpT6iP2YjEo1bEwGpH/yiUn6yhdy+HNto="; pin-sha256="WGJkyYjx1QMdMe0UqlyOKXtydPDVrk7sl2fV+nNm1r4=";
+        pin-sha256="LrKdTxZLRTvyHM4/atX2nquX9BeHRZMCxg3cf4rhc2I="; max-age=864000
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - 7258d5dc6fbd72d2
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 7258d5dc6fbd72d2-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9hc3NldHMvYXBwbGljYXRpb24tZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NS5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvYXNzZXRzL2FwcGxpY2F0aW9uLWY5ZDhlNWNlOGY1MjhkOTk3ZDU4MTU2ZmY1ZjhjMWQ0YjA3NDFhYzIyYjM2N2E2YTYyOTRiM2M3ZTk3NThlOTYuanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxkaXYgY2xhc3M9XCJnb3Z1ay1ncmlkLXJvd1wiPlxuICA8ZGl2IGNsYXNzPVwiZ292dWstZ3JpZC1jb2x1bW4tdHdvLXRoaXJkc1wiPlxuICAgIDxoMSBjbGFzcz1cImdvdnVrLWhlYWRpbmctbFwiPldlIGNvdWxkIG5vdCB2YWxpZGF0ZSB5b3VyIENvbXBhbmllcyBIb3VzZSBudW1iZXI8L2gxPlxuICAgIDxwIGNsYXNzPVwiZ292dWstYm9keVwiPlRoZXJlIGlzIGFuIGlzc3VlIHdpdGggeW91ciBDb21wYW5pZXMgSG91c2UgbnVtYmVyIChpdCBpcyBwb3NzaWJsZSB0aGF0IHlvdXIgY29tcGFueSBpcyBubyBsb25nZXIgYWN0aXZlKS4gWW91IG11c3QgZWl0aGVyIGNyZWF0ZSBhIG5ldyByZWdpc3RyYXRpb24sIG9yIHNwZWFrIHRvIG91ciBjb250YWN0IGNlbnRyZS48L3A+XG5cbiAgICA8cCBjbGFzcz1cImdvdnVrLWJvZHlcIj5cbiAgICAgIEVudmlyb25tZW50IEFnZW5jeSA8YnIvPlxuICAgICAgVGVsZXBob25lIDAzNzA4IDUwNiA1MDYsIE1vbmRheSB0byBGcmlkYXkgKDhhbSB0byA2cG0pIDxici8+XG4gICAgICA8YSBocmVmPVwibWFpbHRvOmVucXVpcmllc0BlbnZpcm9ubWVudC1hZ2VuY3kuZ292LnVrXCI+ZW5xdWlyaWVzQGVudmlyb25tZW50LWFnZW5jeS5nb3YudWs8L2E+XG4gICAgPC9wPlxuICAgICAgPGEgY2xhc3M9XCJnb3Z1ay1idXR0b25cIiBocmVmPVwiL3dhc3RlX2V4ZW1wdGlvbnNfZW5naW5lL3N0YXJ0XCI+Q29udGludWU8L2E+XG4gIDwvZGl2PlxuPC9kaXY+XG5cbjwvYm9keT5cbjwvaHRtbD4ifX0K
+  recorded_at: Mon, 04 Jul 2022 15:18:46 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/files/inactive_companies_house_response.json
+++ b/spec/fixtures/files/inactive_companies_house_response.json
@@ -1,0 +1,63 @@
+{
+  "jurisdiction":"england-wales",
+  "accounts":{
+     "next_accounts":{
+        "period_end_on":"2021-12-31",
+        "period_start_on":"2021-01-01",
+        "overdue":false,
+        "due_on":"2022-09-30"
+     },
+     "last_accounts":{
+        "type":"micro-entity",
+        "period_start_on":"2020-01-01",
+        "period_end_on":"2020-12-31",
+        "made_up_to":"2020-12-31"
+     },
+     "accounting_reference_date":{
+        "month":"12",
+        "day":"31"
+     },
+     "overdue":false,
+     "next_due":"2022-09-30",
+     "next_made_up_to":"2021-12-31"
+  },
+  "registered_office_address":{
+     "address_line_1":"R House",
+     "address_line_2":"Middle Street",
+     "region":"West Yorkshire",
+     "postal_code":"HD1 2BN",
+     "locality":"Thereabouts",
+     "care_of":"C/O A B Cdef"
+  },
+  "date_of_creation":"2000-07-28",
+  "company_name":"BOGUS LIMITED",
+  "type":"ltd",
+  "undeliverable_registered_office_address":false,
+  "last_full_members_list_date":"2015-07-28",
+  "has_been_liquidated":false,
+  "sic_codes":[
+     "43210"
+  ],
+  "status":"dissolved",
+  "company_number":"04041234",
+  "etag":"1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a",
+  "company_status":"inactive",
+  "has_insolvency_history":false,
+  "has_charges":false,
+  "confirmation_statement":{
+     "last_made_up_to":"2021-07-28",
+     "overdue":false,
+     "next_due":"2022-08-11",
+     "next_made_up_to":"2022-07-28"
+  },
+  "links":{
+     "self":"/company/04041234",
+     "filing_history":"/company/04041234/filing-history",
+     "officers":"/company/04041234/officers",
+     "charges":"/company/04041234/charges",
+     "persons_with_significant_control":"/company/04041234/persons-with-significant-control"
+  },
+  "registered_office_is_in_dispute":false,
+  "has_super_secure_pscs":false,
+  "can_file":true
+}

--- a/spec/lib/defra_ruby_companies_house_spec.rb
+++ b/spec/lib/defra_ruby_companies_house_spec.rb
@@ -72,9 +72,19 @@ RSpec.describe DefraRubyCompaniesHouse do
     end
   end
 
-  context "when the call to the CH API returns a 404" do
-    it "raises a standard error" do
-      expect { subject }.to raise_error(StandardError)
+  context "when there is a problem with the companies house API" do
+    context "and the requests time out" do
+      it "raises a standard error" do
+        expect { subject }.to raise_error(StandardError)
+      end
+    end
+
+    context "and requests return an error" do
+      before { stub_request(:get, /#{Rails.configuration.companies_house_host}*/).to_raise(SocketError) }
+
+      it "raises an exception" do
+        expect { subject.status }.to raise_error(StandardError)
+      end
     end
   end
 

--- a/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
@@ -13,6 +13,7 @@ module WasteExemptionsEngine
       allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company).and_return(true)
       allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:company_name).and_return(company_name)
       allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:registered_office_address_lines).and_return(company_address)
+      allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:status).and_return(:active)
     end
 
     include_examples "GET form", :check_registered_name_and_address_form, "/check-registered-name-and-address"

--- a/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
@@ -50,8 +50,9 @@ module WasteExemptionsEngine
     end
 
     context "during a renewal" do
+      let(:check_registered_name_and_address_form) { build(:check_registered_name_and_address_form) }
+
       context "when the company status is no longer active" do
-        let(:check_registered_name_and_address_form) { build(:check_registered_name_and_address_form) }
 
         before do
           allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:status).and_return(:inactive)
@@ -63,6 +64,17 @@ module WasteExemptionsEngine
           expect(response.code).to eq("200")
           expect(response).to render_template("waste_exemptions_engine/check_registered_name_and_address_forms/inactive_company")
           expect(response.body).to have_valid_html
+        end
+      end
+
+      context "when the company status can't be found" do
+        subject { described_class.new(company_no) }
+        before do
+          allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:status).and_return(nil)
+        end
+
+        it "raises a standard error" do
+          expect { subject }.to raise_error(StandardError)
         end
       end
     end

--- a/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
@@ -68,7 +68,7 @@ module WasteExemptionsEngine
         end
       end
 
-      context "when the company status cannot be found" do
+      context "when the company house is down" do
         before do
           allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company).and_return(nil)
         end
@@ -78,14 +78,24 @@ module WasteExemptionsEngine
         end
       end
 
-      context "when the validate company status throws an erorr" do
+      context "when the company status cannot be found" do
         before do
-          allow_any_instance_of(CheckRegisteredNameAndAddressForm).to receive(:validate_company_status).and_raise(:StandardError)
+          allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:status).and_return(:not_found)
         end
         it "raises an error" do
           expect { get request_path }.to raise_error(StandardError)
         end
       end
+
+      context "when the company status throws an error" do
+        before do
+          allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:status).and_return(:StandardError)
+        end
+        it "raises an error" do
+          expect { get request_path }.to raise_error(StandardError)
+        end
+      end
+
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
@@ -48,5 +48,23 @@ module WasteExemptionsEngine
         end
       end
     end
+
+    context "during a renewal" do
+      context "when the company status is no longer active" do
+        let(:check_registered_name_and_address_form) { build(:check_registered_name_and_address_form) }
+
+        before do
+          allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:status).and_return(:inactive)
+        end
+
+        it "displays inactive company error" do
+          get "/waste_exemptions_engine/#{check_registered_name_and_address_form.token}/check-registered-name-and-address"
+
+          expect(response.code).to eq("200")
+          expect(response).to render_template("waste_exemptions_engine/check_registered_name_and_address_forms/inactive_company")
+          expect(response.body).to have_valid_html
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1885
Here we are adding an error partial for when a company is no longer active during its renewal.
This is currently for renewals using the magic link