### PR TITLE
Companies House number validation

### DIFF
--- a/app/controllers/waste_exemptions_engine/check_registered_name_and_address_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/check_registered_name_and_address_forms_controller.rb
@@ -6,7 +6,10 @@ module WasteExemptionsEngine
   class CheckRegisteredNameAndAddressFormsController < FormsController
     def new
       super(CheckRegisteredNameAndAddressForm, "check_registered_name_and_address_form")
+      return if new_registration
+
       begin
+        return render(:inactive_company) unless validate_company_number
         return render(:inactive_company) unless validate_company_status
       rescue StandardError
         Rails.logger.error "Failed to load"
@@ -20,8 +23,20 @@ module WasteExemptionsEngine
 
     private
 
+    VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX = Regexp.new(
+      /\A(\d{8,8}$)|([a-zA-Z]{2}\d{6}$)|([a-zA-Z]{2}\d{5}[a-zA-Z]{1}$)\z/i
+    ).freeze
+
+    def new_registration
+      @transient_registration.is_a?(WasteExemptionsEngine::NewRegistration)
+    end
+
     def validate_company_status
       DefraRubyCompaniesHouse.new(@transient_registration.company_no).status == :active
+    end
+
+    def validate_company_number
+      @transient_registration.company_no&.match?(VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX)
     end
 
     def transient_registration_attributes

--- a/app/controllers/waste_exemptions_engine/check_registered_name_and_address_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/check_registered_name_and_address_forms_controller.rb
@@ -9,8 +9,7 @@ module WasteExemptionsEngine
       return if new_registration
 
       begin
-        return render(:inactive_company) unless validate_company_number
-        return render(:inactive_company) unless validate_company_status
+        return render(:inactive_company) unless validate_company_number && validate_company_status
       rescue StandardError
         Rails.logger.error "Failed to load"
         render(:companies_house_down)

