### PR TITLE
Track partial assisted digital

### DIFF
--- a/app/models/waste_exemptions_engine/new_registration.rb
+++ b/app/models/waste_exemptions_engine/new_registration.rb
@@ -3,5 +3,12 @@
 module WasteExemptionsEngine
   class NewRegistration < TransientRegistration
     include CanUseNewRegistrationWorkflow
+
+    def initialize(params)
+      super(params)
+
+      # Set the initial assistance_mode value to the application's default_assistance_mode
+      update!(assistance_mode: WasteExemptionsEngine.configuration.default_assistance_mode)
+    end
   end
 end

--- a/app/services/waste_exemptions_engine/registration_completion_service.rb
+++ b/app/services/waste_exemptions_engine/registration_completion_service.rb
@@ -69,7 +69,8 @@ module WasteExemptionsEngine
     end
 
     def add_metadata
-      @registration.assistance_mode = WasteExemptionsEngine.configuration.default_assistance_mode
+      @registration.assistance_mode = @transient_registration.assistance_mode ||
+                                      WasteExemptionsEngine.configuration.default_assistance_mode
       @registration.submitted_at = Date.today
     end
 

--- a/db/migrate/20221004145505_add_assistance_mode_to_transient_registrations.rb
+++ b/db/migrate/20221004145505_add_assistance_mode_to_transient_registrations.rb
@@ -1,0 +1,5 @@
+class AddAssistanceModeToTransientRegistrations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :transient_registrations, :assistance_mode, :string, default: nil
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_18_160813) do
+ActiveRecord::Schema.define(version: 2022_10_04_145505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -206,6 +206,7 @@ ActiveRecord::Schema.define(version: 2022_07_18_160813) do
     t.datetime "companies_house_updated_at"
     t.boolean "temp_reuse_applicant_name"
     t.text "workflow_history", default: [], array: true
+    t.string "assistance_mode"
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
   end
 

--- a/spec/models/waste_exemptions_engine/new_registration_spec.rb
+++ b/spec/models/waste_exemptions_engine/new_registration_spec.rb
@@ -25,5 +25,28 @@ module WasteExemptionsEngine
         expect(new_registration).to_not be_a_renewal
       end
     end
+
+    describe "#assistance_mode" do
+
+      context "when the default_assistance_mode is set" do
+        before do
+          allow(WasteExemptionsEngine.configuration).to receive(:default_assistance_mode).and_return("foo")
+        end
+
+        it "sets a new NewRegistration's assistance_mode to the correct value" do
+          expect(subject.assistance_mode).to eq("foo")
+        end
+      end
+
+      context "when the default_assistance_mode is not set" do
+        before do
+          allow(WasteExemptionsEngine.configuration).to receive(:default_assistance_mode).and_return(nil)
+        end
+
+        it "sets a new NewRegistration's assistance_mode to nil" do
+          expect(subject.assistance_mode).to eq(nil)
+        end
+      end
+    end
   end
 end

--- a/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/registration_completion_service_spec.rb
@@ -82,23 +82,23 @@ module WasteExemptionsEngine
           expect(registration.submitted_at).to eq(Date.current)
         end
 
-        context "when the default_assistance_mode is set" do
+        context "when the transient registration's assistance mode is set" do
           before do
-            allow(WasteExemptionsEngine.configuration).to receive(:default_assistance_mode).and_return("foo")
+            allow(new_registration).to receive(:assistance_mode).and_return("foo")
           end
 
-          it "updates the registration's route to the correct value" do
+          it "sets the registration's assistance mode to the same value" do
             run_service
             expect(registration.reload.assistance_mode).to eq("foo")
           end
         end
 
-        context "when the default_assistance_mode is not set" do
+        context "when the transient registration's assistance mode is not set" do
           before do
-            allow(WasteExemptionsEngine.configuration).to receive(:default_assistance_mode).and_return(nil)
+            allow(new_registration).to receive(:assistance_mode).and_return(nil)
           end
 
-          it "updates the registration's route to the correct value" do
+          it "sets the registration's assistance mode to nil" do
             run_service
             expect(registration.reload.assistance_mode).to eq(nil)
           end


### PR DESCRIPTION
This change tracks partially-assisted registrations for inclusion in the Boxi export.
https://eaflood.atlassian.net/browse/RUBY-2002