### PR TITLE
Optional applicant and contact email addresses

### DIFF
--- a/app/controllers/waste_exemptions_engine/applicant_email_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/applicant_email_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.fetch(:applicant_email_form, {}).permit(:confirmed_email, :applicant_email)
+      params.fetch(:applicant_email_form, {}).permit(:confirmed_email, :applicant_email, :no_email_address)
     end
   end
 end

--- a/app/controllers/waste_exemptions_engine/contact_email_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/contact_email_forms_controller.rb
@@ -13,7 +13,7 @@ module WasteExemptionsEngine
     private
 
     def transient_registration_attributes
-      params.fetch(:contact_email_form, {}).permit(:confirmed_email, :contact_email)
+      params.fetch(:contact_email_form, {}).permit(:confirmed_email, :contact_email, :no_email_address)
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/applicant_email_form.rb
+++ b/app/forms/waste_exemptions_engine/applicant_email_form.rb
@@ -5,13 +5,14 @@ module WasteExemptionsEngine
     delegate :applicant_email, to: :transient_registration
 
     attr_writer :confirmed_email
+    attr_accessor :no_email_address
 
-    validates :applicant_email, :confirmed_email, "defra_ruby/validators/email": true
-    validates :confirmed_email, "waste_exemptions_engine/matching_email": { compare_to: :applicant_email }
+    validates_with OptionalEmailFormValidator, attributes: [:applicant_email]
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
       self.confirmed_email = params[:confirmed_email]
+      self.no_email_address = params[:no_email_address]
 
       super(params.permit(:applicant_email))
     end

--- a/app/forms/waste_exemptions_engine/check_your_answers_form.rb
+++ b/app/forms/waste_exemptions_engine/check_your_answers_form.rb
@@ -9,7 +9,9 @@ module WasteExemptionsEngine
     validates :location, "defra_ruby/validators/location": true
     validates :applicant_first_name, :applicant_last_name, "waste_exemptions_engine/person_name": true
     validates :applicant_phone, "defra_ruby/validators/phone_number": true
-    validates :applicant_email, "defra_ruby/validators/email": true
+
+    validates_with WasteExemptionsEngine::OptionalEmailValidator, attributes: [:applicant_email], if: :back_office?
+    validates_with DefraRuby::Validators::EmailValidator, attributes: [:applicant_email], unless: :back_office?
 
     validates :business_type, "defra_ruby/validators/business_type": true
     validates :company_no, "defra_ruby/validators/companies_house_number": true, if: :company_no_required?
@@ -19,7 +21,10 @@ module WasteExemptionsEngine
     validates :contact_first_name, :contact_last_name, "waste_exemptions_engine/person_name": true
     validates :contact_position, "defra_ruby/validators/position": true
     validates :contact_phone, "defra_ruby/validators/phone_number": true
-    validates :contact_email, "defra_ruby/validators/email": true
+
+    validates_with WasteExemptionsEngine::OptionalEmailValidator, attributes: [:contact_email], if: :back_office?
+    validates_with DefraRuby::Validators::EmailValidator, attributes: [:contact_email], unless: :back_office?
+
     validates :contact_address, "waste_exemptions_engine/address": true
 
     validates :on_a_farm, inclusion: { in: [true, false] }
@@ -54,6 +59,10 @@ module WasteExemptionsEngine
       return true unless transient_registration&.site_address
 
       transient_registration.site_address.auto?
+    end
+
+    def back_office?
+      WasteExemptionsEngine.configuration.host_is_back_office?
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/contact_email_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_email_form.rb
@@ -5,13 +5,14 @@ module WasteExemptionsEngine
     delegate :contact_email, to: :transient_registration
 
     attr_writer :confirmed_email
+    attr_accessor :no_email_address
 
-    validates :contact_email, :confirmed_email, "defra_ruby/validators/email": true
-    validates :confirmed_email, "waste_exemptions_engine/matching_email": { compare_to: :contact_email }
+    validates_with OptionalEmailFormValidator, attributes: [:contact_email]
 
     def submit(params)
       # Assign the params for validation and pass them to the BaseForm method for updating
       self.confirmed_email = params[:confirmed_email]
+      self.no_email_address = params[:no_email_address]
 
       super(params.permit(:contact_email))
     end

--- a/app/models/concerns/waste_exemptions_engine/can_use_new_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_new_registration_workflow.rb
@@ -182,8 +182,15 @@ module WasteExemptionsEngine
                       unless: :temp_reuse_applicant_phone?
 
           transitions from: :check_contact_phone_form,
