### PR TITLE
fix deregistration_email_sent_at

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,7 +416,7 @@ GEM
     uniform_notifier (1.16.0)
     validates_email_format_of (1.7.2)
       i18n
-    vcr (6.1.0)
+    vcr (6.2.0)
     w3c_validators (1.3.7)
       json (>= 1.8)
       nokogiri (~> 1.6)


### PR DESCRIPTION
This change drops a migration which would have deleted registration.deregistration_email_sent_at.
https://eaflood.atlassian.net/browse/RUBY-2481