### PR TITLE
RUBY 3066 wex charging bo charging catalogue management rebased

### DIFF
--- a/app/models/waste_exemptions_engine/bucket.rb
+++ b/app/models/waste_exemptions_engine/bucket.rb
@@ -6,7 +6,7 @@ module WasteExemptionsEngine
 
     has_paper_trail
 
-    has_many :bucket_exemptions
+    has_many :bucket_exemptions, dependent: :destroy
     has_many :exemptions, through: :bucket_exemptions
 
     has_one :initial_compliance_charge, lambda {

--- a/app/models/waste_exemptions_engine/exemption.rb
+++ b/app/models/waste_exemptions_engine/exemption.rb
@@ -9,7 +9,7 @@ module WasteExemptionsEngine
 
     has_many :registration_exemptions
     has_many :registrations, through: :registration_exemptions
-    has_many :bucket_exemptions
+    has_many :bucket_exemptions, dependent: :destroy
     has_many :buckets, through: :bucket_exemptions
 
     scope :visible, -> { where(hidden: false) }


### PR DESCRIPTION
- [RUBY-3066] Add association between exemptions and buckets through bucket_exemptions in WasteExemptionsEngine
- [RUBY-3066] Add dependent destroy to bucket_exemptions associations in Bucket and Exemption models


[RUBY-3066]: https://eaflood.atlassian.net/browse/RUBY-3066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUBY-3066]: https://eaflood.atlassian.net/browse/RUBY-3066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