### PR TITLE
Pin activerecord version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     waste_exemptions_engine (0.1.0)
       aasm (~> 5.5)
+      activerecord (< 7.1)
       defra_ruby_address
       defra_ruby_alert
       defra_ruby_area (~> 2.0)

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -58,6 +58,9 @@ Gem::Specification.new do |s|
   # Used for auditing and version control
   s.add_dependency "paper_trail"
 
+  # paper_trail does not currently support activerecord v7.1
+  s.add_dependency "activerecord", "< 7.1"
+
   # Validations
   # A defra created gem of shared validators
   s.add_dependency "defra_ruby_validators"


### PR DESCRIPTION
The paper_trail gem does not currently support Rails (specifically ActiveRecord) 7.1, so we need to pin the gem version.