### PR TITLE
Fix/self serve edit issues

### DIFF
--- a/app/controllers/waste_exemptions_engine/front_office_edit_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/front_office_edit_forms_controller.rb
@@ -41,11 +41,13 @@ module WasteExemptionsEngine
     private
 
     def registration
-      @registration ||= Registration.where(edit_token: params[:edit_token]).first
+      @registration ||= Registration.where(edit_token: params[:edit_token].split("/")[0]).first
     end
 
     def token_expired?
-      registration.edit_token_created_at < ENV.fetch("EDIT_TOKEN_VALIDITY_HOURS", 48).to_i.hours.ago
+      return false unless @registration.present?
+
+      @registration.edit_token_created_at < ENV.fetch("EDIT_TOKEN_VALIDITY_HOURS", 48).to_i.hours.ago
     end
 
     def transition_to_edit(transition)

--- a/app/forms/waste_exemptions_engine/capture_email_form.rb
+++ b/app/forms/waste_exemptions_engine/capture_email_form.rb
@@ -8,7 +8,7 @@ module WasteExemptionsEngine
     validates_with DefraRuby::Validators::EmailValidator, attributes: [:contact_email]
 
     def submit(params)
-      self.contact_email = params[:contact_email]
+      self.contact_email = params[:contact_email].strip
 
       super(params.permit(:reference, :contact_email))
     end

--- a/app/models/concerns/waste_exemptions_engine/can_use_front_office_edit_registration_workflow.rb
+++ b/app/models/concerns/waste_exemptions_engine/can_use_front_office_edit_registration_workflow.rb
@@ -67,6 +67,11 @@ module WasteExemptionsEngine
                       to: :confirm_edit_exemptions_form
 
           #   from confirm_edit_exemptions_form:
+          #     to edit exemptions declaration page if exemption changes are confirmed AND all exemptions deregistered
+          transitions from: :confirm_edit_exemptions_form,
+                      to: :edit_exemptions_declaration_form,
+                      if: :full_deregistration_confirmed?
+
           #     return to main edit page if exemption changes are confirmed
           transitions from: :confirm_edit_exemptions_form,
                       to: :front_office_edit_form,
@@ -123,6 +128,10 @@ module WasteExemptionsEngine
 
       def exemption_edits_confirmed?
         temp_confirm_exemption_edits == true
+      end
+
+      def full_deregistration_confirmed?
+        exemption_edits_confirmed? && all_exemptions_deregistered?
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/app/views/waste_exemptions_engine/edit_exemptions_declaration_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/edit_exemptions_declaration_forms/new.html.erb
@@ -10,13 +10,14 @@
           legend: { text:  t(".heading"), size: "l", tag: "h1" } do %>
 
         <p class="govuk-body">
-          <%= t(".notice") %>
+          <strong> <%= t(".notice") %> </strong>
         </p>
 
         <ul class="govuk-list govuk-list--bullet">
           <li><%= t(".list_item_1") %></li>
           <li><%= t(".list_item_2") %></li>
           <li><%= t(".list_item_3") %></li>
+          <li><%= t(".list_item_4") %></li>
         </ul>
 
         <%= f.govuk_check_box :declaration,

--- a/app/views/waste_exemptions_engine/edit_exemptions_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/edit_exemptions_forms/new.html.erb
@@ -39,7 +39,11 @@
 
       <%= f.govuk_submit %>
 
-      <p class="govuk-hint"><%= t(".guidance_text") %> <%= link_to t(".guidance_link_text"), t(".guidance_link") %></p>
+      <p class="govuk-hint">
+        <%= t(".guidance_text") %>
+        <%= link_to t(".guidance_link_text"), t(".guidance_link"), target: "_blank" %>
+        <%= t(".guidance_link_hint") %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/waste_exemptions_engine/front_office_edit_complete_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/front_office_edit_complete_forms/new.html.erb
@@ -25,7 +25,7 @@
       <br/>
 
       <p class="govuk-body"><%= t(".survey_link_text") %></p>
-      <p class="govuk-body"><%= link_to(t(".survey_link_url"), target: "_blank") %> <%= t(".survey_link_hint") %></p>
+      <p class="govuk-body"><%= link_to(t(".survey_link_url"), t(".survey_link_url"), target: "_blank") %> <%= t(".survey_link_hint") %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/waste_exemptions_engine/renew_exemptions_forms/new.html.erb
+++ b/app/views/waste_exemptions_engine/renew_exemptions_forms/new.html.erb
@@ -39,7 +39,11 @@
 
       <%= f.govuk_submit %>
 
-      <p class="govuk-hint"><%= t(".guidance_text") %> <%= link_to t(".guidance_link_text"), t(".guidance_link") %></p>
+      <p class="govuk-hint">
+        <%= t(".guidance_text") %>
+        <%= link_to t(".guidance_link_text"), t(".guidance_link"), target: "_blank" %>
+        <%= t(".guidance_link_hint") %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/config/locales/forms/edit_exemptions_declaration_forms/en.yml
+++ b/config/locales/forms/edit_exemptions_declaration_forms/en.yml
@@ -7,7 +7,8 @@ en:
         notice: "I confirm that either:"
         list_item_1: the waste operation(s) deregistered are no longer in operation at the place stated in our exemption registration / renewal
         list_item_2: the deregistered activity(s) no longer meets the requirements of exemptions from environmental permitting
-        list_item_3: the exemption was registered in error
+        list_item_3: the exemption waste operation(s) were registered in error
+        list_item_4: the contact details are up to date
         declaration_text: I understand and agree with the declaration above. You can be fined if you provide false or misleading information
         privacy_link_text: "Privacy: how we use your personal information (opens new tab)"
         error_heading: A problem to fix

