### PR TITLE
Add SafeCopyRegistrationAttributesService

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,12 +123,12 @@ GEM
       async (>= 1.25)
     base64 (0.2.0)
     builder (3.2.4)
-    bullet (7.1.5)
+    bullet (7.1.6)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     console (1.23.3)
       fiber-annotation
       fiber-local
@@ -180,7 +180,7 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
-    faker (3.2.2)
+    faker (3.2.3)
       i18n (>= 1.8.11, < 2)
     faraday (2.8.0)
       base64
@@ -238,7 +238,7 @@ GEM
     mime-types-data (3.2023.1205)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.20.0)
+    minitest (5.21.2)
     multi_json (1.15.0)
     net-imap (0.4.8)
       date
@@ -276,7 +276,7 @@ GEM
       ruby-rc4
       ttfunk
     pg (1.5.4)
-    phonelib (0.8.6)
+    phonelib (0.8.7)
     protocol-hpack (1.4.2)
     protocol-http (0.25.0)
     protocol-http1 (0.16.0)

--- a/app/models/waste_exemptions_engine/transient_registration.rb
+++ b/app/models/waste_exemptions_engine/transient_registration.rb
@@ -70,7 +70,9 @@ module WasteExemptionsEngine
     end
 
     def registration_attributes
-      attributes.except(*TRANSIENT_ATTRIBUTES)
+      SafeCopyRegistrationAttributesService.run(source: self,
+                                                target_class: WasteExemptionsEngine::Registration,
+                                                exclude: TRANSIENT_ATTRIBUTES)
     end
 
     def next_state!

--- a/app/services/waste_exemptions_engine/safe_copy_registration_attributes_service.rb
+++ b/app/services/waste_exemptions_engine/safe_copy_registration_attributes_service.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class SafeCopyRegistrationAttributesService < BaseService
+
+    def run(source:, target_class:, exclude: [])
+      source_attributes = source.attributes.except(*exclude)
+
+      unsupported_attribute_keys = source_attributes.except(*target_class.column_names).keys
+
+      source_attributes.except(*unsupported_attribute_keys)
+    end
+  end
+end

--- a/spec/services/waste_exemptions_engine/safe_copy_registration_attributes_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/safe_copy_registration_attributes_service_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe SafeCopyRegistrationAttributesService do
+    describe "#run" do
+
+      shared_examples "returns the correct attributes" do
+
+        subject(:run_service) { described_class.run(source:, target_class:, exclude:) }
+
+        let(:target_class) { WasteExemptionsEngine::Registration }
+        let(:copyable_attributes) { %w[location contact_phone] }
+        let(:non_copyable_attributes) { %w[workflow_state temp_contact_postcode] }
+        let(:exclusion_list) { %w[reference business_type] }
+        let(:exclude) { nil }
+
+        # ensure all available attributes are populated on the source
+        before do
+          source.class.columns.each do |attr|
+            next unless source.send(attr.name).blank? && source.respond_to?("#{attr.name}=")
+
+            source.send "#{attr.name}=", 0
+          end
+        end
+
+        it { expect { run_service }.not_to raise_error }
+
+        it "returns copyable attributes" do
+          result = run_service
+          copyable_attributes.each { |attr| expect(result[attr]).not_to be_nil }
+        end
+
+        it "does not return non-copyable attributes" do
+          result = run_service
+          non_copyable_attributes.each { |attr| expect(result[attr]).to be_nil }
+        end
+
+        context "with an exclusion list" do
+          let(:exclude) { exclusion_list }
+
+          it "does not return the excluded attibutes" do
+            expect(run_service.keys).not_to include(exclusion_list)
+          end
+        end
+      end
+
+      context "when the source is a NewRegistration" do
+        let(:source) { create(:new_registration, :complete) }
+
+        it_behaves_like "returns the correct attributes"
+      end
+
+      context "when the source is a RenewingRegistration" do
+        let(:source) { create(:renewing_registration, :with_all_addresses) }
+
+        it_behaves_like "returns the correct attributes"
+      end
+
+      context "when the source is a BackOfficeEditRegistration" do
+        let(:source) { create(:back_office_edit_registration) }
+
+        it_behaves_like "returns the correct attributes"
+      end
+
+      context "when the source is a FrontOfficeEditRegistration" do
+        let(:source) { create(:front_office_edit_registration) }
+
+        it_behaves_like "returns the correct attributes"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change is to reduce the risk of a registration completion failing due to a transient_registration having an attribute which is not supported on the registration. This has happened in the past where a transient_registration is created before a deployment with an attribute which is no longer present on the registration after the deployment.
https://eaflood.atlassian.net/browse/RUBY-2861