### PR TITLE
Send letters to contacts with no email address

### DIFF
--- a/app/helpers/waste_exemptions_engine/plurals_helper.rb
+++ b/app/helpers/waste_exemptions_engine/plurals_helper.rb
@@ -6,6 +6,7 @@ module WasteExemptionsEngine
       emails = [form.applicant_email, form.contact_email]
       emails.uniq!
       emails.delete(nil)
+      emails.delete("")
 
       if emails.empty?
         "letter"

--- a/app/helpers/waste_exemptions_engine/plurals_helper.rb
+++ b/app/helpers/waste_exemptions_engine/plurals_helper.rb
@@ -5,7 +5,7 @@ module WasteExemptionsEngine
     def confirmation_comms(form)
       emails = [form.applicant_email, form.contact_email]
       emails.uniq!
-      emails.delete(WasteExemptionsEngine.configuration.assisted_digital_email)
+      emails.delete(nil)
 
       if emails.empty?
         "letter"

--- a/app/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter.rb
+++ b/app/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter.rb
@@ -12,6 +12,10 @@ module WasteExemptionsEngine
       "#{applicant_first_name} #{applicant_last_name}"
     end
 
+    def applicant_email_section
+      "#{applicant_email}" if applicant_email.present?
+    end
+
     def contact_name
       "#{contact_first_name} #{contact_last_name}"
     end
@@ -41,7 +45,7 @@ module WasteExemptionsEngine
       items << contact_name_text
       items << contact_position_text if contact_position.present?
       items << contact_phone_text
-      items << contact_email_text
+      items << contact_email_text if contact_email.present?
 
       items
     end

--- a/app/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter.rb
+++ b/app/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter.rb
@@ -12,6 +12,10 @@ module WasteExemptionsEngine
       "#{applicant_first_name} #{applicant_last_name}"
     end
 
+    def applicant_email_section
+      applicant_email.present? ? applicant_email.to_s : no_email_text
+    end
+
     def contact_name
       "#{contact_first_name} #{contact_last_name}"
     end
@@ -42,7 +46,7 @@ module WasteExemptionsEngine
       items << contact_position_text if contact_position.present?
       items << contact_phone_text
       items << contact_email_text if contact_email.present?
-
+      items << no_email_text if contact_email.blank?
       items
     end
 
@@ -124,6 +128,12 @@ module WasteExemptionsEngine
 
     def contact_email_text
       label_and_value("waste_operation_contact.email", contact_email)
+    end
+
+    def no_email_text
+      label_text = I18n.t("notify_confirmation_letter.waste_operation_contact.email")
+      value = I18n.t("notify_confirmation_letter.waste_operation_contact.no_email")
+      "#{label_text} #{value}"
     end
 
     # Location

--- a/app/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter.rb
+++ b/app/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter.rb
@@ -12,10 +12,6 @@ module WasteExemptionsEngine
       "#{applicant_first_name} #{applicant_last_name}"
     end
 
-    def applicant_email_section
-      "#{applicant_email}" if applicant_email.present?
-    end
-
     def contact_name
       "#{contact_first_name} #{contact_last_name}"
     end

--- a/app/services/waste_exemptions_engine/notify_confirmation_letter_service.rb
+++ b/app/services/waste_exemptions_engine/notify_confirmation_letter_service.rb
@@ -27,7 +27,7 @@ module WasteExemptionsEngine
         reference: @registration.reference,
         date_registered: @registration.date_registered,
         applicant_name: @registration.applicant_name,
-        applicant_email: @registration.applicant_email_section,
+        applicant_email: @registration.applicant_email,
         applicant_phone: @registration.applicant_phone,
         business_details: @registration.business_details_section,
         contact_name: @registration.contact_name,

--- a/app/services/waste_exemptions_engine/notify_confirmation_letter_service.rb
+++ b/app/services/waste_exemptions_engine/notify_confirmation_letter_service.rb
@@ -27,7 +27,7 @@ module WasteExemptionsEngine
         reference: @registration.reference,
         date_registered: @registration.date_registered,
         applicant_name: @registration.applicant_name,
-        applicant_email: @registration.applicant_email,
+        applicant_email: @registration.applicant_email_section,
         applicant_phone: @registration.applicant_phone,
         business_details: @registration.business_details_section,
         contact_name: @registration.contact_name,