--- a/config/locales/forms/edit_exemptions_forms/en.yml
+++ b/config/locales/forms/edit_exemptions_forms/en.yml
@@ -12,6 +12,7 @@ en:
         guidance_text: You can get guidance about exemptions at
         guidance_link_text: GovUK
         guidance_link: https://www.gov.uk/guidance/register-your-waste-exemptions-environmental-permits#choose
+        guidance_link_hint: (opens in a new window)
   activemodel:
     errors:
       models:

--- a/config/locales/forms/renew_exemptions_forms/en.yml
+++ b/config/locales/forms/renew_exemptions_forms/en.yml
@@ -12,6 +12,7 @@ en:
         guidance_text: You can get guidance about exemptions at
         guidance_link_text: GovUK
         guidance_link: https://www.gov.uk/guidance/register-your-waste-exemptions-environmental-permits#choose
+        guidance_link_hint: (opens in a new window)
   activemodel:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -481,7 +481,8 @@ WasteExemptionsEngine::Engine.routes.draw do
   get "/edit_registration/:edit_token",
       constraints: { edit_token: /.*/ },
       to: "front_office_edit_forms#validate_edit_token",
-      as: "validate_edit_token"
+      as: "validate_edit_token",
+      defaults: { format: :html }
 
   # Static pages with HighVoltage
   resources :pages, only: [:show], controller: "pages"

--- a/spec/cassettes/w3c_valid_content/front_office_edit_complete_forms_spec/GET-front_office_edit_complete_form.yml
+++ b/spec/cassettes/w3c_valid_content/front_office_edit_complete_forms_spec/GET-front_office_edit_complete_form.yml
@@ -10,22 +10,23 @@ http_interactions:
         media=\"all\" data-turbolinks-track=\"true\" />\n  <script src=\"/assets/application-e7473747669b589218de86035464048c90a00729227c3a03fb2b03b020fd274f.js\"
         data-turbolinks-track=\"true\"></script>\n  \n</head>\n<body>\n\n\n<div class=\"govuk-grid-row\">\n
         \ <div class=\"govuk-grid-column-two-thirds\">\n    <form class=\"new_front_office_edit_complete_form\"
-        id=\"new_front_office_edit_complete_form\" action=\"/waste_exemptions_engine/c6cX1rtb3oL4V2ekzTikbv1P/front-office-edit-complete\"
+        id=\"new_front_office_edit_complete_form\" action=\"/waste_exemptions_engine/dVMu27CNVA7AWS6FV2c89XCd/front-office-edit-complete\"
         accept-charset=\"UTF-8\" method=\"post\">\n      <div class=\"govuk-grid-row\">\n
         \ <div class=\"govuk-grid-column-two-thirds\">\n    \n  </div>\n</div>\n\n\n
         \     <div class=\"govuk-panel govuk-panel--confirmation\">\n        <h1 class=\"govuk-panel__title\">\n
         \         You have successfully updated your registration details\n          <br
         />\n          <span class=\"govuk-panel__body\">Your registration number has
         not changed. It is</span>\n        </h1>\n        <div class=\"govuk-panel__body\">\n
-        \         <strong>\n            <span id=\"reg_identifier\">WEX000001</span>\n
+        \         <strong>\n            <span id=\"reg_identifier\">WEX000794</span>\n
         \         </strong>\n        </div>\n      </div>\n\n      <p class=\"govuk-body\">We
-        have sent a confirmation email to %{contact_email}</p>\n\n      <p class=\"govuk-body\">We
-        will add your changes to the public register, this could take up to 24 hours.
-        This includes\nthe name and address of the individual or organisation responsible,
-        the site address and the\nremaining exemptions you have registered. Updating
-        your details will not extend the length of\nyour registration.\n</p>\n\n      <br/>\n\n
-        \     <p class=\"govuk-body\">You can send us feedback about this process
-        at</p>\n      <p class=\"govuk-body\"><a href=\"/waste_exemptions_engine/c6cX1rtb3oL4V2ekzTikbv1P/front-office-edit-complete?target=_blank\">https://www.smartsurvey.co.uk/s/3S81FQ/</a>
+        have sent a confirmation email to marc.mccullough@rutherford-howe.test</p>\n\n
+        \     <p class=\"govuk-body\">We will add your changes to the public register,
+        this could take up to 24 hours. This includes\nthe name and address of the
+        individual or organisation responsible, the site address and the\nremaining
+        exemptions you have registered. Updating your details will not extend the
+        length of\nyour registration.\n</p>\n\n      <br/>\n\n      <p class=\"govuk-body\">You
+        can send us feedback about this process at</p>\n      <p class=\"govuk-body\"><a
+        target=\"_blank\" href=\"https://www.smartsurvey.co.uk/s/3S81FQ/\">https://www.smartsurvey.co.uk/s/3S81FQ/</a>
         (opens in a new window)</p>\n</form>  </div>\n</div>\n\n\n</body>\n</html>\n"
     headers:
       Content-Type:
@@ -42,7 +43,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 04 Aug 2023 07:52:16 GMT
+      - Thu, 21 Sep 2023 18:39:55 GMT
       Content-Type:
       - application/json;charset=utf-8
       Transfer-Encoding:
@@ -71,22 +72,22 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - 7f15384ddc6935bc
+      - 80a46eff393e412e
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=X5lGNfiayAdTx8LMMVzZHLGlZjaN_0pqcgsPSy5Dlhs-1691135536-0-ASk/DXT+vBBifRKpMeGjFNpSsu9ejPfMhGQlLlQqbreCWB0gihFq5s8fg1xMFfUVz4PrmGsvnI5Yj7NxYslu+UI=;
-        path=/; expires=Fri, 04-Aug-23 08:22:16 GMT; domain=.w3.org; HttpOnly; Secure;
+      - __cf_bm=XmFketKDri_eFRBgsaucUpbbEmo7nziiypLTuM1OlJM-1695321595-0-Acntql5vTU0XuIgO1t8Awfig6WOVbOxbhO+i/eBGx+L/ATXox1R6U7q2Lq9K6nceL4BTJ21i/znVtLhjZYiu9J8=;
+        path=/; expires=Thu, 21-Sep-23 19:09:55 GMT; domain=.w3.org; HttpOnly; Secure;
         SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 7f15384ddc6935bc-LHR
