### PR TITLE
Fix blank/nil email

### DIFF
--- a/app/forms/waste_exemptions_engine/applicant_email_form.rb
+++ b/app/forms/waste_exemptions_engine/applicant_email_form.rb
@@ -10,6 +10,10 @@ module WasteExemptionsEngine
     validates_with OptionalEmailFormValidator, attributes: [:applicant_email]
 
     def submit(params)
+      # Blank email address values should be processed as nil
+      params[:applicant_email] = nil if params[:applicant_email].blank?
+      params[:confirmed_email] = nil if params[:confirmed_email].blank?
+            
       # Assign the params for validation and pass them to the BaseForm method for updating
       self.confirmed_email = params[:confirmed_email]
       self.no_email_address = params[:no_email_address]

--- a/app/forms/waste_exemptions_engine/contact_email_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_email_form.rb
@@ -10,6 +10,10 @@ module WasteExemptionsEngine
     validates_with OptionalEmailFormValidator, attributes: [:contact_email]
 
     def submit(params)
+      # Blank email address values should be processed as nil
+      params[:contact_email] = nil if params[:contact_email].blank?
+      params[:confirmed_email] = nil if params[:confirmed_email].blank?
+
       # Assign the params for validation and pass them to the BaseForm method for updating
       self.confirmed_email = params[:confirmed_email]
       self.no_email_address = params[:no_email_address]

--- a/app/validators/waste_exemptions_engine/optional_email_form_validator.rb
+++ b/app/validators/waste_exemptions_engine/optional_email_form_validator.rb
@@ -7,7 +7,7 @@ module WasteExemptionsEngine
     def validate(record)
       email_address = record.send(attributes[0])
       if WasteExemptionsEngine.configuration.host_is_back_office? && record.no_email_address == "1"
-        if email_address.present?
+        unless email_address.nil?
           add_validation_error(record, :no_email_address, :not_blank)
           return false
         end

--- a/app/views/waste_exemptions_engine/registration_complete_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/registration_complete_forms/new.html.erb
@@ -27,7 +27,7 @@
 
       <p class="govuk-body"><%= t(".confirmation_email_text.#{confirmation_comms(@registration_complete_form)}", applicant: @registration_complete_form.applicant_email, contact: @registration_complete_form.contact_email) %></p>
 
-      <p class="govuk-body"><%= t(".paragraph_1", expiry_month: @registration.expiry_month) %></p>
+      <p class="govuk-body"><%= t(".paragraph_1", expire_day_month_year: registration_expires_day_month_year(@registration)) %></p>
 
       <p class="govuk-body"><%= t(".paragraph_2") %></p>
 

--- a/config/locales/forms/registration_complete_forms/en.yml
+++ b/config/locales/forms/registration_complete_forms/en.yml
@@ -11,7 +11,7 @@ en:
           contact_email: "We have sent a confirmation email to %{contact}."
           applicant_email: "We have sent a confirmation email to %{applicant} and a confirmation letter to your contact address."
           both_emails: "We have sent a confirmation email to %{applicant} and %{contact}."
-        paragraph_1: These exemptions will expire in %{expiry_month}. We will send you a reminder 1 month before they are due to expire.
+        paragraph_1: These exemptions will expire on %{expire_day_month_year}. We will send you a reminder 1 month before they are due to expire.
         paragraph_2: We will add your registration to the public register. This includes the name and address of the individual or organisation responsible, the site address and the exemptions you have registered.
         error_heading: A problem to fix
         next_button: Finished

--- a/spec/helpers/waste_exemptions_engine/application_helper_spec.rb
+++ b/spec/helpers/waste_exemptions_engine/application_helper_spec.rb
@@ -60,5 +60,15 @@ module WasteExemptionsEngine
         end
       end
     end
+
+    describe "expiry date" do
+      context "it formats the date" do
+        let(:registration) { create(:registration, :complete) }
+
+        it "returns the correct expiry date with day, month and year" do
+          expect(helper.registration_expires_day_month_year(registration)).to eq("#{3.years.from_now.strftime('%-d')} #{3.years.from_now.strftime('%B')} #{3.years.from_now.year}")
+        end
+      end
+    end
   end
 end

--- a/spec/support/shared_examples/forms/optional_email_form.rb
+++ b/spec/support/shared_examples/forms/optional_email_form.rb
@@ -75,13 +75,24 @@ RSpec.shared_examples "an optional email form", vcr: true do |form_factory, emai
           let(:email_address) { Faker::Internet.email }
 
           it_behaves_like "should submit"
+          
+          it "populates the email" do
+            expect { form.submit(ActionController::Parameters.new(params)) }
+              .to change { form.transient_registration.send(email_attribute) }
+              .from(nil).to(email_address)
+          end
         end
 
-        context "without an email address" do
-          let(:email_address) { nil }
+        context "with a blank email address" do
+          let(:email_address) { "" }
           let(:no_email_address) { "1" }
 
           it_behaves_like "should submit"
+
+          it "does not populate the email" do
+            expect { form.submit(ActionController::Parameters.new(params)) }
+              .not_to change { form.transient_registration.read_attribute(email_attribute) }.from(nil)
+          end
         end
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/RUBY/boards/374?selectedIssue=RUBY-2051

This change resolves a potential issue where submitting the contact_email  or applicant_email form with a blank contact_email/applicant_email field and selecting the "No email" option would result in the email value of "" (empty string) instead of nil. The value should be nil in all cases where a valid email value has not been provided.