### PR TITLE
Return HTTP 404 instead of 422 for an expired edit_token

### DIFF
--- a/app/controllers/waste_exemptions_engine/front_office_edit_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/front_office_edit_forms_controller.rb
@@ -30,7 +30,8 @@ module WasteExemptionsEngine
 
     def validate_edit_token
       return render(:invalid_edit_link, status: 404) unless registration.present?
-      return render(:edit_link_expired, status: 422) if token_expired?
+      # return 404 for an expired token as WAF is configured to not allow 422 responses:
+      return render(:edit_link_expired, status: 404) if token_expired?
 
       @transient_registration = FrontOfficeEditRegistration.find_or_create_by(reference: registration.reference)
       @transient_registration.aasm.enter_initial_state

--- a/spec/requests/waste_exemptions_engine/front_office_edit_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/front_office_edit_forms_spec.rb
@@ -39,7 +39,7 @@ module WasteExemptionsEngine
         it "returns the expected expired link response" do
           aggregate_failures do
             expect(response).to render_template("waste_exemptions_engine/front_office_edit_forms/edit_link_expired")
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:not_found)
             expect(response.body).to have_valid_html
           end
         end


### PR DESCRIPTION
WAF is configured to not allow 422 responses, so we return a 404 instead for an expired token.
https://eaflood.atlassian.net/browse/RUBY-2643