### PR TITLE
RUBY 3066 wex charging bo charging catalogue management rebased

### DIFF
--- a/app/models/waste_exemptions_engine/band.rb
+++ b/app/models/waste_exemptions_engine/band.rb
@@ -23,18 +23,20 @@ module WasteExemptionsEngine
 
     validates_associated :initial_compliance_charge, numericality: { only_integer: true }
     validates_associated :additional_compliance_charge, numericality: { only_integer: true }
-  end
 
-  before_destroy :check_for_exemptions
+    before_destroy :check_for_exemptions
 
-  def check_for_exemptions
-    unless can_be_destroyed?
+    def can_be_destroyed?
+      exemptions.empty?
+    end
+
+    private
+
+    def check_for_exemptions
+      return if can_be_destroyed?
+
       errors.add(:base, "Cannot delete band while it has exemptions associated")
       throw :abort
     end
-  end
-
-  def can_be_destroyed?
-    exemptions.empty?
   end
 end

--- a/spec/models/waste_exemptions_engine/band_spec.rb
+++ b/spec/models/waste_exemptions_engine/band_spec.rb
@@ -13,6 +13,35 @@ module WasteExemptionsEngine
         end
       end
 
+      describe "callbacks" do
+        context "when destroying a band" do
+          context "when it has no exemptions" do
+            it "destroys the band" do
+              band = create(:band, :no_charges)
+              band.destroy
+              expect(described_class.exists?(band.id)).to be(false)
+            end
+          end
+
+          context "when it has exemptions" do
+            let(:band) { create(:band, :no_charges) }
+
+            before do
+              create(:exemption, band: band)
+              band.destroy
+            end
+
+            it "does not destroy the band" do
+              expect(described_class.exists?(band.id)).to be(true)
+            end
+
+            it "adds an error to the band" do
+              expect(band.errors[:base]).to include("Cannot delete band while it has exemptions associated")
+            end
+          end
+        end
+      end
+
       context "when initial_compliance_charge set" do
         let(:band) { create(:band, :no_charges) }
         let(:charge) { create(:charge, :initial_compliance_charge, charge_amount: 100, chargeable: band) }
@@ -50,6 +79,23 @@ module WasteExemptionsEngine
         it "has charge_amount set to 100" do
           charge
           expect(band.reload.additional_compliance_charge.charge_amount).to eq(100)
+        end
+      end
+
+      describe "#can_be_destroyed" do
+        context "when band has no exemptions" do
+          it "returns true" do
+            band = create(:band, :no_charges)
+            expect(band.can_be_destroyed?).to be(true)
+          end
+        end
+
+        context "when band has exemptions" do
+          it "returns false" do
+            band = create(:band, :no_charges)
+            create(:exemption, band: band)
+            expect(band.can_be_destroyed?).to be(false)
+          end
         end
       end
     end


### PR DESCRIPTION
- [RUBY-3066] Add before_destroy callback to prevent deletion of bands with associated exemptions
- [RUBY-3066] Add callback to prevent destroying an exemption with exemption and add spec


[RUBY-3066]: https://eaflood.atlassian.net/browse/RUBY-3066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUBY-3066]: https://eaflood.atlassian.net/browse/RUBY-3066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