+      - 80a46eff393e412e-LHR
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6NSwibGFzdENvbHVtbiI6MTY0LCJmaXJzdENvbHVtbiI6MywibWVzc2FnZSI6IlRyYWlsaW5nIHNsYXNoIG9uIHZvaWQgZWxlbWVudHMgaGFzIG5vIGVmZmVjdCBhbmQgaW50ZXJhY3RzIGJhZGx5IHdpdGggdW5xdW90ZWQgYXR0cmlidXRlIHZhbHVlcy4iLCJleHRyYWN0IjoiL3RpdGxlPlxuICA8bGluayByZWw9XCJzdHlsZXNoZWV0XCIgaHJlZj1cIi9hc3NldHMvYXBwbGljYXRpb24tZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NS5jc3NcIiBtZWRpYT1cImFsbFwiIGRhdGEtdHVyYm9saW5rcy10cmFjaz1cInRydWVcIiAvPlxuICA8c2MiLCJoaWxpdGVTdGFydCI6MTAsImhpbGl0ZUxlbmd0aCI6MTYyfSx7InR5cGUiOiJpbmZvIiwibGFzdExpbmUiOjI1LCJsYXN0Q29sdW1uIjoxNiwiZmlyc3RDb2x1bW4iOjExLCJtZXNzYWdlIjoiVHJhaWxpbmcgc2xhc2ggb24gdm9pZCBlbGVtZW50cyBoYXMgbm8gZWZmZWN0IGFuZCBpbnRlcmFjdHMgYmFkbHkgd2l0aCB1bnF1b3RlZCBhdHRyaWJ1dGUgdmFsdWVzLiIsImV4dHJhY3QiOiIgICAgICAgICAgPGJyIC8+XG4gICAgICIsImhpbGl0ZVN0YXJ0IjoxMCwiaGlsaXRlTGVuZ3RoIjo2fSx7InR5cGUiOiJpbmZvIiwibGFzdExpbmUiOjQzLCJsYXN0Q29sdW1uIjoxMSwiZmlyc3RDb2x1bW4iOjcsIm1lc3NhZ2UiOiJUcmFpbGluZyBzbGFzaCBvbiB2b2lkIGVsZW1lbnRzIGhhcyBubyBlZmZlY3QgYW5kIGludGVyYWN0cyBiYWRseSB3aXRoIHVucXVvdGVkIGF0dHJpYnV0ZSB2YWx1ZXMuIiwiZXh0cmFjdCI6InA+XG5cbiAgICAgIDxici8+XG5cbiAgICAiLCJoaWxpdGVTdGFydCI6MTAsImhpbGl0ZUxlbmd0aCI6NX0seyJ0eXBlIjoiaW5mbyIsImxhc3RMaW5lIjoyLCJmaXJzdExpbmUiOjEsImxhc3RDb2x1bW4iOjYsImZpcnN0Q29sdW1uIjoxNiwic3ViVHlwZSI6Indhcm5pbmciLCJtZXNzYWdlIjoiQ29uc2lkZXIgYWRkaW5nIGEg4oCcbGFuZ+KAnSBhdHRyaWJ1dGUgdG8gdGhlIOKAnGh0bWzigJ0gc3RhcnQgdGFnIHRvIGRlY2xhcmUgdGhlIGxhbmd1YWdlIG9mIHRoaXMgZG9jdW1lbnQuIiwiZXh0cmFjdCI6IlRZUEUgaHRtbD5cbjxodG1sPlxuPGhlYWQiLCJoaWxpdGVTdGFydCI6MTAsImhpbGl0ZUxlbmd0aCI6N31dLCJzb3VyY2UiOnsidHlwZSI6InRleHQvaHRtbCIsImVuY29kaW5nIjoiVVRGLTgiLCJjb2RlIjoiPCFET0NUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkPlxuICA8dGl0bGU+RHVtbXk8L3RpdGxlPlxuICA8bGluayByZWw9XCJzdHlsZXNoZWV0XCIgaHJlZj1cIi9hc3NldHMvYXBwbGljYXRpb24tZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NS5jc3NcIiBtZWRpYT1cImFsbFwiIGRhdGEtdHVyYm9saW5rcy10cmFjaz1cInRydWVcIiAvPlxuICA8c2NyaXB0IHNyYz1cIi9hc3NldHMvYXBwbGljYXRpb24tZTc0NzM3NDc2NjliNTg5MjE4ZGU4NjAzNTQ2NDA0OGM5MGEwMDcyOTIyN2MzYTAzZmIyYjAzYjAyMGZkMjc0Zi5qc1wiIGRhdGEtdHVyYm9saW5rcy10cmFjaz1cInRydWVcIj48L3NjcmlwdD5cbiAgXG48L2hlYWQ+XG48Ym9keT5cblxuXG48ZGl2IGNsYXNzPVwiZ292dWstZ3JpZC1yb3dcIj5cbiAgPGRpdiBjbGFzcz1cImdvdnVrLWdyaWQtY29sdW1uLXR3by10aGlyZHNcIj5cbiAgICA8Zm9ybSBjbGFzcz1cIm5ld19mcm9udF9vZmZpY2VfZWRpdF9jb21wbGV0ZV9mb3JtXCIgaWQ9XCJuZXdfZnJvbnRfb2ZmaWNlX2VkaXRfY29tcGxldGVfZm9ybVwiIGFjdGlvbj1cIi93YXN0ZV9leGVtcHRpb25zX2VuZ2luZS9jNmNYMXJ0YjNvTDRWMmVrelRpa2J2MVAvZnJvbnQtb2ZmaWNlLWVkaXQtY29tcGxldGVcIiBhY2NlcHQtY2hhcnNldD1cIlVURi04XCIgbWV0aG9kPVwicG9zdFwiPlxuICAgICAgPGRpdiBjbGFzcz1cImdvdnVrLWdyaWQtcm93XCI+XG4gIDxkaXYgY2xhc3M9XCJnb3Z1ay1ncmlkLWNvbHVtbi10d28tdGhpcmRzXCI+XG4gICAgXG4gIDwvZGl2PlxuPC9kaXY+XG5cblxuICAgICAgPGRpdiBjbGFzcz1cImdvdnVrLXBhbmVsIGdvdnVrLXBhbmVsLS1jb25maXJtYXRpb25cIj5cbiAgICAgICAgPGgxIGNsYXNzPVwiZ292dWstcGFuZWxfX3RpdGxlXCI+XG4gICAgICAgICAgWW91IGhhdmUgc3VjY2Vzc2Z1bGx5IHVwZGF0ZWQgeW91ciByZWdpc3RyYXRpb24gZGV0YWlsc1xuICAgICAgICAgIDxiciAvPlxuICAgICAgICAgIDxzcGFuIGNsYXNzPVwiZ292dWstcGFuZWxfX2JvZHlcIj5Zb3VyIHJlZ2lzdHJhdGlvbiBudW1iZXIgaGFzIG5vdCBjaGFuZ2VkLiBJdCBpczwvc3Bhbj5cbiAgICAgICAgPC9oMT5cbiAgICAgICAgPGRpdiBjbGFzcz1cImdvdnVrLXBhbmVsX19ib2R5XCI+XG4gICAgICAgICAgPHN0cm9uZz5cbiAgICAgICAgICAgIDxzcGFuIGlkPVwicmVnX2lkZW50aWZpZXJcIj5XRVgwMDAwMDE8L3NwYW4+XG4gICAgICAgICAgPC9zdHJvbmc+XG4gICAgICAgIDwvZGl2PlxuICAgICAgPC9kaXY+XG5cbiAgICAgIDxwIGNsYXNzPVwiZ292dWstYm9keVwiPldlIGhhdmUgc2VudCBhIGNvbmZpcm1hdGlvbiBlbWFpbCB0byAle2NvbnRhY3RfZW1haWx9PC9wPlxuXG4gICAgICA8cCBjbGFzcz1cImdvdnVrLWJvZHlcIj5XZSB3aWxsIGFkZCB5b3VyIGNoYW5nZXMgdG8gdGhlIHB1YmxpYyByZWdpc3RlciwgdGhpcyBjb3VsZCB0YWtlIHVwIHRvIDI0IGhvdXJzLiBUaGlzIGluY2x1ZGVzXG50aGUgbmFtZSBhbmQgYWRkcmVzcyBvZiB0aGUgaW5kaXZpZHVhbCBvciBvcmdhbmlzYXRpb24gcmVzcG9uc2libGUsIHRoZSBzaXRlIGFkZHJlc3MgYW5kIHRoZVxucmVtYWluaW5nIGV4ZW1wdGlvbnMgeW91IGhhdmUgcmVnaXN0ZXJlZC4gVXBkYXRpbmcgeW91ciBkZXRhaWxzIHdpbGwgbm90IGV4dGVuZCB0aGUgbGVuZ3RoIG9mXG55b3VyIHJlZ2lzdHJhdGlvbi5cbjwvcD5cblxuICAgICAgPGJyLz5cblxuICAgICAgPHAgY2xhc3M9XCJnb3Z1ay1ib2R5XCI+WW91IGNhbiBzZW5kIHVzIGZlZWRiYWNrIGFib3V0IHRoaXMgcHJvY2VzcyBhdDwvcD5cbiAgICAgIDxwIGNsYXNzPVwiZ292dWstYm9keVwiPjxhIGhyZWY9XCIvd2FzdGVfZXhlbXB0aW9uc19lbmdpbmUvYzZjWDFydGIzb0w0VjJla3pUaWtidjFQL2Zyb250LW9mZmljZS1lZGl0LWNvbXBsZXRlP3RhcmdldD1fYmxhbmtcIj5odHRwczovL3d3dy5zbWFydHN1cnZleS5jby51ay9zLzNTODFGUS88L2E+IChvcGVucyBpbiBhIG5ldyB3aW5kb3cpPC9wPlxuPC9mb3JtPiAgPC9kaXY+XG48L2Rpdj5cblxuXG48L2JvZHk+XG48L2h0bWw+In19Cg==
-  recorded_at: Fri, 04 Aug 2023 07:52:14 GMT
+        eyJtZXNzYWdlcyI6W3sidHlwZSI6ImluZm8iLCJsYXN0TGluZSI6NSwibGFzdENvbHVtbiI6MTY0LCJmaXJzdENvbHVtbiI6MywibWVzc2FnZSI6IlRyYWlsaW5nIHNsYXNoIG9uIHZvaWQgZWxlbWVudHMgaGFzIG5vIGVmZmVjdCBhbmQgaW50ZXJhY3RzIGJhZGx5IHdpdGggdW5xdW90ZWQgYXR0cmlidXRlIHZhbHVlcy4iLCJleHRyYWN0IjoiL3RpdGxlPlxuICA8bGluayByZWw9XCJzdHlsZXNoZWV0XCIgaHJlZj1cIi9hc3NldHMvYXBwbGljYXRpb24tZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NS5jc3NcIiBtZWRpYT1cImFsbFwiIGRhdGEtdHVyYm9saW5rcy10cmFjaz1cInRydWVcIiAvPlxuICA8c2MiLCJoaWxpdGVTdGFydCI6MTAsImhpbGl0ZUxlbmd0aCI6MTYyfSx7InR5cGUiOiJpbmZvIiwibGFzdExpbmUiOjI1LCJsYXN0Q29sdW1uIjoxNiwiZmlyc3RDb2x1bW4iOjExLCJtZXNzYWdlIjoiVHJhaWxpbmcgc2xhc2ggb24gdm9pZCBlbGVtZW50cyBoYXMgbm8gZWZmZWN0IGFuZCBpbnRlcmFjdHMgYmFkbHkgd2l0aCB1bnF1b3RlZCBhdHRyaWJ1dGUgdmFsdWVzLiIsImV4dHJhY3QiOiIgICAgICAgICAgPGJyIC8+XG4gICAgICIsImhpbGl0ZVN0YXJ0IjoxMCwiaGlsaXRlTGVuZ3RoIjo2fSx7InR5cGUiOiJpbmZvIiwibGFzdExpbmUiOjQzLCJsYXN0Q29sdW1uIjoxMSwiZmlyc3RDb2x1bW4iOjcsIm1lc3NhZ2UiOiJUcmFpbGluZyBzbGFzaCBvbiB2b2lkIGVsZW1lbnRzIGhhcyBubyBlZmZlY3QgYW5kIGludGVyYWN0cyBiYWRseSB3aXRoIHVucXVvdGVkIGF0dHJpYnV0ZSB2YWx1ZXMuIiwiZXh0cmFjdCI6InA+XG5cbiAgICAgIDxici8+XG5cbiAgICAiLCJoaWxpdGVTdGFydCI6MTAsImhpbGl0ZUxlbmd0aCI6NX0seyJ0eXBlIjoiaW5mbyIsImxhc3RMaW5lIjoyLCJmaXJzdExpbmUiOjEsImxhc3RDb2x1bW4iOjYsImZpcnN0Q29sdW1uIjoxNiwic3ViVHlwZSI6Indhcm5pbmciLCJtZXNzYWdlIjoiQ29uc2lkZXIgYWRkaW5nIGEg4oCcbGFuZ+KAnSBhdHRyaWJ1dGUgdG8gdGhlIOKAnGh0bWzigJ0gc3RhcnQgdGFnIHRvIGRlY2xhcmUgdGhlIGxhbmd1YWdlIG9mIHRoaXMgZG9jdW1lbnQuIiwiZXh0cmFjdCI6IlRZUEUgaHRtbD5cbjxodG1sPlxuPGhlYWQiLCJoaWxpdGVTdGFydCI6MTAsImhpbGl0ZUxlbmd0aCI6N31dLCJzb3VyY2UiOnsidHlwZSI6InRleHQvaHRtbCIsImVuY29kaW5nIjoiVVRGLTgiLCJjb2RlIjoiPCFET0NUWVBFIGh0bWw+XG48aHRtbD5cbjxoZWFkPlxuICA8dGl0bGU+RHVtbXk8L3RpdGxlPlxuICA8bGluayByZWw9XCJzdHlsZXNoZWV0XCIgaHJlZj1cIi9hc3NldHMvYXBwbGljYXRpb24tZTNiMGM0NDI5OGZjMWMxNDlhZmJmNGM4OTk2ZmI5MjQyN2FlNDFlNDY0OWI5MzRjYTQ5NTk5MWI3ODUyYjg1NS5jc3NcIiBtZWRpYT1cImFsbFwiIGRhdGEtdHVyYm9saW5rcy10cmFjaz1cInRydWVcIiAvPlxuICA8c2NyaXB0IHNyYz1cIi9hc3NldHMvYXBwbGljYXRpb24tZTc0NzM3NDc2NjliNTg5MjE4ZGU4NjAzNTQ2NDA0OGM5MGEwMDcyOTIyN2MzYTAzZmIyYjAzYjAyMGZkMjc0Zi5qc1wiIGRhdGEtdHVyYm9saW5rcy10cmFjaz1cInRydWVcIj48L3NjcmlwdD5cbiAgXG48L2hlYWQ+XG48Ym9keT5cblxuXG48ZGl2IGNsYXNzPVwiZ292dWstZ3JpZC1yb3dcIj5cbiAgPGRpdiBjbGFzcz1cImdvdnVrLWdyaWQtY29sdW1uLXR3by10aGlyZHNcIj5cbiAgICA8Zm9ybSBjbGFzcz1cIm5ld19mcm9udF9vZmZpY2VfZWRpdF9jb21wbGV0ZV9mb3JtXCIgaWQ9XCJuZXdfZnJvbnRfb2ZmaWNlX2VkaXRfY29tcGxldGVfZm9ybVwiIGFjdGlvbj1cIi93YXN0ZV9leGVtcHRpb25zX2VuZ2luZS9kVk11MjdDTlZBN0FXUzZGVjJjODlYQ2QvZnJvbnQtb2ZmaWNlLWVkaXQtY29tcGxldGVcIiBhY2NlcHQtY2hhcnNldD1cIlVURi04XCIgbWV0aG9kPVwicG9zdFwiPlxuICAgICAgPGRpdiBjbGFzcz1cImdvdnVrLWdyaWQtcm93XCI+XG4gIDxkaXYgY2xhc3M9XCJnb3Z1ay1ncmlkLWNvbHVtbi10d28tdGhpcmRzXCI+XG4gICAgXG4gIDwvZGl2PlxuPC9kaXY+XG5cblxuICAgICAgPGRpdiBjbGFzcz1cImdvdnVrLXBhbmVsIGdvdnVrLXBhbmVsLS1jb25maXJtYXRpb25cIj5cbiAgICAgICAgPGgxIGNsYXNzPVwiZ292dWstcGFuZWxfX3RpdGxlXCI+XG4gICAgICAgICAgWW91IGhhdmUgc3VjY2Vzc2Z1bGx5IHVwZGF0ZWQgeW91ciByZWdpc3RyYXRpb24gZGV0YWlsc1xuICAgICAgICAgIDxiciAvPlxuICAgICAgICAgIDxzcGFuIGNsYXNzPVwiZ292dWstcGFuZWxfX2JvZHlcIj5Zb3VyIHJlZ2lzdHJhdGlvbiBudW1iZXIgaGFzIG5vdCBjaGFuZ2VkLiBJdCBpczwvc3Bhbj5cbiAgICAgICAgPC9oMT5cbiAgICAgICAgPGRpdiBjbGFzcz1cImdvdnVrLXBhbmVsX19ib2R5XCI+XG4gICAgICAgICAgPHN0cm9uZz5cbiAgICAgICAgICAgIDxzcGFuIGlkPVwicmVnX2lkZW50aWZpZXJcIj5XRVgwMDA3OTQ8L3NwYW4+XG4gICAgICAgICAgPC9zdHJvbmc+XG4gICAgICAgIDwvZGl2PlxuICAgICAgPC9kaXY+XG5cbiAgICAgIDxwIGNsYXNzPVwiZ292dWstYm9keVwiPldlIGhhdmUgc2VudCBhIGNvbmZpcm1hdGlvbiBlbWFpbCB0byBtYXJjLm1jY3VsbG91Z2hAcnV0aGVyZm9yZC1ob3dlLnRlc3Q8L3A+XG5cbiAgICAgIDxwIGNsYXNzPVwiZ292dWstYm9keVwiPldlIHdpbGwgYWRkIHlvdXIgY2hhbmdlcyB0byB0aGUgcHVibGljIHJlZ2lzdGVyLCB0aGlzIGNvdWxkIHRha2UgdXAgdG8gMjQgaG91cnMuIFRoaXMgaW5jbHVkZXNcbnRoZSBuYW1lIGFuZCBhZGRyZXNzIG9mIHRoZSBpbmRpdmlkdWFsIG9yIG9yZ2FuaXNhdGlvbiByZXNwb25zaWJsZSwgdGhlIHNpdGUgYWRkcmVzcyBhbmQgdGhlXG5yZW1haW5pbmcgZXhlbXB0aW9ucyB5b3UgaGF2ZSByZWdpc3RlcmVkLiBVcGRhdGluZyB5b3VyIGRldGFpbHMgd2lsbCBub3QgZXh0ZW5kIHRoZSBsZW5ndGggb2ZcbnlvdXIgcmVnaXN0cmF0aW9uLlxuPC9wPlxuXG4gICAgICA8YnIvPlxuXG4gICAgICA8cCBjbGFzcz1cImdvdnVrLWJvZHlcIj5Zb3UgY2FuIHNlbmQgdXMgZmVlZGJhY2sgYWJvdXQgdGhpcyBwcm9jZXNzIGF0PC9wPlxuICAgICAgPHAgY2xhc3M9XCJnb3Z1ay1ib2R5XCI+PGEgdGFyZ2V0PVwiX2JsYW5rXCIgaHJlZj1cImh0dHBzOi8vd3d3LnNtYXJ0c3VydmV5LmNvLnVrL3MvM1M4MUZRL1wiPmh0dHBzOi8vd3d3LnNtYXJ0c3VydmV5LmNvLnVrL3MvM1M4MUZRLzwvYT4gKG9wZW5zIGluIGEgbmV3IHdpbmRvdyk8L3A+XG48L2Zvcm0+ICA8L2Rpdj5cbjwvZGl2PlxuXG5cbjwvYm9keT5cbjwvaHRtbD4ifX0K
+  recorded_at: Thu, 21 Sep 2023 18:39:54 GMT
 recorded_with: VCR 6.2.0

