### PR TITLE
Fix blank/nil email options

### DIFF
--- a/app/forms/waste_exemptions_engine/applicant_email_form.rb
+++ b/app/forms/waste_exemptions_engine/applicant_email_form.rb
@@ -4,21 +4,20 @@ module WasteExemptionsEngine
   class ApplicantEmailForm < BaseForm
     delegate :applicant_email, to: :transient_registration
 
-    attr_writer :confirmed_email
-    attr_accessor :no_email_address
+    attr_accessor :confirmed_email, :no_email_address
 
     validates_with OptionalEmailFormValidator, attributes: [:applicant_email]
 
     def submit(params)
+      # Blank email address values should be processed as nil
+      params[:applicant_email] = nil if params[:applicant_email].blank?
+      params[:confirmed_email] = nil if params[:confirmed_email].blank?
+
       # Assign the params for validation and pass them to the BaseForm method for updating
       self.confirmed_email = params[:confirmed_email]
       self.no_email_address = params[:no_email_address]
 
       super(params.permit(:applicant_email))
-    end
-
-    def confirmed_email
-      @confirmed_email || applicant_email
     end
   end
 end

--- a/app/forms/waste_exemptions_engine/contact_email_form.rb
+++ b/app/forms/waste_exemptions_engine/contact_email_form.rb
@@ -4,21 +4,20 @@ module WasteExemptionsEngine
   class ContactEmailForm < BaseForm
     delegate :contact_email, to: :transient_registration
 
-    attr_writer :confirmed_email
-    attr_accessor :no_email_address
+    attr_accessor :confirmed_email, :no_email_address
 
     validates_with OptionalEmailFormValidator, attributes: [:contact_email]
 
     def submit(params)
+      # Blank email address values should be processed as nil
+      params[:contact_email] = nil if params[:contact_email].blank?
+      params[:confirmed_email] = nil if params[:confirmed_email].blank?
+
       # Assign the params for validation and pass them to the BaseForm method for updating
       self.confirmed_email = params[:confirmed_email]
       self.no_email_address = params[:no_email_address]
 
       super(params.permit(:contact_email))
-    end
-
-    def confirmed_email
-      @confirmed_email || contact_email
     end
   end
 end

--- a/app/validators/waste_exemptions_engine/optional_email_form_validator.rb
+++ b/app/validators/waste_exemptions_engine/optional_email_form_validator.rb
@@ -7,7 +7,7 @@ module WasteExemptionsEngine
     def validate(record)
       email_address = record.send(attributes[0])
       if WasteExemptionsEngine.configuration.host_is_back_office? && record.no_email_address == "1"
-        if email_address.present?
+        unless email_address.nil?
           add_validation_error(record, :no_email_address, :not_blank)
           return false
         end

--- a/spec/dummy/config/initializers/waste_exemptions_engine.rb
+++ b/spec/dummy/config/initializers/waste_exemptions_engine.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 WasteExemptionsEngine.configure do |config|
-  # Assisted digital config
-  config.assisted_digital_email = ENV["WEX_ASSISTED_DIGITAL_EMAIL"] || "wex-ad@example.com"
-
   # General config
   config.application_name = "waste-exemptions-front-office"
   config.git_repository_url = "https://github.com/DEFRA/waste-exemptions-front-office"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_14_164313) do
+ActiveRecord::Schema.define(version: 2022_07_18_160813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/support/shared_examples/forms/optional_email_form.rb
+++ b/spec/support/shared_examples/forms/optional_email_form.rb
@@ -75,13 +75,24 @@ RSpec.shared_examples "an optional email form", vcr: true do |form_factory, emai
           let(:email_address) { Faker::Internet.email }
 
           it_behaves_like "should submit"
+
+          it "populates the email" do
+            expect { form.submit(ActionController::Parameters.new(params)) }
+              .to change { form.transient_registration.send(email_attribute) }
+              .from(nil).to(email_address)
+          end
         end
 
-        context "without an email address" do
-          let(:email_address) { nil }
+        context "with a blank email address" do
+          let(:email_address) { "" }
           let(:no_email_address) { "1" }
 
           it_behaves_like "should submit"
+
+          it "does not populate the email" do
+            expect { form.submit(ActionController::Parameters.new(params)) }
+              .not_to change { form.transient_registration.read_attribute(email_attribute) }.from(nil)
+          end
         end
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/RUBY/boards/374?selectedIssue=RUBY-2051

This change resolves a potential issue where submitting the contact_email or applicant_email form with a blank contact_email/applicant_email field and selecting the "No email" option would result in the email value of "" (empty string) instead of nil. The value should be nil in all cases where a valid email value has not been provided.