### PR TITLE
Fix/order edit exemptions

### DIFF
--- a/app/presenters/waste_exemptions_engine/certificate_presenter.rb
+++ b/app/presenters/waste_exemptions_engine/certificate_presenter.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
     end
 
     def human_business_type
-      I18n.t("waste_exemptions_engine.pdfs.certificate.busness_types.#{business_type}")
+      I18n.t("waste_exemptions_engine.pdfs.certificate.business_types.#{business_type}")
     end
 
     def contact_name

--- a/app/presenters/waste_exemptions_engine/registration_details_presenter.rb
+++ b/app/presenters/waste_exemptions_engine/registration_details_presenter.rb
@@ -88,7 +88,7 @@ module WasteExemptionsEngine
     # Business details
 
     def business_type_text
-      human_business_type = I18n.t("waste_exemptions_engine.pdfs.certificate.busness_types.#{business_type}")
+      human_business_type = I18n.t("waste_exemptions_engine.pdfs.certificate.business_types.#{business_type}")
       label_and_value("business_details.type", human_business_type)
     end
 

--- a/app/views/waste_exemptions_engine/edit_exemptions_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/edit_exemptions_forms/new.html.erb
@@ -20,7 +20,7 @@
           <% end %>
 
           <div class="govuk-checkboxes">
-            <% @edit_exemptions_form.registration.active_exemptions.each do |exemption|  %>
+            <% @edit_exemptions_form.registration.active_exemptions.sort_by { |x| x.code }.each do |exemption|  %>
               <div class="govuk-checkboxes__item">
                 <%= f.check_box :exemption_ids,
                     { :multiple => true,

--- a/config/locales/pdfs/certificate.en.yml
+++ b/config/locales/pdfs/certificate.en.yml
@@ -2,7 +2,7 @@ en:
   waste_exemptions_engine:
     pdfs:
       certificate:
-        busness_types:
+        business_types:
           soleTrader: Individual or sole trader
           limitedCompany: Limited company
           partnership: Partnership


### PR DESCRIPTION
This change orders the exemptions by exemption code on the edit exemptions page. This is necessary for the automated regression tests to pass consistently.
https://eaflood.atlassian.net/browse/RUBY-2689