-                      to: :check_contact_email_form,
-                      if: :temp_reuse_applicant_phone?
+                      to: :contact_email_form,
+                      unless: :applicant_email?
+
+          transitions from: :check_contact_phone_form,
+                      to: :check_contact_email_form
+
+          transitions from: :contact_phone_form,
+                      to: :contact_email_form,
+                      unless: :applicant_email
 
           transitions from: :contact_phone_form,
                       to: :check_contact_email_form

--- a/app/validators/waste_exemptions_engine/optional_email_form_validator.rb
+++ b/app/validators/waste_exemptions_engine/optional_email_form_validator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OptionalEmailFormValidator < ActiveModel::EachValidator
+    include CanAddValidationErrors
+
+    def validate(record)
+      email_address = record.send(attributes[0])
+      if WasteExemptionsEngine.configuration.host_is_back_office? && record.no_email_address == "1"
+        if email_address.present?
+          add_validation_error(record, :no_email_address, :not_blank)
+          return false
+        end
+
+        return true
+      end
+
+      if record.confirmed_email != email_address
+        add_validation_error(record, :confirmed_email, :does_not_match)
+        return false
+      end
+
+      DefraRuby::Validators::EmailValidator.new(attributes: attributes).validate(record)
+    end
+  end
+end

--- a/app/validators/waste_exemptions_engine/optional_email_validator.rb
+++ b/app/validators/waste_exemptions_engine/optional_email_validator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OptionalEmailValidator < ActiveModel::EachValidator
+
+    def validate(record)
+      return true unless record.contact_email.present?
+
+      DefraRuby::Validators::EmailValidator.new(attributes: [:contact_email]).validate(record)
+    end
+  end
+end

--- a/app/views/waste_exemptions_engine/applicant_email_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/applicant_email_forms/new.html.erb
@@ -13,6 +13,15 @@
       <%= f.govuk_email_field :confirmed_email,
           label: { text: t(".confirmed_email_label") } %>
 
+      <% if WasteExemptionsEngine.configuration.host_is_back_office? %>
+        <%= f.govuk_check_boxes_fieldset :no_email_address, multiple: false, legend: -> {} do %>
+          <%= f.govuk_check_box :no_email_address,
+              1, 0, multiple: false, link_errors: true, label: { text: t(".no_applicant_email_label") }
+          %>
+          <p>
+        <% end %>
+      <% end %>
+
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/waste_exemptions_engine/contact_email_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/contact_email_forms/new.html.erb
@@ -13,6 +13,15 @@
       <%= f.govuk_email_field :confirmed_email,
           label: { text: t(".confirmed_email_label") } %>
 
+      <% if WasteExemptionsEngine.configuration.host_is_back_office? %>
+        <%= f.govuk_check_boxes_fieldset :no_email_address, multiple: false, legend: -> {} do %>
+          <%= f.govuk_check_box :no_email_address,
+              1, 0, multiple: false, link_errors: true, label: { text: t(".no_contact_email_label") }
+          %>
+          <p>
+        <% end %>
+      <% end %>
+
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/config/locales/forms/applicant_email_forms/en.yml
+++ b/config/locales/forms/applicant_email_forms/en.yml
@@ -7,6 +7,7 @@ en:
         error_heading: A problem to fix
         applicant_email_label: Email address
         confirmed_email_label: Confirm email address
+        no_applicant_email_label: This customer has no access to an email address
         next_button: Continue
   activemodel:
     errors:
@@ -20,6 +21,8 @@ en:
               blank: "Enter your email address again to confirm it"
               invalid_format: "Enter a valid confirmed email address - there’s a mistake in that one"
               does_not_match: "The email addresses you’ve entered don’t match"
+            no_email_address:
+              not_blank: You cannot enter email addresses and select 'This customer has no access to an email address'
             token:
               invalid_format: "The token is not valid"
               missing: "The token is missing"

--- a/config/locales/forms/contact_email_forms/en.yml
+++ b/config/locales/forms/contact_email_forms/en.yml
@@ -7,6 +7,7 @@ en:
         error_heading: A problem to fix
         contact_email_label: Email address
         confirmed_email_label: Confirm email address
+        no_contact_email_label: This customer has no access to an email address
         next_button: Continue
   activemodel:
     errors:
