### PR TITLE
Remove reference to U1 exemptions on deregister flow

### DIFF
--- a/app/views/waste_exemptions_engine/confirm_edit_exemptions_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/confirm_edit_exemptions_forms/new.html.erb
@@ -11,8 +11,6 @@
         <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
       <% end %>
 
-      <p class="govuk-hint"><%= t(".description") %></p>
-
       <ul class="govuk-list">
         <% @confirm_edit_exemptions_form.transient_registration.excluded_exemptions.each do |exemption_id| %>
           <% exemption = WasteExemptionsEngine::Exemption.find_by(id: exemption_id) %>

--- a/app/views/waste_exemptions_engine/deregistration_complete_partial_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/deregistration_complete_partial_forms/new.html.erb
@@ -40,8 +40,7 @@
 
       <p class="govuk-body"><%= t(".confirmation_email_text", contact_email: @deregistration_complete_partial_form.contact_email) %></p>
       <p class="govuk-body"><%= t(".paragraph_1") %></p>
-      <p class="govuk-body"><%= t(".paragraph_2") %></p>
-      <p class="govuk-body"><%= t(".paragraph_3") %> <%= link_to(t(".survey_link"), t(".survey_link")) %></p>
+      <p class="govuk-body"><%= t(".paragraph_2") %> <%= link_to(t(".survey_link"), t(".survey_link")) %></p>
 
     <% end %>
   </div>

--- a/config/locales/forms/confirm_edit_exemptions_forms/en.yml
+++ b/config/locales/forms/confirm_edit_exemptions_forms/en.yml
@@ -5,7 +5,6 @@ en:
         back_link: Back
         heading: Are you sure you want to remove these exemptions?
         heading_deregister: Are you sure you want to deregister all of these exemptions and be removed from the public register?
-        description: You aren't allowed to de-register and then renew a U1 exemption at the same place within a 3 year period.
         legend: Confirm edit exemptions
         radio_yes: "Yes"
         radio_no: "No"

--- a/config/locales/forms/deregistration_complete_partial_forms/en.yml
+++ b/config/locales/forms/deregistration_complete_partial_forms/en.yml
@@ -8,9 +8,8 @@ en:
         highlight_text: Your registration number has not changed. It is
         subheading: What will happen next
         confirmation_email_text: We have sent a confirmation email to %{contact_email}
-        paragraph_1: You aren't allowed to de-register and then renew a U1 exemption at the same place within a 3 year period.
-        paragraph_2: We will add your changes to the public register, this could take up to 24 hours. This includes the name and address of the individual or organisation responsible, the site address and the remaining exemptions you have registered.
-        paragraph_3: Tell us your thoughts about this process -
+        paragraph_1: We will add your changes to the public register, this could take up to 24 hours. This includes the name and address of the individual or organisation responsible, the site address and the remaining exemptions you have registered.
+        paragraph_2: Tell us your thoughts about this process -
         survey_link: https://www.smartsurvey.co.uk/s/3S81FQ/
   activemodel:
     errors:

--- a/config/locales/forms/edit_exemptions_forms/en.yml
+++ b/config/locales/forms/edit_exemptions_forms/en.yml
@@ -5,7 +5,7 @@ en:
         title: Uncheck any exemptions that are no longer needed
         heading: Uncheck any exemptions that are no longer needed
         current_heading: Your current exemptions
-        description: Uncheck any exemptions that you don't need. You aren't allowed to de-register and then renew a U1 exemption at the same place within a 3 year period.
+        description: Uncheck any exemptions that you don't need.
         legend: Exemptions
         error_heading: A problem to fix
         next_button: Continue

--- a/spec/cassettes/w3c_valid_content/deregistration_complete_partial_forms_spec/when-the-registration-is-in-the-correct-state.yml
+++ b/spec/cassettes/w3c_valid_content/deregistration_complete_partial_forms_spec/when-the-registration-is-in-the-correct-state.yml
@@ -18,9 +18,7 @@ http_interactions:
         class=\"govuk-panel__body\">\n          <strong>\n            <span id=\"reg_identifier\">WEX000390</span>\n
         \         </strong>\n        </div>\n      </div>\n\n      <h2 class=\"govuk-heading-m\">What
         will happen next</h2>\n\n      <p class=\"govuk-body\">We have sent a confirmation
-        email to lavone@example.net</p>\n      <p class=\"govuk-body\">You aren&#39;t
-        allowed to de-register and then renew a U1 exemption at the same place within
-        a 3 year period.</p>\n      <p class=\"govuk-body\">We will add your changes
+        email to lavone@example.net</p>\n      <p class=\"govuk-body\">We will add your changes
         to the public register, this could take up to 24 hours. This includes the
         name and address of the individual or organisation responsible, the site address
         and the remaining exemptions you have registered.</p>\n      <p class=\"govuk-body\">Tell


### PR DESCRIPTION
This removes the text "You aren't allowed to de-register and then (renew) a U1 exemption at the same place within a 3-year period." from the requested pages