--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -74,7 +74,7 @@ module WasteExemptionsEngine
     end
 
     def send_confirmation_messages
-      send_confirmation_letter if ad_email_address?(@registration.contact_email)
+      send_confirmation_letter unless @registration.contact_email.present?
 
       send_confirmation_emails
     end
@@ -88,7 +88,7 @@ module WasteExemptionsEngine
 
     def send_confirmation_emails
       distinct_recipients.each do |recipient|
-        send_confirmation_email(recipient) unless ad_email_address?(recipient)
+        send_confirmation_email(recipient) if recipient.present?
       end
     end
 
@@ -100,11 +100,7 @@ module WasteExemptionsEngine
     end
 
     def distinct_recipients
-      [@registration.applicant_email, @registration.contact_email].map(&:downcase).uniq
-    end
-
-    def ad_email_address?(email)
-      email == WasteExemptionsEngine.configuration.assisted_digital_email
+      [@registration.applicant_email, @registration.contact_email].compact.map(&:downcase).uniq
     end
   end
 end

--- a/config/locales/confirmation_letters.en.yml
+++ b/config/locales/confirmation_letters.en.yml
@@ -29,6 +29,7 @@ en:
       position: "Position:"
       telephone: "Telephone:"
       email: "Email:"
+      no_email: "Not present"
     waste_operation_location:
       address: "Waste operation location:"
       ngr: "Grid reference:"

--- a/spec/cassettes/registration_complete_letter_sent.yml
+++ b/spec/cassettes/registration_complete_letter_sent.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notifications.service.gov.uk/v2/notifications/letter
+    body:
+      encoding: UTF-8
+      string: '{"template_id":"81cae4bd-9f4c-4e14-bf3c-44573cee4f5b","personalisation":{"reference":"WEX000009","date_registered":"18
+        July 2022","applicant_name":"Kristle Pfeffer","applicant_email":null,"applicant_phone":"01234567890","business_details":["Business
+        or organisation type: Limited company","Registered name of the company: Schmeler
+        and Sons","Registration number of the company: 09360070","Registered address
+        of the company: Grant-Kerluke, 10604, 61087 Morissette Burgs, North, Keeblerport,
+        BS1 5AH"],"contact_name":"Clyde Wyman","contact_details":["Name: Clyde Wyman","Position:
+        scientist","Telephone: 01234567890","Email: "],"site_details":["Grid reference:
+        ST 58337 72855","Site details: Et corporis odit voluptates."],"exemption_details":["U11:
+        Id repellendus atque illum. – Expires on 17 July 2025","U12: Sint hic saepe
+        est. – Expires on 17 July 2025","U13: Animi voluptas et accusamus. – Expires
+        on 17 July 2025"],"deregistered_exemption_details":[],"show_deregistered_exemption_details":false,"address_line_1":"Clyde
+        Wyman","address_line_2":"Tromp Group","address_line_3":"15807","address_line_4":"6394
+        Augustine Island","address_line_5":"South","address_line_6":"Andersonfurt","address_line_7":"BS1
+        5AH"}}'
+    headers:
+      User-Agent:
+      - NOTIFY-API-RUBY-CLIENT/5.3.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic <API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '112'
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 18 Jul 2022 09:33:01 GMT
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - gunicorn
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-B3-Spanid:
+      - 3d113f3bbeb4f121
+      X-B3-Traceid:
+      - 1a7ca5aba2b7da3e3d113f3bbeb4f121
+      X-Vcap-Request-Id:
+      - 73a498e5-2071-4965-750b-5741ecb67f3c
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 04354ce99e843be4590eff596a34d268.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - LHR61-C1
+      X-Amz-Cf-Id:
+      - OoDjg66dpTrcOhBHh0_jObm0zZzpFfswTSbprk7tZA_4oGcMWALQ8g==
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"error":"BadRequestError","message":"Missing personalisation:
+        applicant_email"}],"status_code":400}
+
+'
+  recorded_at: Mon, 18 Jul 2022 09:33:01 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/w3c_valid_content/registration_complete_forms_spec/when-the-registration-is-in-the-correct-state.yml
+++ b/spec/cassettes/w3c_valid_content/registration_complete_forms_spec/when-the-registration-is-in-the-correct-state.yml
@@ -14,12 +14,12 @@ http_interactions:
         \         You have registered your exemptions for 3 years\n          <br />\n
         \         <span class=\"govuk-panel__body\">Your registration number is</span>\n
         \       </h1>\n        <div class=\"govuk-panel__body\">\n          <strong>\n