@@ -20,6 +21,8 @@ en:
               blank: "Enter your email address again to confirm it"
               invalid_format: "Enter a valid confirmed email address"
               does_not_match: "The email addresses you’ve entered don’t match"
+            no_email_address:
+              not_blank: You cannot enter email addresses and select 'This customer has no access to an email address'
             token:
               invalid_format: "The token is not valid"
               missing: "The token is missing"

--- a/lib/waste_exemptions_engine.rb
+++ b/lib/waste_exemptions_engine.rb
@@ -121,6 +121,17 @@ module WasteExemptionsEngine
       end
     end
 
+    # Used to determine if engine is running in the back-office rather than the front-office
+    def host_is_back_office=(value)
+      @host_is_back_office = change_string_to_boolean_for(value)
+    end
+
+    def host_is_back_office?
+      return false unless @host_is_back_office
+
+      @host_is_back_office
+    end
+
     private
 
     # If the setting's value is "true", then set to a boolean true. Otherwise, set it to false.

--- a/spec/forms/waste_exemptions_engine/applicant_email_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/applicant_email_form_spec.rb
@@ -4,64 +4,6 @@ require "rails_helper"
 
 module WasteExemptionsEngine
   RSpec.describe ApplicantEmailForm, type: :model do
-    subject(:form) { build(:applicant_email_form) }
-
-    describe "validations" do
-      subject(:validators) { form._validators }
-
-      describe "email attribute validation" do
-        it "validates the applicant email using the EmailValidator class" do
-          expect(validators.keys).to include(:applicant_email)
-          expect(validators[:applicant_email].first.class)
-            .to eq(DefraRuby::Validators::EmailValidator)
-        end
-
-        it "validates the confirmed email using the EmailValidator class" do
-          expect(validators.keys).to include(:confirmed_email)
-          expect(validators[:confirmed_email].map(&:class))
-            .to include(DefraRuby::Validators::EmailValidator)
-        end
-      end
-
-      describe "matching email validation" do
-        it "validates the applicant email and confirmed email using the MatchingEmailValidator class " do
-          expect(validators.keys).to include(:confirmed_email)
-
-          matching_email_validators = validators[:confirmed_email].select do |v|
-            v.instance_of?(WasteExemptionsEngine::MatchingEmailValidator)
-          end
-          expect(matching_email_validators.count).to eq(1)
-          expect(matching_email_validators.first.options).to eq(compare_to: :applicant_email)
-        end
-      end
-    end
-
-    it_behaves_like "a validated form", :applicant_email_form do
-      let(:valid_params) do
-        { applicant_email: "test@example.com", confirmed_email: "test@example.com" }
-      end
-      let(:invalid_params) do
-        [
-          { applicant_email: "test@example.com", confirmed_email: "different@example.com" },
-          { applicant_email: "", confirmed_email: "test@example.com" },
-          { applicant_email: "test@example.com", confirmed_email: "" },
-          { applicant_email: "", confirmed_email: "" }
-        ]
-      end
-    end
-
-    describe "#submit" do
-      context "when the form is valid" do
-        it "updates the transient registration with the applicant email address" do
-          email = "test@example.com"
-          valid_params = { applicant_email: email, confirmed_email: email }
-          transient_registration = form.transient_registration
-
-          expect(transient_registration.applicant_email).to be_blank
-          form.submit(ActionController::Parameters.new(valid_params).permit!)
-          expect(transient_registration.applicant_email).to eq(email)
-        end
-      end
-    end
+    it_behaves_like "an optional email form", :applicant_email_form, :applicant_email
   end
 end

--- a/spec/forms/waste_exemptions_engine/contact_email_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/contact_email_form_spec.rb
@@ -4,64 +4,6 @@ require "rails_helper"
 
 module WasteExemptionsEngine
   RSpec.describe ContactEmailForm, type: :model do