--- a/spec/forms/waste_exemptions_engine/capture_email_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/capture_email_form_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe CaptureEmailForm, type: :model do
+    subject(:form) { build(:capture_email_form, contact_email: contact_email) }
+    let(:contact_email) { "foo@example.com" }
+    let(:params) { { contact_email: contact_email } }
+
+    it "validates the contact_email field using the DefraRuby::Validators::EmailValidator class" do
+      validators = form._validators
+      expect(validators.keys).to include(:contact_email)
+      expect(validators[:contact_email].first.class).to eq(DefraRuby::Validators::EmailValidator)
+    end
+
+    shared_examples "submits and populates the contact_email" do
+      it "submits the form successfully" do
+        expect(form.submit(ActionController::Parameters.new(params))).to be true
+      end
+
+      it "populates the contact_email" do
+        expect { form.submit(ActionController::Parameters.new(params)) }
+          .to change { form.transient_registration.contact_email }.to(contact_email.strip)
+      end
+    end
+
+    shared_examples "does not submit" do
+      it "does not submit the form successfully" do
+        expect(form.submit(ActionController::Parameters.new(params))).to be false
+      end
+    end
+
+    context "when the form is valid" do
+      # before { form.transient_registration.contact_email = nil }
+
+      context "with a vald email address" do
+          let(:contact_email) { Faker::Internet.email }
+
+          it_behaves_like "submits and populates the contact_email"
+        end
+
+        context "with whitespace around the email address" do
+          let(:actual_email) { Faker::Internet.email }
+          let(:contact_email) { "  #{actual_email} " }
+
+          it_behaves_like "submits and populates the contact_email"
+        end
+      end
+
+    context "with an invalid email address" do
+      let(:contact_email) { "foo" }
+
+      it_behaves_like "does not submit"
+    end
+  end
+end