-        \           <span id=\"reg_identifier\">WEX000012</span>\n          </strong>\n
+        \           <span id=\"reg_identifier\">WEX000443</span>\n          </strong>\n
         \       </div>\n      </div>\n\n      <h2 class=\"govuk-heading-m\">What will
         happen next</h2>\n\n      <p class=\"govuk-body\">We have sent a confirmation
-        email to earline@example.com and donte_mckenzie@example.org.</p>\n\n      <p
-        class=\"govuk-body\">These exemptions will expire in . We will send you a
-        reminder 1 month before they are due to expire.</p>\n\n      <p class=\"govuk-body\">We
+        email to collin.abernathy@example.org and stanley@example.com.</p>\n\n      <p
+        class=\"govuk-body\">These exemptions will expire in July 2025. We will send
+        you a reminder 1 month before they are due to expire.</p>\n\n      <p class=\"govuk-body\">We
         will add your registration to the public register. This includes the name
         and address of the individual or organisation responsible, the site address
         and the exemptions you have registered.</p>\n\n  </div>\n</div>\n\n\n</body>\n</html>\n"
@@ -38,7 +38,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 22 Mar 2022 11:14:18 GMT
+      - Fri, 15 Jul 2022 12:24:36 GMT
       Content-Type:
       - application/json;charset=utf-8
       Transfer-Encoding:
@@ -67,7 +67,7 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - 6efe80c0aacc71ea
+      - 72b279dbfd86731e
       Cf-Cache-Status:
       - DYNAMIC
       Expect-Ct:
@@ -75,12 +75,12 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 6efe80c0aacc71ea-LHR
+      - 72b279dbfd86731e-LHR
       Alt-Svc:
       - h3=":443"; ma=86400, h3-29=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9hc3NldHMvYXBwbGljYXRpb24tZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NS5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvYXNzZXRzL2FwcGxpY2F0aW9uLWY5ZDhlNWNlOGY1MjhkOTk3ZDU4MTU2ZmY1ZjhjMWQ0YjA3NDFhYzIyYjM2N2E2YTYyOTRiM2M3ZTk3NThlOTYuanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxkaXYgY2xhc3M9XCJnb3Z1ay1ncmlkLXJvd1wiPlxuICA8ZGl2IGNsYXNzPVwiZ292dWstZ3JpZC1jb2x1bW4tdHdvLXRoaXJkc1wiPlxuXG4gICAgICA8ZGl2IGNsYXNzPVwiZ292dWstcGFuZWwgZ292dWstcGFuZWwtLWNvbmZpcm1hdGlvblwiPlxuICAgICAgICA8aDEgY2xhc3M9XCJnb3Z1ay1wYW5lbF9fdGl0bGVcIj5cbiAgICAgICAgICBZb3UgaGF2ZSByZWdpc3RlcmVkIHlvdXIgZXhlbXB0aW9ucyBmb3IgMyB5ZWFyc1xuICAgICAgICAgIDxiciAvPlxuICAgICAgICAgIDxzcGFuIGNsYXNzPVwiZ292dWstcGFuZWxfX2JvZHlcIj5Zb3VyIHJlZ2lzdHJhdGlvbiBudW1iZXIgaXM8L3NwYW4+XG4gICAgICAgIDwvaDE+XG4gICAgICAgIDxkaXYgY2xhc3M9XCJnb3Z1ay1wYW5lbF9fYm9keVwiPlxuICAgICAgICAgIDxzdHJvbmc+XG4gICAgICAgICAgICA8c3BhbiBpZD1cInJlZ19pZGVudGlmaWVyXCI+V0VYMDAwMDEyPC9zcGFuPlxuICAgICAgICAgIDwvc3Ryb25nPlxuICAgICAgICA8L2Rpdj5cbiAgICAgIDwvZGl2PlxuXG4gICAgICA8aDIgY2xhc3M9XCJnb3Z1ay1oZWFkaW5nLW1cIj5XaGF0IHdpbGwgaGFwcGVuIG5leHQ8L2gyPlxuXG4gICAgICA8cCBjbGFzcz1cImdvdnVrLWJvZHlcIj5XZSBoYXZlIHNlbnQgYSBjb25maXJtYXRpb24gZW1haWwgdG8gZWFybGluZUBleGFtcGxlLmNvbSBhbmQgZG9udGVfbWNrZW56aWVAZXhhbXBsZS5vcmcuPC9wPlxuXG4gICAgICA8cCBjbGFzcz1cImdvdnVrLWJvZHlcIj5UaGVzZSBleGVtcHRpb25zIHdpbGwgZXhwaXJlIGluIC4gV2Ugd2lsbCBzZW5kIHlvdSBhIHJlbWluZGVyIDEgbW9udGggYmVmb3JlIHRoZXkgYXJlIGR1ZSB0byBleHBpcmUuPC9wPlxuXG4gICAgICA8cCBjbGFzcz1cImdvdnVrLWJvZHlcIj5XZSB3aWxsIGFkZCB5b3VyIHJlZ2lzdHJhdGlvbiB0byB0aGUgcHVibGljIHJlZ2lzdGVyLiBUaGlzIGluY2x1ZGVzIHRoZSBuYW1lIGFuZCBhZGRyZXNzIG9mIHRoZSBpbmRpdmlkdWFsIG9yIG9yZ2FuaXNhdGlvbiByZXNwb25zaWJsZSwgdGhlIHNpdGUgYWRkcmVzcyBhbmQgdGhlIGV4ZW1wdGlvbnMgeW91IGhhdmUgcmVnaXN0ZXJlZC48L3A+XG5cbiAgPC9kaXY+XG48L2Rpdj5cblxuXG48L2JvZHk+XG48L2h0bWw+In19Cg==
