### PR TITLE
Change to back navigation for renewals

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_renewing_registration_workflow.rb
@@ -294,7 +294,11 @@ module WasteExemptionsEngine
                       to: :registration_number_form
 
           transitions from: :operator_postcode_form,
-                      to: :operator_name_form
+                      to: :operator_name_form,
+                      if: :skip_registration_number?
+
+          transitions from: :operator_postcode_form,
+                      to: :business_type_form
 
           transitions from: :operator_address_lookup_form,
                       to: :operator_postcode_form

--- a/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/operator_postcode_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/renewing_registration_workflow_state/operator_postcode_form_spec.rb
@@ -5,10 +5,47 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe RenewingRegistration, type: :model do
     describe "#workflow_state" do
-      it_behaves_like "a postcode transition",
-                      previous_state: :operator_name_form,
-                      address_type: "operator",
-                      factory: :renewing_registration
+      next_state = :operator_address_lookup_form
+      current_state = :operator_postcode_form
+      subject(:renewing_registration) { create(:renewing_registration, workflow_state: current_state) }
+
+      context "when a RenewingRegistration's state is #{current_state}" do
+        context "when renewing_registrations business type is a company or llp" do
+          previous_state = :business_type_form
+
+          [TransientRegistration::BUSINESS_TYPES[:limited_liability_partnership],
+           TransientRegistration::BUSINESS_TYPES[:limited_company]].each do |business_type|
+            before(:each) { renewing_registration.business_type = business_type }
+
+            it "can transition to either #{previous_state} or #{next_state}" do
+              expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+            end
+
+            it "changes to #{previous_state} after the 'back' event" do
+              expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+            end
+          end
+        end
+
+        context "when renewing_registration business type is not a company or llp" do
+          previous_state = :operator_name_form
+
+          [TransientRegistration::BUSINESS_TYPES[:charity],
+           TransientRegistration::BUSINESS_TYPES[:local_authority],
+           TransientRegistration::BUSINESS_TYPES[:partnership],
+           TransientRegistration::BUSINESS_TYPES[:sole_trader]].each do |business_type|
+            before(:each) { renewing_registration.business_type = business_type }
+
+            it "can only transition to either #{previous_state} or #{next_state}" do
+              expect(renewing_registration).to transition_from(current_state).to(next_state).on_event(:next)
+            end
+
+            it "changes to #{previous_state} after the 'back' event" do
+              expect(renewing_registration).to transition_from(current_state).to(previous_state).on_event(:back)
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1999
Here we have the changes to the back navigation for operator_postcode_form. Previously it was going back to operator name form even when the business type was a company. This change stops that and navigates it back to the correct page. 