--- a/spec/forms/waste_exemptions_engine/capture_email_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/capture_email_form_spec.rb
@@ -35,18 +35,18 @@ module WasteExemptionsEngine
       # before { form.transient_registration.contact_email = nil }
 
       context "with a vald email address" do
-          let(:contact_email) { Faker::Internet.email }
+        let(:contact_email) { Faker::Internet.email }
 
-          it_behaves_like "submits and populates the contact_email"
-        end
-
-        context "with whitespace around the email address" do
-          let(:actual_email) { Faker::Internet.email }
-          let(:contact_email) { "  #{actual_email} " }
-
-          it_behaves_like "submits and populates the contact_email"
-        end
+        it_behaves_like "submits and populates the contact_email"
       end
+
+      context "with whitespace around the email address" do
+        let(:actual_email) { Faker::Internet.email }
+        let(:contact_email) { "  #{actual_email} " }
+
+        it_behaves_like "submits and populates the contact_email"
+      end
+    end
 
     context "with an invalid email address" do
       let(:contact_email) { "foo" }

--- a/spec/models/waste_exemptions_engine/front_office_edit_registration_workflow_state/confirm_edit_exemptions_form_spec.rb
+++ b/spec/models/waste_exemptions_engine/front_office_edit_registration_workflow_state/confirm_edit_exemptions_form_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module WasteExemptionsEngine
   RSpec.describe ConfirmEditExemptionsForm do