-  recorded_at: Tue, 22 Mar 2022 11:14:17 GMT
-recorded_with: VCR 6.0.0
+        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9hc3NldHMvYXBwbGljYXRpb24tZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NS5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvYXNzZXRzL2FwcGxpY2F0aW9uLWY5ZDhlNWNlOGY1MjhkOTk3ZDU4MTU2ZmY1ZjhjMWQ0YjA3NDFhYzIyYjM2N2E2YTYyOTRiM2M3ZTk3NThlOTYuanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxkaXYgY2xhc3M9XCJnb3Z1ay1ncmlkLXJvd1wiPlxuICA8ZGl2IGNsYXNzPVwiZ292dWstZ3JpZC1jb2x1bW4tdHdvLXRoaXJkc1wiPlxuXG4gICAgICA8ZGl2IGNsYXNzPVwiZ292dWstcGFuZWwgZ292dWstcGFuZWwtLWNvbmZpcm1hdGlvblwiPlxuICAgICAgICA8aDEgY2xhc3M9XCJnb3Z1ay1wYW5lbF9fdGl0bGVcIj5cbiAgICAgICAgICBZb3UgaGF2ZSByZWdpc3RlcmVkIHlvdXIgZXhlbXB0aW9ucyBmb3IgMyB5ZWFyc1xuICAgICAgICAgIDxiciAvPlxuICAgICAgICAgIDxzcGFuIGNsYXNzPVwiZ292dWstcGFuZWxfX2JvZHlcIj5Zb3VyIHJlZ2lzdHJhdGlvbiBudW1iZXIgaXM8L3NwYW4+XG4gICAgICAgIDwvaDE+XG4gICAgICAgIDxkaXYgY2xhc3M9XCJnb3Z1ay1wYW5lbF9fYm9keVwiPlxuICAgICAgICAgIDxzdHJvbmc+XG4gICAgICAgICAgICA8c3BhbiBpZD1cInJlZ19pZGVudGlmaWVyXCI+V0VYMDAwNDQzPC9zcGFuPlxuICAgICAgICAgIDwvc3Ryb25nPlxuICAgICAgICA8L2Rpdj5cbiAgICAgIDwvZGl2PlxuXG4gICAgICA8aDIgY2xhc3M9XCJnb3Z1ay1oZWFkaW5nLW1cIj5XaGF0IHdpbGwgaGFwcGVuIG5leHQ8L2gyPlxuXG4gICAgICA8cCBjbGFzcz1cImdvdnVrLWJvZHlcIj5XZSBoYXZlIHNlbnQgYSBjb25maXJtYXRpb24gZW1haWwgdG8gY29sbGluLmFiZXJuYXRoeUBleGFtcGxlLm9yZyBhbmQgc3RhbmxleUBleGFtcGxlLmNvbS48L3A+XG5cbiAgICAgIDxwIGNsYXNzPVwiZ292dWstYm9keVwiPlRoZXNlIGV4ZW1wdGlvbnMgd2lsbCBleHBpcmUgaW4gSnVseSAyMDI1LiBXZSB3aWxsIHNlbmQgeW91IGEgcmVtaW5kZXIgMSBtb250aCBiZWZvcmUgdGhleSBhcmUgZHVlIHRvIGV4cGlyZS48L3A+XG5cbiAgICAgIDxwIGNsYXNzPVwiZ292dWstYm9keVwiPldlIHdpbGwgYWRkIHlvdXIgcmVnaXN0cmF0aW9uIHRvIHRoZSBwdWJsaWMgcmVnaXN0ZXIuIFRoaXMgaW5jbHVkZXMgdGhlIG5hbWUgYW5kIGFkZHJlc3Mgb2YgdGhlIGluZGl2aWR1YWwgb3Igb3JnYW5pc2F0aW9uIHJlc3BvbnNpYmxlLCB0aGUgc2l0ZSBhZGRyZXNzIGFuZCB0aGUgZXhlbXB0aW9ucyB5b3UgaGF2ZSByZWdpc3RlcmVkLjwvcD5cblxuICA8L2Rpdj5cbjwvZGl2PlxuXG5cbjwvYm9keT5cbjwvaHRtbD4ifX0K
+  recorded_at: Fri, 15 Jul 2022 12:24:35 GMT
+recorded_with: VCR 6.1.0

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -30,8 +30,8 @@ FactoryBot.define do
       contact_email { applicant_email }
     end
 