-    subject(:form) { build(:contact_email_form) }
-
-    describe "validations" do
-      subject(:validators) { form._validators }
-
-      describe "email attribute validation" do
-        it "validates the contact email using the EmailValidator class" do
-          expect(validators.keys).to include(:contact_email)
-          expect(validators[:contact_email].first.class)
-            .to eq(DefraRuby::Validators::EmailValidator)
-        end
-
-        it "validates the confirmed email using the EmailValidator class" do
-          expect(validators.keys).to include(:confirmed_email)
-          expect(validators[:confirmed_email].map(&:class))
-            .to include(DefraRuby::Validators::EmailValidator)
-        end
-      end
-
-      describe "matching email validation" do
-        it "validates the contact email and confirmed email using the MatchingEmailValidator class " do
-          expect(validators.keys).to include(:confirmed_email)
-
-          matching_email_validators = validators[:confirmed_email].select do |v|
-            v.instance_of?(WasteExemptionsEngine::MatchingEmailValidator)
-          end
-          expect(matching_email_validators.count).to eq(1)
-          expect(matching_email_validators.first.options).to eq(compare_to: :contact_email)
-        end
-      end
-    end
-
-    it_behaves_like "a validated form", :contact_email_form do
-      let(:valid_params) do
-        { contact_email: "test@example.com", confirmed_email: "test@example.com" }
-      end
-      let(:invalid_params) do
-        [
-          { contact_email: "test@example.com", confirmed_email: "different@example.com" },
-          { contact_email: "", confirmed_email: "test@example.com" },
-          { contact_email: "test@example.com", confirmed_email: "" },
-          { contact_email: "", confirmed_email: "" }
-        ]
-      end
-    end
-
-    describe "#submit" do
-      context "when the form is valid" do
-        it "updates the transient registration with the contact email address" do
-          email = "test@example.com"
-          valid_params = { contact_email: email, confirmed_email: email }
-          transient_registration = form.transient_registration
-
-          expect(transient_registration.contact_email).to be_blank
-          form.submit(ActionController::Parameters.new(valid_params).permit!)
-          expect(transient_registration.contact_email).to eq(email)
-        end
-      end
-    end
+    it_behaves_like "an optional email form", :contact_email_form, :contact_email
   end
 end

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/check_contact_phone_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/check_contact_phone_form_spec.rb
@@ -8,17 +8,34 @@ module WasteExemptionsEngine
       let(:new_registration) do
         create(:new_registration,
                workflow_state: :check_contact_phone_form,
-               temp_reuse_applicant_phone: temp_reuse_applicant_phone)
+               temp_reuse_applicant_phone: temp_reuse_applicant_phone,
+               applicant_email: applicant_email)
       end
+      let(:applicant_email) { nil }
 
       context "when temp_reuse_applicant_phone is true" do
         let(:temp_reuse_applicant_phone) { true }
 
-        it "transitions to :check_contact_email_form" do
-          expect(new_registration)
-            .to transition_from(:check_contact_phone_form)
-            .to(:check_contact_email_form)
-            .on_event(:next)
+        context "and applicant_email is present" do
+          let(:applicant_email) { Faker::Internet.email }
+
+          it "transitions to :check_contact_email_form" do
+            expect(new_registration)
+              .to transition_from(:check_contact_phone_form)
+              .to(:check_contact_email_form)
+              .on_event(:next)
+          end
+        end
+
+        context "and applicant email is not present" do
+          let(:applicant_email) { nil }
+
+          it "transitions to :contact_email_form" do
+            expect(new_registration)
+              .to transition_from(:check_contact_phone_form)
+              .to(:contact_email_form)
+              .on_event(:next)
+          end
         end
       end
 

--- a/spec/models/waste_exemptions_engine/new_registration_workflow_state/contact_phone_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_workflow_state/contact_phone_form_spec.rb
@@ -5,10 +5,34 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe NewRegistration, type: :model do
     describe "#workflow_state" do
-      it_behaves_like "a simple bidirectional transition",
-                      current_state: :contact_phone_form,
-                      next_state: :check_contact_email_form,
-                      factory: :new_registration
+      let(:new_registration) do
+        create(:new_registration,
+               workflow_state: :contact_phone_form,
+               applicant_email: applicant_email)
+      end
+      let(:applicant_email) { nil }
+
+      context "when applicant_email is present" do
+        let(:applicant_email) { Faker::Internet.email }
+
+        it "transitions to :check_contact_email_form" do
+          expect(new_registration)
+            .to transition_from(:contact_phone_form)
+            .to(:check_contact_email_form)
+            .on_event(:next)
+        end
+      end
+
+      context "when applicant email is not present" do
+        let(:applicant_email) { nil }
+
+        it "transitions to :contact_email_form" do
+          expect(new_registration)
+            .to transition_from(:contact_phone_form)
+            .to(:contact_email_form)
+            .on_event(:next)
+        end
+      end
     end
   end
 end