-    subject(:form) { build(:confirm_edit_exemptions_form, transient_registration_factory: :front_office_edit_registration) }
+    subject(:form) { build(:confirm_edit_exemptions_form) }
 
     it "validates the form using the YesNoValidator class" do
       validators = form._validators

--- a/spec/requests/waste_exemptions_engine/confirm_edit_exemptions_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/confirm_edit_exemptions_forms_spec.rb
@@ -5,8 +5,7 @@ require "rails_helper"
 module WasteExemptionsEngine
   RSpec.describe "confirm edit exemptions form" do
     let(:request_path) { "/waste_exemptions_engine/#{form.token}/confirm-edit-exemptions" }
-    let(:transient_registration_factory) { :renewing_registration }
-    let(:form) { build(:confirm_edit_exemptions_form, transient_registration_factory:) }
+    let(:form) { build(:confirm_edit_exemptions_form) }
 
     describe "#new" do
       it "renders the correct template" do
@@ -20,58 +19,60 @@ module WasteExemptionsEngine
     end
 
     describe "#create" do
-      shared_examples "common form submission behaviour" do
-        before do
-          transient_registration.excluded_exemptions = exemption_ids_to_remove
-          transient_registration.save!
+      before do
+        transient_registration.excluded_exemptions = exemption_ids_to_remove
+        transient_registration.save!
+      end
+
+      let(:transient_registration) { form.transient_registration }
+      let(:exemptions) { transient_registration.exemptions }
+      let(:exemption_ids_to_remove) { [exemptions.first, exemptions.last].pluck(:id) }
+      let(:exemption_ids_to_retain) { (exemptions.pluck(:id) - exemption_ids_to_remove) }
+
+      context "when selecting the no option" do
+        let(:valid_params) do
+          {
+            confirm_edit_exemptions_form: {
+              exemption_ids: exemption_ids_to_retain,
+              temp_confirm_exemption_edits: "false"
+            }
+          }
         end
 
