### PR TITLE
Fix navigation from the confirm-edit-exemptions page

### DIFF
--- a/app/models/concerns/waste_exemptions_engine/can_use_front_office_edit_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_front_office_edit_registration_workflow.rb
@@ -67,8 +67,14 @@ module WasteExemptionsEngine
                       to: :confirm_edit_exemptions_form
 
           #   from confirm_edit_exemptions_form:
+          #     return to main edit page if exemption changes are confirmed
           transitions from: :confirm_edit_exemptions_form,
-                      to: :front_office_edit_form
+                      to: :front_office_edit_form,
+                      if: :exemption_edits_confirmed?
+
+          #     otherwise back to the edit exemptions page
+          transitions from: :confirm_edit_exemptions_form,
+                      to: :edit_exemptions_form
 
           #   from edit_exemptions_declaration_form:
           #     to registration complete only if all exemptions are being deregistered

--- a/spec/models/waste_exemptions_engine/front_office_edit_registration_workflow_state/confirm_edit_exemptions_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/front_office_edit_registration_workflow_state/confirm_edit_exemptions_form_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module WasteExemptionsEngine
   RSpec.describe ConfirmEditExemptionsForm do
-    subject(:form) { build(:confirm_edit_exemptions_form, front_office: true) }
+    subject(:form) { build(:confirm_edit_exemptions_form, transient_registration_factory: :front_office_edit_registration) }
 
     it "validates the form using the YesNoValidator class" do
       validators = form._validators

--- a/spec/requests/waste_exemptions_engine/confirm_edit_exemptions_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/confirm_edit_exemptions_forms_spec.rb
@@ -5,16 +5,8 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe "confirm edit exemptions form" do
     let(:request_path) { "/waste_exemptions_engine/#{form.token}/confirm-edit-exemptions" }
-    let(:form) { build(:confirm_edit_exemptions_form) }
-    let(:transient_registration) { form.transient_registration }
-    let(:exemptions) { transient_registration.exemptions }
-    let(:exemption_ids_to_remove) { [exemptions.first, exemptions.last].pluck(:id) }
-    let(:exemption_ids_to_retain) { (exemptions.pluck(:id) - exemption_ids_to_remove) }
-
-    before do
-      transient_registration.excluded_exemptions = exemption_ids_to_remove
-      transient_registration.save!
-    end
+    let(:transient_registration_factory) { :renewing_registration }
+    let(:form) { build(:confirm_edit_exemptions_form, transient_registration_factory:) }
 
     describe "#new" do
       it "renders the correct template" do
@@ -28,101 +20,127 @@ module WasteExemptionsEngine
     end
 
     describe "#create" do