--- a/spec/cassettes/w3c_valid_content/check_registered_name_and_address_forms_spec/when-the-company-number-is-invalid.yml
+++ b/spec/cassettes/w3c_valid_content/check_registered_name_and_address_forms_spec/when-the-company-number-is-invalid.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://validator.w3.org/nu/?out=json&parser=html&showsource=yes
+    body:
+      encoding: UTF-8
+      string: "<!DOCTYPE html>\n<html>\n<head>\n  <title>Dummy</title>\n  <link rel=\"stylesheet\"
+        media=\"all\" href=\"/assets/application-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.css\"
+        data-turbolinks-track=\"true\" />\n  <script src=\"/assets/application-f9d8e5ce8f528d997d58156ff5f8c1d4b0741ac22b367a6a6294b3c7e9758e96.js\"
+        data-turbolinks-track=\"true\"></script>\n  \n</head>\n<body>\n\n<div class=\"govuk-grid-row\">\n
+        \ <div class=\"govuk-grid-column-two-thirds\">\n    <h1 class=\"govuk-heading-l\">We
+        could not validate your Companies House number</h1>\n    <p class=\"govuk-body\">There
+        is an issue with your Companies House number (it is possible that your company
+        is no longer active). You must either create a new registration, or speak
+        to our contact centre.</p>\n\n    <p class=\"govuk-body\">\n      Environment
+        Agency <br/>\n      Telephone 03708 506 506, Monday to Friday (8am to 6pm)
+        <br/>\n      <a href=\"mailto:enquiries@environment-agency.gov.uk\">enquiries@environment-agency.gov.uk</a>\n
+        \   </p>\n      <a class=\"govuk-button\" href=\"/waste_exemptions_engine/start\">Continue</a>\n
+        \ </div>\n</div>\n\n</body>\n</html>\n"
+    headers:
+      Content-Type:
+      - text/html; charset=utf-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 21 Jul 2022 14:50:48 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - gzip
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - content-type
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Cache-Control:
+      - no-cache
+      Vary:
+      - Accept-Encoding, User-Agent
+      Strict-Transport-Security:
+      - max-age=15552015; preload
+      Public-Key-Pins:
+      - pin-sha256="cN0QSpPIkuwpT6iP2YjEo1bEwGpH/yiUn6yhdy+HNto="; pin-sha256="WGJkyYjx1QMdMe0UqlyOKXtydPDVrk7sl2fV+nNm1r4=";
+        pin-sha256="LrKdTxZLRTvyHM4/atX2nquX9BeHRZMCxg3cf4rhc2I="; max-age=864000
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - 72e4c0462ea88868
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 72e4c0462ea88868-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6MiwiZmlyc3RMaW5lIjoxLCJsYXN0Q29sdW1uIjo2LCJmaXJzdENvbHVtbiI6MTYsInN1YlR5cGUiOiJ3YXJuaW5nIiwibWVzc2FnZSI6IkNvbnNpZGVyIGFkZGluZyBhIOKAnGxhbmfigJ0gYXR0cmlidXRlIHRvIHRoZSDigJxodG1s4oCdIHN0YXJ0IHRhZyB0byBkZWNsYXJlIHRoZSBsYW5ndWFnZSBvZiB0aGlzIGRvY3VtZW50LiIsImV4dHJhY3QiOiJUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkIiwiaGlsaXRlU3RhcnQiOjEwLCJoaWxpdGVMZW5ndGgiOjd9XSwic291cmNlIjp7InR5cGUiOiJ0ZXh0L2h0bWwiLCJlbmNvZGluZyI6IlVURi04IiwiY29kZSI6IjwhRE9DVFlQRSBodG1sPlxuPGh0bWw+XG48aGVhZD5cbiAgPHRpdGxlPkR1bW15PC90aXRsZT5cbiAgPGxpbmsgcmVsPVwic3R5bGVzaGVldFwiIG1lZGlhPVwiYWxsXCIgaHJlZj1cIi9hc3NldHMvYXBwbGljYXRpb24tZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NS5jc3NcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCIgLz5cbiAgPHNjcmlwdCBzcmM9XCIvYXNzZXRzL2FwcGxpY2F0aW9uLWY5ZDhlNWNlOGY1MjhkOTk3ZDU4MTU2ZmY1ZjhjMWQ0YjA3NDFhYzIyYjM2N2E2YTYyOTRiM2M3ZTk3NThlOTYuanNcIiBkYXRhLXR1cmJvbGlua3MtdHJhY2s9XCJ0cnVlXCI+PC9zY3JpcHQ+XG4gIFxuPC9oZWFkPlxuPGJvZHk+XG5cbjxkaXYgY2xhc3M9XCJnb3Z1ay1ncmlkLXJvd1wiPlxuICA8ZGl2IGNsYXNzPVwiZ292dWstZ3JpZC1jb2x1bW4tdHdvLXRoaXJkc1wiPlxuICAgIDxoMSBjbGFzcz1cImdvdnVrLWhlYWRpbmctbFwiPldlIGNvdWxkIG5vdCB2YWxpZGF0ZSB5b3VyIENvbXBhbmllcyBIb3VzZSBudW1iZXI8L2gxPlxuICAgIDxwIGNsYXNzPVwiZ292dWstYm9keVwiPlRoZXJlIGlzIGFuIGlzc3VlIHdpdGggeW91ciBDb21wYW5pZXMgSG91c2UgbnVtYmVyIChpdCBpcyBwb3NzaWJsZSB0aGF0IHlvdXIgY29tcGFueSBpcyBubyBsb25nZXIgYWN0aXZlKS4gWW91IG11c3QgZWl0aGVyIGNyZWF0ZSBhIG5ldyByZWdpc3RyYXRpb24sIG9yIHNwZWFrIHRvIG91ciBjb250YWN0IGNlbnRyZS48L3A+XG5cbiAgICA8cCBjbGFzcz1cImdvdnVrLWJvZHlcIj5cbiAgICAgIEVudmlyb25tZW50IEFnZW5jeSA8YnIvPlxuICAgICAgVGVsZXBob25lIDAzNzA4IDUwNiA1MDYsIE1vbmRheSB0byBGcmlkYXkgKDhhbSB0byA2cG0pIDxici8+XG4gICAgICA8YSBocmVmPVwibWFpbHRvOmVucXVpcmllc0BlbnZpcm9ubWVudC1hZ2VuY3kuZ292LnVrXCI+ZW5xdWlyaWVzQGVudmlyb25tZW50LWFnZW5jeS5nb3YudWs8L2E+XG4gICAgPC9wPlxuICAgICAgPGEgY2xhc3M9XCJnb3Z1ay1idXR0b25cIiBocmVmPVwiL3dhc3RlX2V4ZW1wdGlvbnNfZW5naW5lL3N0YXJ0XCI+Q29udGludWU8L2E+XG4gIDwvZGl2PlxuPC9kaXY+XG5cbjwvYm9keT5cbjwvaHRtbD4ifX0K
+  recorded_at: Thu, 21 Jul 2022 14:50:48 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/RUBY/boards/374?selectedIssue=RUBY-1885

This change means that during a renewal if the company number is invalid it will show the user the 'inactive company' page rather than the 'companies house down' one previously. 