-        let(:transient_registration) { form.transient_registration }
-        let(:exemptions) { transient_registration.exemptions }
-        let(:exemption_ids_to_remove) { [exemptions.first, exemptions.last].pluck(:id) }
-        let(:exemption_ids_to_retain) { (exemptions.pluck(:id) - exemption_ids_to_remove) }
+        it "redirects to the correct workflow step" do
+          post request_path, params: valid_params
 
-        context "when selecting the no option" do
-          let(:valid_params) do
-            {
-              confirm_edit_exemptions_form: {
-                exemption_ids: exemption_ids_to_retain,
-                temp_confirm_exemption_edits: "false"
-              }
-            }
+          aggregate_failures do
+            expect(response).to have_http_status(:see_other)
+            expect(response).to redirect_to("/waste_exemptions_engine/#{form.token}/edit-exemptions")
           end
+        end
 
-          it "redirects to the correct workflow step" do
+        it "does not cease any exemptions" do
+          expect { post request_path, params: valid_params }
+            .not_to change { transient_registration.reload.exemption_ids.length }
+        end
+      end
+
+      context "when selecting the yes option" do
+        let(:valid_params) do
+          {
+            confirm_edit_exemptions_form: {
+              exemption_ids: exemption_ids_to_retain,
+              temp_confirm_exemption_edits: "true"
+            }
+          }
+        end
+
+        context "with a subset of exemptions removed" do
+          let(:exemption_ids_to_remove) { [exemptions.first, exemptions.last].pluck(:id) }
+
+          it "redirects to the main edit page" do
             post request_path, params: valid_params
 
             aggregate_failures do
               expect(response).to have_http_status(:see_other)
-              expect(response).to redirect_to("/waste_exemptions_engine/#{form.token}/edit-exemptions")
-            end
-          end
-
-          it "does not cease any exemptions" do
-            expect { post request_path, params: valid_params }
-              .not_to change { transient_registration.reload.exemption_ids.length }
-          end
-        end
-
-        context "when selecting the yes option" do
-          let(:valid_params) do
-            {
-              confirm_edit_exemptions_form: {
-                exemption_ids: exemption_ids_to_retain,
-                temp_confirm_exemption_edits: "true"
-              }
-            }
-          end
-
-          it "redirects to the correct workflow step" do
-            post request_path, params: valid_params
-
-            aggregate_failures do
-              expect(response).to have_http_status(:see_other)
-              expect(response).to redirect_to("/waste_exemptions_engine/#{form.token}/#{next_page_if_confirmed}")
+              expect(response).to redirect_to("/waste_exemptions_engine/#{form.token}/fo_edit")
             end
           end
 