-    trait :has_ad_contact_email do
-      contact_email { WasteExemptionsEngine.configuration.assisted_digital_email }
+    trait :has_no_email do
+      contact_email { nil }
     end
 
     trait :has_people do

--- a/spec/helpers/waste_exemptions_engine/plurals_helper_spec.rb
+++ b/spec/helpers/waste_exemptions_engine/plurals_helper_spec.rb
@@ -31,23 +31,23 @@ module WasteExemptionsEngine
         let(:applicant_email) { "applicant_email@test.com" }
         let(:contact_email) { "contact_email@test.com" }
 
-        context "when the applicant email is the AD email" do
-          let(:applicant_email) { WasteExemptionsEngine.configuration.assisted_digital_email }
+        context "when the applicant email is blank (AD)" do
+          let(:applicant_email) { nil }
 
           it "returns the string `contact_email`" do
             expect(helper.confirmation_comms(form)).to eq("contact_email")
           end
         end
 
-        context "when the contact email is the AD email" do
-          let(:contact_email) { WasteExemptionsEngine.configuration.assisted_digital_email }
+        context "when the contact email is blank (AD)" do
+          let(:contact_email) { nil }
 
           it "returns the string `applicant_email`" do
             expect(helper.confirmation_comms(form)).to eq("applicant_email")
           end
         end
 
-        context "when neither email is the AD email" do
+        context "when neither email is the blank (AD)" do
           it "returns the string `both_emails`" do
             expect(helper.confirmation_comms(form)).to eq("both_emails")
           end
@@ -58,8 +58,8 @@ module WasteExemptionsEngine
         let(:applicant_email) { "applicant_email@test.com" }
         let(:contact_email) { applicant_email }
 
-        context "when both emails are the AD email" do
-          let(:applicant_email) { WasteExemptionsEngine.configuration.assisted_digital_email }
+        context "when both emails are blank (AD)" do
+          let(:applicant_email) { nil }
 
           it "returns the string `letter`" do
             expect(helper.confirmation_comms(form)).to eq("letter")

--- a/spec/helpers/waste_exemptions_engine/plurals_helper_spec.rb
+++ b/spec/helpers/waste_exemptions_engine/plurals_helper_spec.rb
@@ -52,6 +52,22 @@ module WasteExemptionsEngine
             expect(helper.confirmation_comms(form)).to eq("both_emails")
           end
         end
