### PR TITLE
Added in company house down page for API issues

### DIFF
--- a/app/controllers/waste_exemptions_engine/check_registered_name_and_address_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/check_registered_name_and_address_forms_controller.rb
@@ -10,7 +10,7 @@ module WasteExemptionsEngine
         return render(:inactive_company) unless validate_company_status
       rescue StandardError
         Rails.logger.error "Failed to load"
-        return render(:companies_house_down)  
+        render(:companies_house_down)
       end
     end
 

--- a/app/forms/waste_exemptions_engine/check_registered_name_and_address_form.rb
+++ b/app/forms/waste_exemptions_engine/check_registered_name_and_address_form.rb
@@ -17,20 +17,6 @@ module WasteExemptionsEngine
       companies_house_service.registered_office_address_lines
     end
 
-    def validate_company_status
-      case companies_house_service.status
-      when :active
-        true
-      when :inactive
-        false
-      when :not_found
-        raise StandardError "Failed to find company status"
-      else
-        # Sonarcloud suggested that not having an `else` is a code smell
-        raise StandardError "Failed to find company status"
-      end
-    end
-
     def submit(params)
       params[:operator_name] = registered_company_name if params[:temp_use_registered_company_details] == "true"
       super(params)

--- a/app/views/waste_exemptions_engine/check_registered_name_and_address_forms/companies_house_down.html.erb
+++ b/app/views/waste_exemptions_engine/check_registered_name_and_address_forms/companies_house_down.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+    <p class="govuk-body"><%= t(".paragraph_1") %></p>
+    <p class="govuk-body"><%= t(".paragraph_2") %></p>
+  </div>
+</div>

--- a/config/locales/forms/check_registered_name_and_address_forms/en.yml
+++ b/config/locales/forms/check_registered_name_and_address_forms/en.yml
@@ -18,6 +18,11 @@ en:
           line_2: Telephone 03708 506 506, Monday to Friday (8am to 6pm)
         enquiries_email: enquiries@environment-agency.gov.uk
         continue: Continue
+      companies_house_down:
+        title: There is a problem with Companies House
+        heading: There is a problem with Companies House
+        paragraph_1: We are unable to verify your Companies House details at the moment
+        paragraph_2: Please try again later.
   activemodel:
     errors:
       models:

--- a/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
@@ -67,35 +67,19 @@ module WasteExemptionsEngine
           expect(response.body).to have_valid_html
         end
       end
+    end
 
-      context "when the company house is down" do
-        before do
-          allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:load_company).and_return(nil)
-        end
-
-        it "raises an error" do
-          expect { get request_path }.to raise_error(StandardError)
-        end
+    context "when the company house API is down" do
+      before do
+        allow_any_instance_of(CheckRegisteredNameAndAddressFormsController).to receive(:validate_company_status).and_raise(StandardError)
       end
 
-      context "when the company status cannot be found" do
-        before do
-          allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:status).and_return(:not_found)
-        end
-        it "raises an error" do
-          expect { get request_path }.to raise_error(StandardError)
-        end
-      end
+      let(:check_registered_name_and_address_form) { build(:check_registered_name_and_address_form) }
+      it "raises an error" do
 
-      context "when the company status throws an error" do
-        before do
-          allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:status).and_return(:StandardError)
-        end
-        it "raises an error" do
-          expect { get request_path }.to raise_error(StandardError)
-        end
+        get request_path
+        expect(response).to render_template("waste_exemptions_engine/check_registered_name_and_address_forms/companies_house_down")
       end
-
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/check_registered_name_and_address_forms_spec.rb
@@ -71,7 +71,7 @@ module WasteExemptionsEngine
 
     context "when the company house API is down" do
       before do
-        allow_any_instance_of(CheckRegisteredNameAndAddressFormsController).to receive(:validate_company_status).and_raise(StandardError)
+        allow_any_instance_of(DefraRubyCompaniesHouse).to receive(:status).and_raise(StandardError)
       end
 
       let(:check_registered_name_and_address_form) { build(:check_registered_name_and_address_form) }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1886
Here we add a template informing the users when the companies house API is down to try again later.