@@ -81,57 +82,56 @@ module WasteExemptionsEngine
           end
         end
 
-        context "when an invalid option value has been provided" do
-          let(:invalid_params) do
-            {
-              confirm_edit_exemptions_form: {
-                temp_confirm_exemption_edits: nil
-              }
-            }
-          end
+        context "with all exemptions removed" do
+          let(:exemption_ids_to_remove) { exemptions.pluck(:id) }
 
-          it "re-renders the new template and displays a validation error" do
-            post request_path, params: invalid_params
+          it "redirects to the deregistration declaration page" do
+            post request_path, params: valid_params
 
             aggregate_failures do
-              expect(response).to have_http_status(:ok)
-              expect(response).to render_template("waste_exemptions_engine/confirm_edit_exemptions_forms/new")
-              expect(response.body).to have_html_escaped_string("You must select Yes or No")
-            end
-          end
-        end
-
-        context "when no workflow_state has been provided" do
-          let(:invalid_params) do
-            {
-              confirm_edit_exemptions_form: {}
-            }
-          end
-
-          it "re-renders the new template and displays a validation error" do
-            post request_path, params: invalid_params
-
-            aggregate_failures do
-              expect(response).to have_http_status(:ok)
-              expect(response).to render_template("waste_exemptions_engine/confirm_edit_exemptions_forms/new")
-              expect(response.body).to have_html_escaped_string("You must select Yes or No")
+              expect(response).to have_http_status(:see_other)
+              expect(response).to redirect_to("/waste_exemptions_engine/#{form.token}/edit-exemptions-declaration")
             end
           end
         end
       end
 
-      context "with a renewing registration" do
-        let(:transient_registration_factory) { :renewing_registration }
-        let(:next_page_if_confirmed) { "edit-exemptions-declaration" }
+      context "when an invalid option value has been provided" do
+        let(:invalid_params) do
+          {
+            confirm_edit_exemptions_form: {
+              temp_confirm_exemption_edits: nil
+            }
+          }
+        end
 
-        it_behaves_like "common form submission behaviour"
+        it "re-renders the new template and displays a validation error" do
+          post request_path, params: invalid_params
+
+          aggregate_failures do
+            expect(response).to have_http_status(:ok)
+            expect(response).to render_template("waste_exemptions_engine/confirm_edit_exemptions_forms/new")
+            expect(response.body).to have_html_escaped_string("You must select Yes or No")
+          end
+        end
       end
 
-      context "with a front-office edit registration" do
-        let(:transient_registration_factory) { :front_office_edit_registration }
-        let(:next_page_if_confirmed) { "fo_edit" }
+      context "when no workflow_state has been provided" do
+        let(:invalid_params) do
+          {
+            confirm_edit_exemptions_form: {}
+          }
+        end
 
-        it_behaves_like "common form submission behaviour"
+        it "re-renders the new template and displays a validation error" do
+          post request_path, params: invalid_params
+
+          aggregate_failures do
+            expect(response).to have_http_status(:ok)
+            expect(response).to render_template("waste_exemptions_engine/confirm_edit_exemptions_forms/new")
+            expect(response.body).to have_html_escaped_string("You must select Yes or No")
+          end
+        end
       end
     end
   end

--- a/spec/requests/waste_exemptions_engine/front_office_edit_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/front_office_edit_forms_spec.rb
@@ -22,7 +22,7 @@ module WasteExemptionsEngine
       end
 
       context "when the edit_token is invalid" do
-        let(:edit_token) { "foo" }
+        let(:edit_token) { "foo/bar/baz.txt" }
 
         it "returns the expected invalid link response" do
           aggregate_failures do

--- a/spec/support/factories/forms/confirm_edit_exemptions_form.rb
+++ b/spec/support/factories/forms/confirm_edit_exemptions_form.rb
@@ -2,13 +2,9 @@
 
 FactoryBot.define do
   factory :confirm_edit_exemptions_form, class: "WasteExemptionsEngine::ConfirmEditExemptionsForm" do
-    # default to a renewing_registration and allow override to a front_office_edit_registration
-    transient do
-      transient_registration_factory { :renewing_registration }
-    end
 
     initialize_with do
-      new(create(transient_registration_factory, workflow_state: "confirm_edit_exemptions_form"))
+      new(create(:front_office_edit_registration, workflow_state: "confirm_edit_exemptions_form"))
     end
   end
 end


### PR DESCRIPTION
This change resolves the following issues with front-office edit / deregistration:
1. https://eaflood.atlassian.net/browse/RUBY-2566: Ignore whitespace in the email field in the capture_email form
2. https://eaflood.atlassian.net/browse/RUBY-2643: Missing template error: https://errbit-prd.aws-int.defra.cloud/apps/63ceb3516b99690550a33710/problems/6507e7586b9969038f24c06a - caused by invalid edit_token values which include forward-slashes, confusing Rails template rendering logic
3. https://eaflood.atlassian.net/browse/RUBY-2561: Guidance should open in a new tab
4. https://eaflood.atlassian.net/browse/RUBY-2561: Submitting the full deregistration confirmation form goes back to the main edit page instead of the declaration and final deregistration confirmation pages.
5. https://eaflood.atlassian.net/browse/RUBY-2602: Tweak declaration page content
6. https://eaflood.atlassian.net/browse/RUBY-2565: Fix smart survey link