--- a/spec/support/shared_examples/forms/optional_email_form.rb
+++ b/spec/support/shared_examples/forms/optional_email_form.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "an optional email form", vcr: true do |form_factory, email_attribute|
+  subject(:form) { build(form_factory) }
+
+  describe "validations" do
+    subject(:validators) { form._validators }
+
+    describe "email attribute validation" do
+      it "validates the #{email_attribute} using the OptionalEmailFormValidator class" do
+        expect(validators[email_attribute].first.class).to eq(WasteExemptionsEngine::OptionalEmailFormValidator)
+      end
+    end
+  end
+
+  it_behaves_like "a validated form", form_factory do
+    let(:valid_params) do
+      { "#{email_attribute}": "test@example.com", confirmed_email: "test@example.com" }
+    end
+    let(:invalid_params) do
+      [
+        { "#{email_attribute}": "test@example.com", confirmed_email: "different@example.com" },
+        { "#{email_attribute}": "", confirmed_email: "test@example.com" },
+        { "#{email_attribute}": "test@example.com", confirmed_email: "" },
+        { "#{email_attribute}": "", confirmed_email: "" }
+      ]
+    end
+  end
+
+  describe "#submit" do
+    let(:params) do
+      {
+        "#{email_attribute}": email_address,
+        confirmed_email: email_address,
+        no_email_address: defined?(no_email_address) ? no_email_address : nil
+      }
+    end
+    let(:email_address) { Faker::Internet.email }
+    let(:is_back_office) { false }
+    before { allow(WasteExemptionsEngine.configuration).to receive(:host_is_back_office?).and_return(is_back_office) }
+
+    shared_examples "should submit" do
+      it "submits the form successfully" do
+        expect(form.submit(ActionController::Parameters.new(params))).to eq(true)
+      end
+    end
+
+    shared_examples "should not submit" do
+      it "does not submit the form successfully" do
+        expect(form.submit(ActionController::Parameters.new(params))).to eq(false)
+      end
+    end
+
+    context "when the form is valid" do
+      context "when running in the front office" do
+        let(:is_back_office) { false }
+
+        context "with an email address" do
+          let(:email_address) { Faker::Internet.email }
+
+          it_behaves_like "should submit"
+
+          it "updates the transient registration with the contact email address" do
+            expect { form.submit(ActionController::Parameters.new(params).permit!) }
+              .to change { form.transient_registration.send(email_attribute) }
+              .from(nil).to(email_address)
+          end
+        end
+      end
+
+      context "when running in the back office" do
+        let(:is_back_office) { true }
+
+        context "with an email address" do
+          let(:email_address) { Faker::Internet.email }
+
+          it_behaves_like "should submit"
+        end
+
+        context "without an email address" do
+          let(:email_address) { nil }
+          let(:no_email_address) { "1" }
+
+          it_behaves_like "should submit"
+        end
+      end
+    end
+
+    context "when the form is not valid" do
+      context "when running in the front office" do
+        let(:is_back_office) { false }
+
+        context "with no parameters" do
+          let(:params) { {} }
+
+          it_behaves_like "should not submit"
+        end
+      end
+
+      context "when running in the back office" do
+        let(:is_back_office) { true }
+
+        context "without an email address and with the no-email-address option not selected" do
+          let(:email_address) { nil }
+          let(:no_email_address) { "0" }
+
+          it_behaves_like "should not submit"
+        end
+
+        context "with an email address and with the no-email-address option selected" do
+          let(:email_address) { Faker::Internet.email }
+          let(:no_email_address) { "1" }
+
+          it_behaves_like "should not submit"
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/models/transient_registration_workflow_state/a_simple_bidirectional_transition.rb
+++ b/spec/support/shared_examples/models/transient_registration_workflow_state/a_simple_bidirectional_transition.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples "a simple bidirectional transition" do |current_state:, ne
   context "when a subject's state is #{current_state}" do
     subject(:subject) { create(factory, workflow_state: current_state) }
 
-    it "can only transition to either #{next_state}" do
+    it "can only transition to #{next_state}" do
       permitted_states = Helpers::WorkflowStates.permitted_states(subject)
       expect(permitted_states).to match_array([next_state])
     end