+
+        context "when contact email is empty sting" do
+          let(:contact_email) { "" }
+
+          it "returns the string 'appliant email" do
+            expect(helper.confirmation_comms(form)).to eq("applicant_email")
+          end
+        end
+
+        context "when applicant email is an empty string" do
+          let(:applicant_email) { "" }
+
+          it "returns the string 'contact_email'" do
+            expect(helper.confirmation_comms(form)).to eq("contact_email")
+          end
+        end
       end
 
       context "when applicant and contact emails are equal" do

--- a/spec/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter_spec.rb
+++ b/spec/presenters/waste_exemptions_engine/notify_confirmation_letter_presenter_spec.rb
@@ -20,6 +20,23 @@ module WasteExemptionsEngine
       end
     end
 
+    describe "#applicant_email" do
+      context "when an email is present" do
+        it "returns the correcrt value" do
+          expect(subject.applicant_email_section).to eq(registration.applicant_email.to_s)
+        end
+      end
+
+      context "when an email isn't present" do
+        let(:registration) { create(:registration, :complete, :with_active_exemptions, applicant_email: email) }
+        let(:email) { nil }
+
+        it "returns the correct value" do
+          expect(subject.applicant_email_section).to eq("Email: Not present")
+        end
+      end
+    end
+
     describe "#contact_name" do
       it "returns the correct value" do
         expect(subject.contact_name).to eq("#{registration.contact_first_name} #{registration.contact_last_name}")
@@ -118,6 +135,23 @@ module WasteExemptionsEngine
           ]
 
           expect(subject.contact_details_section).to eq(expected_array)
+        end
+
+        context "when a contact email is not specified" do
+          let(:registration) { create(:registration, :complete, :with_active_exemptions, contact_email: email, contact_position: position) }
+          let(:email) { nil }
+          let(:position) { "Head of Waste" }
+
+          it "returns an array with the correct data and labels" do
+            expected_array = [
+              "Name: #{registration.contact_first_name} #{registration.contact_last_name}",
+              "Position: Head of Waste",
+              "Telephone: #{registration.contact_phone}",
+              "Email: Not present"
+            ]
+
+            expect(subject.contact_details_section).to eq(expected_array)
+          end
         end
       end
 

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -109,7 +109,7 @@ module WasteExemptionsEngine
           expect(NewRegistration.where(reference: new_registration.reference).count).to eq(0)
         end
 
-        context "when the contact email is not the NCCC email" do
+        context "when the contact email is not blank (AD)" do
           it "sends a confirmation email to both the applicant and the contact emails" do
             expect(ConfirmationEmailService).to receive(:run).with(registration: instance_of(Registration),
                                                                    recipient: new_registration.applicant_email)
@@ -135,10 +135,10 @@ module WasteExemptionsEngine
           end
         end
 
-        context "when the contact email is the NCCC email" do
-          let(:new_registration) { create(:new_registration, :complete, :has_ad_contact_email) }
+        context "when the contact email is blank (AD)" do
+          let(:new_registration) { create(:new_registration, :complete, :has_no_email) }
 
-          context "when the applicant email is the NCCC email" do
+          context "when the applicant email is blank (AD)" do
             before { new_registration.update(applicant_email: new_registration.contact_email) }
 
             it "sends a confirmation letter" do
@@ -148,13 +148,13 @@ module WasteExemptionsEngine
             end
 
             it "does not send any confirmation emails" do
+              allow(NotifyConfirmationLetterService).to receive(:run)
               expect(ConfirmationEmailService).to_not receive(:run)
-
               run_service
             end
           end
 
-          context "when the applicant email is not the NCCC email" do
+          context "when the applicant email is not blank" do
             it "sends a confirmation letter" do
               expect(NotifyConfirmationLetterService).to receive(:run).with(registration: instance_of(Registration)).once
 
@@ -162,6 +162,7 @@ module WasteExemptionsEngine
             end
 
             it "only emails the applicant email" do
+              allow(NotifyConfirmationLetterService).to receive(:run)
               expect(ConfirmationEmailService).to receive(:run).with(registration: instance_of(Registration),
                                                                      recipient: new_registration.applicant_email).once
               expect(ConfirmationEmailService).to_not receive(:run).with(registration: instance_of(Registration),


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1997

Here we have the changes to allow letters to be sent to registrations without an email address. 
In WEX there are two emails address captured, applicant_email and contact_email. 
These changes mean letters are sent to any emails that are nil value instead of the NCCC email address.

A plural helper method was also affected with the change, and has been updated to allow for a nil address. 