-      context "when selecting the no option" do
-        let(:valid_params) do
-          {
-            confirm_edit_exemptions_form: {
-              exemption_ids: exemption_ids_to_retain,
-              temp_confirm_exemption_edits: "false"
+      shared_examples "common form submission behaviour" do
+        before do
+          transient_registration.excluded_exemptions = exemption_ids_to_remove
+          transient_registration.save!
+        end
+
+        let(:transient_registration) { form.transient_registration }
+        let(:exemptions) { transient_registration.exemptions }
+        let(:exemption_ids_to_remove) { [exemptions.first, exemptions.last].pluck(:id) }
+        let(:exemption_ids_to_retain) { (exemptions.pluck(:id) - exemption_ids_to_remove) }
+
+        context "when selecting the no option" do
+          let(:valid_params) do
+            {
+              confirm_edit_exemptions_form: {
+                exemption_ids: exemption_ids_to_retain,
+                temp_confirm_exemption_edits: "false"
+              }
             }
-          }
-        end
-
-        it "redirects to the correct workflow step" do
-          post request_path, params: valid_params
-
-          aggregate_failures do
-            expect(response).to have_http_status(:see_other)
-            expect(response).to redirect_to("/waste_exemptions_engine/#{form.token}/edit-exemptions")
           end
-        end
 
-        it "does not remove any exemptions" do
-          expect { post request_path, params: valid_params }
-            .not_to change { transient_registration.reload.exemptions.length }
-        end
-      end
-
-      context "when selecting the yes option" do
-        let(:valid_params) do
-          {
-            confirm_edit_exemptions_form: {
-              exemption_ids: exemption_ids_to_retain,
-              temp_confirm_exemption_edits: "true"
-            }
-          }
-        end
-
-        it "redirects to the correct workflow step" do
-          post request_path, params: valid_params
-
-          aggregate_failures do
-            expect(response).to have_http_status(:see_other)
-            expect(response).to redirect_to("/waste_exemptions_engine/#{form.token}/edit-exemptions-declaration")
-          end
-        end
-
-        it "removes the exemptions selected for removal" do
-          aggregate_failures do
-            previous_exemption_count = exemptions.count
-
+          it "redirects to the correct workflow step" do
             post request_path, params: valid_params
 
-            current_exemptions = transient_registration.reload.exemptions
+            aggregate_failures do
+              expect(response).to have_http_status(:see_other)
+              expect(response).to redirect_to("/waste_exemptions_engine/#{form.token}/edit-exemptions")
+            end
+          end
 
-            expect(current_exemptions.length).to eq(previous_exemption_count - 2)
-            expect(current_exemptions).not_to include(exemptions.first)
-            expect(current_exemptions).not_to include(exemptions.last)
+          it "does not remove any exemptions" do
+            expect { post request_path, params: valid_params }
+              .not_to change { transient_registration.reload.exemptions.length }
           end
         end
-      end
 
-      context "when an invalid option value has been provided" do
-        let(:invalid_params) do
-          {
-            confirm_edit_exemptions_form: {
-              temp_confirm_exemption_edits: nil
+        context "when selecting the yes option" do
+          let(:valid_params) do
+            {
+              confirm_edit_exemptions_form: {
+                exemption_ids: exemption_ids_to_retain,
+                temp_confirm_exemption_edits: "true"
+              }
             }
-          }
+          end
+
+          it "redirects to the correct workflow step" do
+            post request_path, params: valid_params
+
+            aggregate_failures do
+              expect(response).to have_http_status(:see_other)
+              expect(response).to redirect_to("/waste_exemptions_engine/#{form.token}/#{next_page_if_confirmed}")
+            end
+          end
+
+          it "removes the exemptions selected for removal" do
+            aggregate_failures do
+              previous_exemption_count = exemptions.count
+
+              post request_path, params: valid_params
+
+              current_exemptions = transient_registration.reload.exemptions
+
+              expect(current_exemptions.length).to eq(previous_exemption_count - 2)
+              expect(current_exemptions).not_to include(exemptions.first)
+              expect(current_exemptions).not_to include(exemptions.last)
+            end
+          end
         end
 
-        it "re-renders the new template and displays a validation error" do
-          post request_path, params: invalid_params
+        context "when an invalid option value has been provided" do
+          let(:invalid_params) do
+            {
+              confirm_edit_exemptions_form: {
+                temp_confirm_exemption_edits: nil
+              }
+            }
+          end
 
-          aggregate_failures do
-            expect(response).to have_http_status(:ok)
-            expect(response).to render_template("waste_exemptions_engine/confirm_edit_exemptions_forms/new")
-            expect(response.body).to have_html_escaped_string("You must select Yes or No")
+          it "re-renders the new template and displays a validation error" do
+            post request_path, params: invalid_params
+
+            aggregate_failures do
+              expect(response).to have_http_status(:ok)
+              expect(response).to render_template("waste_exemptions_engine/confirm_edit_exemptions_forms/new")
+              expect(response.body).to have_html_escaped_string("You must select Yes or No")
+            end
+          end
+        end
+
+        context "when no workflow_state has been provided" do
+          let(:invalid_params) do
+            {
+              confirm_edit_exemptions_form: {}
+            }
+          end
+
+          it "re-renders the new template and displays a validation error" do
+            post request_path, params: invalid_params
+
+            aggregate_failures do
+              expect(response).to have_http_status(:ok)
+              expect(response).to render_template("waste_exemptions_engine/confirm_edit_exemptions_forms/new")
+              expect(response.body).to have_html_escaped_string("You must select Yes or No")
+            end
           end
         end
       end
 
-      context "when no workflow_state has been provided" do
-        let(:invalid_params) do
-          {
-            confirm_edit_exemptions_form: {}
-          }
-        end
+      context "with a renewing registration" do
+        let(:transient_registration_factory) { :renewing_registration }
+        let(:next_page_if_confirmed) { "edit-exemptions-declaration" }
 
-        it "re-renders the new template and displays a validation error" do
-          post request_path, params: invalid_params
+        it_behaves_like "common form submission behaviour"
+      end
 
-          aggregate_failures do
-            expect(response).to have_http_status(:ok)
-            expect(response).to render_template("waste_exemptions_engine/confirm_edit_exemptions_forms/new")
-            expect(response.body).to have_html_escaped_string("You must select Yes or No")
-          end
-        end
+      context "with a front-office edit registration" do
+        let(:transient_registration_factory) { :front_office_edit_registration }
+        let(:next_page_if_confirmed) { "fo_edit" }
+
+        it_behaves_like "common form submission behaviour"
       end
     end
   end

--- a/spec/support/factories/forms/confirm_edit_exemptions_form.rb
+++ b/spec/support/factories/forms/confirm_edit_exemptions_form.rb
@@ -4,12 +4,11 @@ FactoryBot.define do
   factory :confirm_edit_exemptions_form, class: "WasteExemptionsEngine::ConfirmEditExemptionsForm" do
     # default to a renewing_registration and allow override to a front_office_edit_registration
     transient do
-      front_office { false }
+      transient_registration_factory { :renewing_registration }
     end
 
     initialize_with do
-      factory = front_office ? :front_office_edit_registration : :renewing_registration
-      new(create(factory, workflow_state: "confirm_edit_exemptions_form"))
+      new(create(transient_registration_factory, workflow_state: "confirm_edit_exemptions_form"))
     end
   end
 end


### PR DESCRIPTION
This change fixes an issue with navigation from the confirm-edit-exemptions page when the user selects "No".
https://eaflood.atlassian.net/browse/RUBY-2561