### PR TITLE
exemption deregistration service

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ Naming/VariableNumber:
 RSpec/SortMetadata:
   Enabled: false
 
+# TODO: Remove these exclusions 
 # The effort to update the existing specs to align with these cops is too high.
 # Future changes to the specs should avoid adding more of these offenses
 # and, where possible, remove existing offenses.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.14.1)
+    nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)

--- a/app/services/waste_exemptions_engine/exemption_deregistration_service.rb
+++ b/app/services/waste_exemptions_engine/exemption_deregistration_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "notifications/client"
+
+module WasteExemptionsEngine
+  class ExemptionDeregistrationService < BaseService
+    def run(transient_registration)
+      @transient_registration = transient_registration
+      @original_registration = transient_registration.registration
+      @contact_email = @original_registration.contact_email
+
+      case registration_exemptions_delta.length
+      when 0
+        return false
+      when @original_registration.registration_exemptions.length
+        full_deregister
+      else
+        partial_deregister
+      end
+
+      true
+    end
+
+    private
+
+    def registration_exemptions_delta
+      exemptions_delta_ids ||= (@original_registration.exemptions - @transient_registration.exemptions).pluck(:id)
+      @registration_exemptions_delta ||=
+        @original_registration.registration_exemptions.where(exemption_id: exemptions_delta_ids)
+    end
+
+    def full_deregister
+      deregister_exemptions(@original_registration.registration_exemptions)
+      create_paper_trail_version
+      DeregistrationConfirmationEmailService.run(registration: @original_registration, recipient: @contact_email)
+    end
+
+    def partial_deregister
+      deregister_exemptions(registration_exemptions_delta)
+      create_paper_trail_version
+      RegistrationEditConfirmationEmailService.run(registration: @original_registration, recipient: @contact_email)
+    end
+
+    def deregister_exemptions(registration_exemptions)
+      registration_exemptions.update_all(
+        state: "inactive",
+        deregistration_message: I18n.t("self_serve_deregistration.message"),
+        deregistered_at: Time.zone.now
+      )
+    end
+
+    def create_paper_trail_version
+      @original_registration.paper_trail.save_with_version
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,9 @@ en:
           one: 1 address found
           other: "%{count} addresses found"
 
+  self_serve_deregistration:
+    message: "Deregistered via self-serve"
+
   # Custom error pages
   invalid_id_title: Invalid ID
   invalid_id_heading: The exemption registration ID is not valid

--- a/spec/services/waste_exemptions_engine/exemption_deregistration_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/exemption_deregistration_service_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe ExemptionDeregistrationService do
+    describe "run" do
+      let(:transient_registration) { create(:renewing_registration) }
+      let(:registration) { transient_registration.registration }
+      let(:deregistration_confirmation_email_service) { instance_double(DeregistrationConfirmationEmailService) }
+      let(:registration_edit_confirmation_email_service) { instance_double(RegistrationEditConfirmationEmailService) }
+
+      subject(:run_service) { described_class.run(transient_registration) }
+
+      before do
+        allow(DeregistrationConfirmationEmailService).to receive(:new).and_return(deregistration_confirmation_email_service)
+        allow(deregistration_confirmation_email_service).to receive(:run)
+        allow(RegistrationEditConfirmationEmailService).to receive(:new).and_return(registration_edit_confirmation_email_service)
+        allow(registration_edit_confirmation_email_service).to receive(:run)
+      end
+
+      context "with no changes" do
+        it "does not modify the registration" do
+          expect { run_service }.not_to change(transient_registration, :updated_at)
+        end
+
+        it "does not send a deregistration confirmation email" do
+          run_service
+          expect(deregistration_confirmation_email_service).not_to have_received(:run)
+        end
+
+        it "does not send a registration edit confirmation email" do
+          run_service
+          expect(registration_edit_confirmation_email_service).not_to have_received(:run)
+        end
+
+        it "returns false" do
+          expect(run_service).to be false
+        end
+      end
+
+      context "with all exemptions removed" do
+        before do
+          transient_registration.exemptions = []
+          transient_registration.save!
+        end
+
+        # the registration does not have a status of its own; status is at the registration_exemption level
+        it "deactivates all exemptions for the registration" do
+          expect { run_service }.to change { registration.registration_exemptions.pluck(:state).uniq }
+            .from(["active"])
+            .to(["inactive"])
+        end
+
+        it "sets the deregistered_at timestamp for all exemptions" do
+          expect { run_service }.to change { registration.registration_exemptions.pluck(:deregistered_at).uniq }
+            .from([nil])
+            .to([Date.today])
+        end
+
+        it "sets the self-serve deregistration message for each registration_exemption" do
+          expect { run_service }.to change { registration.registration_exemptions.pluck(:deregistration_message).uniq }
+            .from([nil])
+            .to([I18n.t("self_serve_deregistration.message")])
+        end
+
+        with_versioning do
+          it "creates a new registration version" do
+            expect { run_service }.to change { registration.versions.count }.by(1)
+          end
+        end
+
+        it "sends a confirmation email" do
+          run_service
+          expect(deregistration_confirmation_email_service).to have_received(:run)
+        end
+
+        it "returns true" do
+          expect(run_service).to be true
+        end
+      end
+
+      context "with a subset of exemptions removed" do
+        let(:removed_exemption_ids) { [registration.registration_exemptions.first.exemption_id, registration.registration_exemptions.last.exemption_id] }
+
+        before do
+          transient_registration.exemptions = transient_registration.exemptions.reject do |tre|
+            removed_exemption_ids.include?(tre.id)
+          end
+          transient_registration.save!
+        end
+
+        it "removes the exemptions" do
+          expect { run_service }.to change { registration.registration_exemptions.where(state: "inactive").count }
+            .from(0)
+            .to(removed_exemption_ids.length)
+        end
+
+        it "deactivates the removed exemptions" do
+          expect { run_service }.to change { removed_registration_exemptions.pluck(:state).uniq }
+            .to(["inactive"])
+        end
+
+        it "sets the deregistered_at timestamp each removed exemption" do
+          expect { run_service }.to change { removed_registration_exemptions.pluck(:deregistered_at).uniq }
+            .to([Date.today])
+        end
+
+        it "sets the self-serve deregistration message for each removed exemption" do
+          expect { run_service }.to change { removed_registration_exemptions.pluck(:deregistration_message).uniq }
+            .to([I18n.t("self_serve_deregistration.message")])
+        end
+
+        it "does not modify the remaining exemptions" do
+          expect { run_service }.not_to change { (registration.exemptions - removed_registration_exemptions).pluck(:updated_at) }
+        end
+
+        with_versioning do
+          it "creates a new registration version" do
+            expect { run_service }.to change { registration.versions.count }.by(1)
+          end
+        end
+
+        it "sends a confirmation email" do
+          run_service
+          expect(registration_edit_confirmation_email_service).to have_received(:run)
+        end
+
+        it "returns true" do
+          expect(run_service).to be true
+        end
+      end
+
+      def removed_registration_exemptions
+        registration.reload.registration_exemptions.select { |ex| removed_exemption_ids.include?(ex.exemption_id) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change adds an exemption deregistration service which handles null, full and partial de-registrations:
* If the `transient_registration` has the same exemptions as the original registration, nothing happens.
* If the `transient_registration` has no exemptions, all exemptions  for the registration are deactivated with a `deregistered_at` value of today.
* If the `transient_registration` has a subset of the exemptions of the original registration, all unselected exemptions are set to "inactive" with a `deregistered_at` date of today and a `state` of "inactive". All selected exemptions remain unchanged.
https://eaflood.atlassian.net/browse/RUBY-2356