--- a/spec/validators/waste_exemptions_engine/optional_email_form_validator_spec.rb
+++ b/spec/validators/waste_exemptions_engine/optional_email_form_validator_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Test
+  OptionalEmailFormValidatable = Struct.new(:contact_email) do
+    include ActiveModel::Validations
+
+    attr_reader :contact_email
+    attr_reader :confirmed_email
+    attr_reader :no_email_address
+
+    validates_with WasteExemptionsEngine::OptionalEmailFormValidator, attributes: [:contact_email]
+  end
+end
+
+module WasteExemptionsEngine
+  RSpec.describe OptionalEmailFormValidator do
+
+    subject { Test::OptionalEmailFormValidatable.new }
+
+    let(:contact_email) { Faker::Internet.email }
+    let(:confirmed_email) { contact_email }
+    before do
+      allow(subject).to receive(:contact_email).and_return(contact_email)
+      allow(subject).to receive(:confirmed_email).and_return(confirmed_email)
+      allow(subject).to receive(:no_email_address).and_return(no_email_address)
+    end
+
+    shared_examples "is valid" do
+      it "passes the validity check" do
+        expect(subject).to be_valid
+      end
+    end
+
+    shared_examples "is not valid" do
+      it "does not pass the validity check" do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    RSpec.shared_examples "contact email address is required" do
+      context "with an email address" do
+        let(:contact_email) { Faker::Internet.email }
+        it_behaves_like "is valid"
+      end
+
+      context "without an email address" do
+        let(:contact_email) { nil }
+        it_behaves_like "is not valid"
+      end
+
+      context "with a matching confirmed email address" do
+        let(:confirmed_email) { contact_email }
+        it_behaves_like "is valid"
+      end
+
+      context "with a mismatched confirmed email address" do
+        let(:confirmed_email) { "not@chance.com" }
+        it_behaves_like "is not valid"
+      end
+    end
+
+    context "when running in the front office" do
+      before { allow(WasteExemptionsEngine.configuration).to receive(:host_is_back_office?).and_return(false) }
+      let(:no_email_address) { nil }
+
+      it_behaves_like "contact email address is required"
+    end
+
+    context "when running in the back office" do
+      before { allow(WasteExemptionsEngine.configuration).to receive(:host_is_back_office?).and_return(true) }
+
+      context "with no_email_address set to zero" do
+        let(:no_email_address) { "0" }
+        it_behaves_like "contact email address is required"
+      end
+
+      context "with no_email_address set to nil" do
+        let(:no_email_address) { nil }
+        it_behaves_like "contact email address is required"
+      end
+
+      context "with no_email_address set to one" do
+        let(:no_email_address) { "1" }
+
+        context "with an email address" do
+          let(:contact_email) { Faker::Internet.email }
+          it_behaves_like "is not valid"
+        end
+
+        context "without an email address" do
+          let(:contact_email) { nil }
+          it_behaves_like "is valid"
+        end
+      end
+    end
+  end
+end

--- a/spec/validators/waste_exemptions_engine/optional_email_validator_spec.rb
+++ b/spec/validators/waste_exemptions_engine/optional_email_validator_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Test
+  OptionalEmailValidatable = Struct.new(:contact_email) do
+    include ActiveModel::Validations
+
+    attr_reader :contact_email
+
+    validates_with WasteExemptionsEngine::OptionalEmailValidator, attributes: [:contact_email]
+  end
+end
+
+module WasteExemptionsEngine
+  RSpec.describe OptionalEmailValidator do
+
+    subject { Test::OptionalEmailValidatable.new }
+
+    before do
+      allow(subject).to receive(:contact_email).and_return(contact_email)
+    end
+
+    shared_examples "is valid" do
+      it "passes the validity check" do
+        expect(subject).to be_valid
+      end
+    end
+
+    shared_examples "is not valid" do
+      it "does not pass the validity check" do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context "with no contact email address" do
+      let(:contact_email) { nil }
+      it_behaves_like "is valid"
+    end
+
+    context "with a valid email address" do
+      let(:contact_email) { Faker::Internet.email }
+      it_behaves_like "is valid"
+    end
+
+    context "with an invalid email address" do
+      let(:contact_email) { "not_a_valid_email" }
+      it_behaves_like "is not valid"
+    end
+  end
+end


### PR DESCRIPTION
This change makes applicant and contact email addresses optional in the back-office only. Leaving the contact email blank will ensure that the contact receives a letter instead of an email (implemented separately under https://eaflood.atlassian.net/browse/RUBY-1997). 
This change also ensures that the page which presents the option to reuse the applicant email as the contact email is skipped if applicant email has not been populated.
https://eaflood.atlassian.net/browse/RUBY-1719