### PR TITLE
[RUBY-2789] Optimize cleanup task by adding index to created_at in transient_registrations

### DIFF
--- a/db/migrate/20231107131130_add_index_to_transient_registrations_created_at.rb
+++ b/db/migrate/20231107131130_add_index_to_transient_registrations_created_at.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToTransientRegistrationsCreatedAt < ActiveRecord::Migration[7.0]
+  def change
+    add_index :transient_registrations, :created_at
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_01_155801) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_07_131130) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "tsm_system_rows"
@@ -126,11 +126,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_01_155801) do
     t.string "renew_token"
     t.integer "referring_registration_id"
     t.datetime "companies_house_updated_at", precision: nil
+    t.datetime "deregistration_email_sent_at", precision: nil
     t.string "edit_token"
     t.datetime "edit_token_created_at"
+    t.index ["deregistration_email_sent_at"], name: "index_registrations_on_deregistration_email_sent_at"
     t.index ["edit_token"], name: "index_registrations_on_edit_token", unique: true
     t.index ["reference"], name: "index_registrations_on_reference", unique: true
     t.index ["renew_token"], name: "index_registrations_on_renew_token", unique: true
+  end
+
+  create_table "reports_generated_reports", id: :serial, force: :cascade do |t|
+    t.string "file_name"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.date "data_from_date"
+    t.date "data_to_date"
   end
 
   create_table "transient_addresses", id: :serial, force: :cascade do |t|
@@ -225,7 +235,34 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_01_155801) do
     t.text "excluded_exemptions", default: [], array: true
     t.boolean "temp_confirm_exemption_edits"
     t.boolean "temp_confirm_no_exemption_changes"
+    t.index ["created_at"], name: "index_transient_registrations_on_created_at"
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
+  end
+
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "invitation_token"
+    t.datetime "invitation_created_at", precision: nil
+    t.datetime "invitation_sent_at", precision: nil
+    t.datetime "invitation_accepted_at", precision: nil
+    t.integer "invitation_limit"
+    t.integer "invited_by_id"
+    t.string "invited_by_type"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
+    t.datetime "locked_at", precision: nil
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.string "session_token"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.string "role"
+    t.boolean "active", default: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
   create_table "version_archives", id: :serial, force: :cascade do |t|

--- a/spec/presenters/waste_exemptions_engine/registration_details_presenter_spec.rb
+++ b/spec/presenters/waste_exemptions_engine/registration_details_presenter_spec.rb
@@ -211,7 +211,7 @@ module WasteExemptionsEngine
 
     describe "#exemptions_section" do
       let(:registration) { create(:registration, :complete, :with_active_exemptions) }
-      let(:expected_expiry_date) { 3.years.from_now.strftime("%d %B %Y") }
+      let(:expected_expiry_date) { 3.years.from_now.strftime("%-d %B %Y") }
 
       it "returns an array with the correct exemptions" do
         expected_array = []


### PR DESCRIPTION
Introduces a database index to enhance query performance for transient registrations cleanup job,
potentially resolving the memory issues encountered during scheduled task execution.
