### PR TITLE
Feature/ruby 3049 charge calculation

### DIFF
--- a/app/models/waste_exemptions_engine/band_charge_detail.rb
+++ b/app/models/waste_exemptions_engine/band_charge_detail.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class BandChargeDetail < ApplicationRecord
+    self.table_name = "band_charge_details"
+
+    belongs_to :band
+
+    def total_compliance_charge_amount
+      initial_compliance_charge_amount + additional_compliance_charge_amount
+    end
+  end
+end

--- a/app/models/waste_exemptions_engine/charge_detail.rb
+++ b/app/models/waste_exemptions_engine/charge_detail.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ChargeDetail < ApplicationRecord
+    self.table_name = "charge_details"
+
+    has_many :charge_detail_band_charge_details, dependent: :destroy
+    has_many :band_charge_details, through: :charge_detail_band_charge_details
+
+    def total_compliance_charge_amount
+      non_bucket_compliance_charge_amount = band_charge_details.sum do |bc|
+        bc.initial_compliance_charge_amount + bc.additional_compliance_charge_amount
+      end
+
+      non_bucket_compliance_charge_amount + bucket_charge_amount
+    end
+
+    def total_charge_amount
+      registration_charge_amount +
+        total_compliance_charge_amount
+    end
+  end
+end

--- a/app/models/waste_exemptions_engine/charge_detail_band_charge_detail.rb
+++ b/app/models/waste_exemptions_engine/charge_detail_band_charge_detail.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ChargeDetailBandChargeDetail < ApplicationRecord
+    self.table_name = "charge_detail_band_charge_details"
+
+    belongs_to :charge_detail
+    belongs_to :band_charge_detail
+  end
+end

--- a/app/models/waste_exemptions_engine/charging_strategy.rb
+++ b/app/models/waste_exemptions_engine/charging_strategy.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class ChargingStrategy
+    attr_reader :order, :highest_band
+
+    def initialize(order)
+      @order = order
+      @highest_band = order.highest_band
+    end
+
+    def registration_charge_amount
+      order.exemptions.empty? ? 0 : Charge.find_by(charge_type: "registration_charge").charge_amount
+    end
+
+    def charge_details
+      ChargeDetail.new(
+        registration_charge_amount:,
+        band_charge_details:
+      )
+    end
+
+    def total_compliance_charge_amount
+      @total_compliance_charge_amount ||=
+        (order.bucket&.initial_compliance_charge&.charge_amount || 0) +
+        band_charge_details.sum do |bc|
+          bc.initial_compliance_charge_amount + bc.additional_compliance_charge_amount
+        end
+    end
+
+    def total_charge_amount
+      @total_charge_amount ||= registration_charge_amount + total_compliance_charge_amount
+    end
+
+    def band_charge_details
+      @band_charge_details ||= populate_band_charge_details
+    end
+
+    private
+
+    def populate_band_charge_details
+      bands = Band.where(id: order.exemptions.map(&:band_id).uniq)
+      bands.map do |band|
+        initial_compliance_charge_amount = initial_compliance_charge(band)
+        additional_compliance_charge_amount = additional_compliance_charge(
+          band,
+          initial_compliance_charge_amount.positive?
+        )
+        BandChargeDetail.new(
+          band_id: band.id,
+          initial_compliance_charge_amount:,
+          additional_compliance_charge_amount:
+        )
+      end
+    end
+
+    def initial_compliance_charge(_band)
+      raise NotImplementedError
+    end
+
+    def additional_compliance_charge(_band, _initial_compliance_charge_applied)
+      raise NotImplementedError
+    end
+  end
+end

--- a/app/models/waste_exemptions_engine/charging_strategy.rb
+++ b/app/models/waste_exemptions_engine/charging_strategy.rb
@@ -14,7 +14,7 @@ module WasteExemptionsEngine
     end
 
     def charge_details
-      ChargeDetail.new(
+      @charge_details = ChargeDetail.new(
         registration_charge_amount:,
         band_charge_details:
       )

--- a/app/models/waste_exemptions_engine/order.rb
+++ b/app/models/waste_exemptions_engine/order.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class Order < ApplicationRecord
+
+    self.table_name = "orders"
+
+    has_many :order_exemptions, dependent: :destroy
+    has_many :exemptions, through: :order_exemptions
+
+    has_one :order_bucket, dependent: :destroy
+    has_one :bucket, through: :order_bucket
+
+    def highest_band
+      return nil if exemptions.empty?
+
+      exemptions.max_by { |exemption| exemption.band.initial_compliance_charge.charge_amount }.band
+    end
+
+    def bucket?
+      bucket.present?
+    end
+  end
+end

--- a/app/models/waste_exemptions_engine/order_bucket.rb
+++ b/app/models/waste_exemptions_engine/order_bucket.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OrderBucket < ApplicationRecord
+    self.table_name = "order_buckets"
+
+    belongs_to :order
+    belongs_to :bucket
+  end
+end

--- a/app/models/waste_exemptions_engine/order_exemption.rb
+++ b/app/models/waste_exemptions_engine/order_exemption.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OrderExemption < ApplicationRecord
+    self.table_name = "order_exemptions"
+
+    belongs_to :order
+    belongs_to :exemption
+  end
+end

--- a/app/services/waste_exemptions_engine/farmer_charging_strategy.rb
+++ b/app/services/waste_exemptions_engine/farmer_charging_strategy.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class FarmerChargingStrategy < ChargingStrategy
+    attr_reader :bucket
+
+    def initialize(order)
+      @bucket = order.bucket
+
+      super
+    end
+
+    def charge_details
+      ChargeDetail.new(
+        registration_charge_amount:,
+        band_charge_details:,
+        bucket_charge_amount:
+      )
+    end
+
+    private
+
+    def bucket_charge_amount
+      return 0 unless any_qualifying_bucket_exemptions
+
+      bucket.initial_compliance_charge.charge_amount
+    end
+
+    def order_exemptions_in_bucket
+      @order_exemptions_in_bucket = order.exemptions.select { |ex| bucket.exemptions.include?(ex) }
+    end
+
+    def any_qualifying_bucket_exemptions
+      @any_qualifying_bucket_exemptions = bucket.present? && !order_exemptions_in_bucket.empty?
+    end
+
+    def initial_compliance_charge(band)
+      return 0 if any_qualifying_bucket_exemptions
+
+      band == highest_band ? band.initial_compliance_charge.charge_amount : 0
+    end
+
+    def additional_compliance_charge(band, initial_compliance_charge_applied)
+      additional_exemptions_count(band,
+                                  initial_compliance_charge_applied) * band.additional_compliance_charge.charge_amount
+    end
+
+    def additional_exemptions_count(band, initial_compliance_charge_applied)
+      exemptions_already_charged = initial_compliance_charge_applied ? 1 : 0
+      order_exemptions_in_band = order.exemptions.select { |ex| ex.band == band }.count
+      bucket_exemptions_in_band = order_exemptions_in_bucket.select { |ex| ex.band == band }.count
+
+      order_exemptions_in_band - bucket_exemptions_in_band - exemptions_already_charged
+    end
+  end
+end

--- a/app/services/waste_exemptions_engine/order_calculator.rb
+++ b/app/services/waste_exemptions_engine/order_calculator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OrderCalculator
+
+    attr_reader :order, :strategy
+
+    delegate :charge_details, to: :strategy
+
+    def initialize(order:, strategy:)
+      @order = order
+      @strategy = strategy.new(order)
+    end
+
+    def calculate_registration_charge
+      @order.exemptions.empty? ? 0 : charge_details.registration_charge_amount
+      charge_details.registration_charge_amount
+    end
+
+    def calculate_compliance_charges
+      charge_details.band_charge_details.to_a
+    end
+
+    def calculate_total_compliance_charge
+      charge_details.total_compliance_charge_amount
+    end
+
+    def calculate_total_charge
+      charge_details.total_charge_amount
+    end
+  end
+end

--- a/app/services/waste_exemptions_engine/order_calculator_service.rb
+++ b/app/services/waste_exemptions_engine/order_calculator_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class OrderCalculatorService
+
+    attr_reader :order, :strategy, :calculator
+
+    delegate :calculate_registration_charge,
+             :calculate_compliance_charges,
+             :calculate_total_compliance_charge,
+             :calculate_total_charge,
+             :charge_details,
+             to: :calculator
+
+    def initialize(order)
+      @order = order
+      @strategy = strategy_type.new(order)
+      @calculator = OrderCalculator.new(order: order, strategy: strategy)
+    end
+
+    def strategy_type
+      @strategy_type ||= if order.bucket? && order.bucket.name == "Farmer exemptions"
+                           FarmerChargingStrategy
+                         else
+                           RegularChargingStrategy
+                         end
+    end
+  end
+end

--- a/app/services/waste_exemptions_engine/regular_charging_strategy.rb
+++ b/app/services/waste_exemptions_engine/regular_charging_strategy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class RegularChargingStrategy < ChargingStrategy
+
+    private
+
+    def initial_compliance_charge(band)
+      band == highest_band ? band.initial_compliance_charge.charge_amount : 0
+    end
+
+    def additional_compliance_charge(band, _initial_compliance_charge_applied)
+      band_exemptions_count = order.exemptions.select { |ex| ex.band == band }.count
+      count = (band == highest_band ? band_exemptions_count - 1 : band_exemptions_count)
+      count * band.additional_compliance_charge.charge_amount
+    end
+  end
+end

--- a/db/migrate/20240603131021_create_waste_exemptions_engine_orders.rb
+++ b/db/migrate/20240603131021_create_waste_exemptions_engine_orders.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CreateWasteExemptionsEngineOrders < ActiveRecord::Migration[7.1]
+  def change
+    create_table :orders, &:timestamps
+  end
+end

--- a/db/migrate/20240603131052_create_waste_exemptions_engine_order_exemptions.rb
+++ b/db/migrate/20240603131052_create_waste_exemptions_engine_order_exemptions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateWasteExemptionsEngineOrderExemptions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :order_exemptions do |t|
+      t.references :order, foreign_key: true
+      t.references :exemption, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240603141812_create_waste_exemptions_engine_order_buckets.rb
+++ b/db/migrate/20240603141812_create_waste_exemptions_engine_order_buckets.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateWasteExemptionsEngineOrderBuckets < ActiveRecord::Migration[7.1]
+  def change
+    create_table :order_buckets do |t|
+      t.references :order, foreign_key: true
+      t.references :bucket, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240603155042_create_waste_carriers_engine_charge_details.rb
+++ b/db/migrate/20240603155042_create_waste_carriers_engine_charge_details.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateWasteCarriersEngineChargeDetails < ActiveRecord::Migration[7.1]
+  def change
+    create_table :charge_details do |t|
+      t.integer :registration_charge_amount
+      t.integer :bucket_charge_amount, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240604104155_waste_exemptions_engine_create_band_charge_details.rb
+++ b/db/migrate/20240604104155_waste_exemptions_engine_create_band_charge_details.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class WasteExemptionsEngineCreateBandChargeDetails < ActiveRecord::Migration[7.1]
+  def change
+    create_table :band_charge_details do |t|
+      t.bigint "band_id"
+
+      t.integer :initial_compliance_charge_amount, default: 0
+      t.integer :additional_compliance_charge_amount, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240604104208_waste_exemptions_engine_create_charge_detail_band_charge_details.rb
+++ b/db/migrate/20240604104208_waste_exemptions_engine_create_charge_detail_band_charge_details.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class WasteExemptionsEngineCreateChargeDetailBandChargeDetails < ActiveRecord::Migration[7.1]
+  def change
+    create_table :charge_detail_band_charge_details do |t|
+      t.references :charge_detail, foreign_key: true
+      t.references :band_charge_detail, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/band_charge_detail_spec.rb
+++ b/spec/models/waste_exemptions_engine/band_charge_detail_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe BandChargeDetail do
+    let(:band) { build(:band) }
+    let(:band_charge_detail) { build(:band_charge_detail, band:) }
+
+    describe "band" do
+      it { expect(band_charge_detail).to respond_to(:band) }
+    end
+
+    describe "initial_compliance_charge_amount" do
+      it { expect(band_charge_detail).to respond_to(:initial_compliance_charge_amount) }
+    end
+
+    describe "additional_compliance_charge_amount" do
+      it { expect(band_charge_detail).to respond_to(:additional_compliance_charge_amount) }
+    end
+
+    describe "#total_compliance_charge_amount" do
+      it do
+        expect(band_charge_detail.total_compliance_charge_amount).to eq(
+          band_charge_detail.initial_compliance_charge_amount +
+          band_charge_detail.additional_compliance_charge_amount
+        )
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/charge_detail_spec.rb
+++ b/spec/models/waste_exemptions_engine/charge_detail_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe ChargeDetail do
+    let(:charge_detail) { build(:charge_detail) }
+    let(:band_charges) { charge_detail.band_charge_details }
+    let(:total_compliance_charge_amount) do
+      band_charges.sum do |bc|
+        bc.initial_compliance_charge_amount + bc.additional_compliance_charge_amount
+      end
+    end
+
+    describe "#total_compliance_charge_amount" do
+      it { expect(charge_detail.total_compliance_charge_amount).to eq total_compliance_charge_amount }
+    end
+
+    describe "#total_charge_amount" do
+      it do
+        expect(charge_detail.total_charge_amount).to eq(
+          charge_detail.registration_charge_amount +
+          total_compliance_charge_amount
+        )
+      end
+    end
+  end
+end

--- a/spec/models/waste_exemptions_engine/order_spec.rb
+++ b/spec/models/waste_exemptions_engine/order_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe Order do
+
+    describe "#highest_band" do
+      subject(:highest_band) { described_class.new(exemptions:).highest_band }
+
+      # rubocop:disable RSpec/IndexedLet
+      let(:band_1) do
+        build(:band,
+              initial_compliance_charge: build(:charge, :initial_compliance_charge, charge_amount: 5),
+              additional_compliance_charge: build(:charge, :additional_compliance_charge, charge_amount: 3))
+      end
+      let(:band_2) do
+        build(:band,
+              initial_compliance_charge: build(:charge, :initial_compliance_charge, charge_amount: 6),
+              additional_compliance_charge: build(:charge, :additional_compliance_charge, charge_amount: 4))
+      end
+      let(:band_3) do
+        build(:band,
+              initial_compliance_charge: build(:charge, :initial_compliance_charge, charge_amount: 7),
+              additional_compliance_charge: build(:charge, :additional_compliance_charge, charge_amount: 5))
+      end
+      # rubocop:enable RSpec/IndexedLet
+
+      let(:exemptions) do
+        [
+          build(:exemption, band: band_1),
+          build(:exemption, band: band_2),
+          build(:exemption, band: band_3)
+        ]
+      end
+
+      context "when the order has no exemptions" do
+        let(:exemptions) { [] }
+
+        it { expect(highest_band).to be_nil }
+      end
+
+      context "when the order has a single band 1 exemption" do
+        let(:exemptions) { [build(:exemption, band: band_1)] }
+
+        it { expect(highest_band).to eq band_1 }
+      end
+
+      context "when the order has a single band 3 exemption" do
+        let(:exemptions) { [build(:exemption, band: band_3)] }
+
+        it { expect(highest_band).to eq band_3 }
+      end
+
+      context "when the order has multiple exemptions from the same band" do
+        let(:exemptions) do
+          [
+            build(:exemption, band: band_2),
+            build(:exemption, band: band_2)
+          ]
+        end
+
+        it { expect(highest_band).to eq band_2 }
+      end
+
+      context "when the order has multiple exemptions from different bands" do
+        let(:exemptions) do
+          [
+            build(:exemption, band: band_1),
+            build(:exemption, band: band_2)
+          ]
+        end
+
+        it { expect(highest_band).to eq band_2 }
+      end
+    end
+
+    describe "#bucket" do
+      subject(:order_bucket) { described_class.new(bucket:).bucket }
+
+      context "when the order has no bucket" do
+        let(:bucket) { nil }
+
+        it { expect(order_bucket).to be_nil }
+      end
+
+      context "when the order has a bucket" do
+        let(:bucket) { create(:bucket) }
+
+        it { expect(order_bucket).to eq bucket }
+      end
+    end
+
+    # This method is sytactic sugar for bucket not nil.
+    describe "#bucket?" do
+      subject(:has_bucket) { described_class.new(exemptions: [], bucket:).bucket? }
+      context "when the order does not include a bucket" do
+        let(:bucket) { nil }
+
+        it { expect(has_bucket).to be false }
+      end
+
+      context "when the order includes a bucket" do
+        let(:bucket) { build(:bucket) }
+
+        it { expect(has_bucket).to be true }
+      end
+    end
+  end
+end

--- a/spec/services/waste_exemptions_engine/charging_strategy_spec.rb
+++ b/spec/services/waste_exemptions_engine/charging_strategy_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+
+  RSpec.describe ChargingStrategy do
+    include_context "with bands and charges"
+    include_context "with an order with exemptions"
+
+    # A subclass of described_class with the virtual methods implemented for test purposes:
+    let(:strategy_test_class) do
+      Class.new(described_class) do
+        attr_reader :band_1, :band_2, :band_3
+
+        def initialize(order)
+          @band_1, @band_2, @band_3 = Band.all.limit(3).sort_by(&:sequence).to_a
+
+          super(order)
+        end
+
+        def initial_compliance_charge(band)
+          case band
+          when band_1, band_2
+            0
+          else
+            10
+          end
+        end
+
+        def additional_compliance_charge(band, _initial_compliance_charge_applied)
+          case band
+          when band_1
+            4
+          when band_2
+            5
+          else
+            7
+          end
+        end
+      end
+    end
+
+    describe "#registration_charge" do
+      subject(:strategy_registration_charge_amount) { strategy_test_class.new(order).registration_charge_amount }
+
+      shared_examples "constant registration charge" do
+        it { expect(strategy_registration_charge_amount).to eq registration_charge_amount }
+      end
+
+      context "with an empty order" do
+        let(:exemptions) { [] }
+
+        it { expect(strategy_registration_charge_amount).to be_zero }
+      end
+
+      context "with an order with a single exemption" do
+        let(:exemptions) { single_band_single_exemption }
+
+        it_behaves_like "constant registration charge"
+      end
+
+      context "with an order with multiple exemptions in a single band" do
+        let(:exemptions) { single_band_multiple_exemptions }
+
+        it_behaves_like "constant registration charge"
+      end
+
+      context "with an order with multiple exemptions in multiple bands" do
+        let(:exemptions) { multiple_bands_multiple_exemptions }
+
+        it_behaves_like "constant registration charge"
+      end
+    end
+
+    describe "#charge_details" do
+      subject(:charge_details) { strategy_test_class.new(order).charge_details }
+
+      let(:exemptions) { multiple_bands_multiple_exemptions }
+
+      it { expect(charge_details).to be_a(ChargeDetail) }
+      it { expect(charge_details.registration_charge_amount).to eq registration_charge_amount }
+      it { expect(charge_details.band_charge_details.length).to eq 3 }
+      it { expect(charge_details.bucket_charge_amount).to be_zero }
+    end
+
+    describe "#total_charge_amount" do
+      subject(:strategy) { strategy_test_class.new(order) }
+
+      let(:exemptions) { multiple_bands_multiple_exemptions }
+
+      it do
+        expect(strategy.total_charge_amount).to eq(
+          strategy.registration_charge_amount +
+          strategy.charge_details.band_charge_details.sum do |bc|
+            bc.initial_compliance_charge_amount + bc.additional_compliance_charge_amount
+          end
+        )
+      end
+    end
+  end
+end

--- a/spec/services/waste_exemptions_engine/farmer_charging_strategy_spec.rb
+++ b/spec/services/waste_exemptions_engine/farmer_charging_strategy_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe FarmerChargingStrategy do
+    include_context "with bands and charges"
+    include_context "with an order with exemptions"
+
+    let(:bucket_exemptions) do
+      [
+        build_list(:exemption, 3, band: band_1),
+        build_list(:exemption, 3, band: band_2),
+        build_list(:exemption, 3, band: band_3)
+      ].flatten
+    end
+
+    let(:bucket) { create(:bucket, :farmer_exemptions) }
+    let(:bucket_charge_amount) { bucket.initial_compliance_charge.charge_amount }
+
+    before do
+      bucket.exemptions << bucket_exemptions
+      order.bucket = bucket
+    end
+
+    describe "#charge_details" do
+      subject(:charge_details) { described_class.new(order).charge_details }
+      let(:band_charges) { charge_details.band_charge_details }
+      let(:total_compliance_charge_amount) do
+        band_charges.sum { |bc| bc.initial_compliance_charge_amount + bc.additional_compliance_charge_amount }
+      end
+
+      context "when there are no farmer bucket exemptions in the order" do
+        # let(:exemptions) { multiple_bands_multiple_exemptions }
+
+        it_behaves_like "non-bucket charging strategy #charge_details"
+      end
+
+      context "with an order with bucket exemptions only" do
+        let(:exemptions) { bucket_exemptions }
+
+        it { expect(charge_details.registration_charge_amount).to eq(registration_charge_amount) }
+
+        it { expect(band_charges.length).to eq 3 }
+        it { expect(band_charges[0].initial_compliance_charge_amount).to be_zero }
+        it { expect(band_charges[1].initial_compliance_charge_amount).to be_zero }
+        it { expect(band_charges[2].initial_compliance_charge_amount).to be_zero }
+
+        it { expect(charge_details.bucket_charge_amount).to eq bucket_charge_amount }
+
+        it { expect(charge_details.total_compliance_charge_amount).to eq bucket_charge_amount }
+        it { expect(charge_details.total_charge_amount).to eq registration_charge_amount + bucket_charge_amount }
+      end
+
+      context "with an order with both bucket and non-bucket exemptions" do
+        let(:exemptions) { bucket_exemptions + multiple_bands_multiple_exemptions }
+
+        it { expect(charge_details.registration_charge_amount).to eq(registration_charge_amount) }
+
+        it { expect(band_charges.length).to eq 3 }
+        it { expect(band_charges[0].initial_compliance_charge_amount).to be_zero }
+        it { expect(band_charges[0].additional_compliance_charge_amount).to eq(3 * band_1.additional_compliance_charge.charge_amount) }
+
+        it { expect(band_charges[1].initial_compliance_charge_amount).to be_zero }
+        it { expect(band_charges[1].additional_compliance_charge_amount).to eq(2 * band_2.additional_compliance_charge.charge_amount) }
+
+        it { expect(band_charges[2].initial_compliance_charge_amount).to be_zero }
+        it { expect(band_charges[2].additional_compliance_charge_amount).to eq(1 * band_3.additional_compliance_charge.charge_amount) }
+
+        it { expect(charge_details.bucket_charge_amount).to eq bucket_charge_amount }
+
+        it do
+          expect(charge_details.total_compliance_charge_amount).to eq(
+            bucket_charge_amount +
+            band_charges.sum { |bc| bc.initial_compliance_charge_amount + bc.additional_compliance_charge_amount }
+          )
+        end
+
+        it do
+          expect(charge_details.total_charge_amount).to eq(
+            registration_charge_amount +
+            total_compliance_charge_amount +
+            bucket_charge_amount
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_exemptions_engine/order_calculator_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/order_calculator_service_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe OrderCalculatorService do
+    include_context "with bands and charges"
+    include_context "with an order with exemptions"
+
+    subject(:service) { described_class.new(order) }
+
+    let(:bucket) { nil }
+    let(:exemptions) { multiple_bands_multiple_exemptions }
+    let(:order) { build(:order, exemptions:, bucket:) }
+
+    # The numbers here are just to suport stubbing the calculator methods - they are not internally consistent.
+    # Validation of charge value consistency is covered in the OrderCalculator specs.
+    let(:expected_registration_charge) { 5 }
+    let(:expected_compliance_charges) do
+      [
+        build(:band_charge_detail, initial_compliance_charge_amount: 10, additional_compliance_charge_amount: 5),
+        build(:band_charge_detail, initial_compliance_charge_amount: 15, additional_compliance_charge_amount: 12)
+      ]
+    end
+    let(:expected_total_compliance_charge) do
+      expected_compliance_charges.sum { |b| b.initial_compliance_charge_amount + b.additional_compliance_charge_amount }
+    end
+    let(:expected_total_charge) { expected_registration_charge + expected_total_compliance_charge }
+    let(:charge_detail) { build(:charge_detail) }
+
+    let(:calculator) do
+      instance_double(OrderCalculator,
+                      calculate_registration_charge: expected_registration_charge,
+                      calculate_compliance_charges: expected_compliance_charges,
+                      calculate_total_compliance_charge: expected_total_compliance_charge,
+                      calculate_total_charge: expected_total_charge,
+                      charge_details: charge_detail)
+    end
+
+    before { allow(OrderCalculator).to receive(:new).and_return(calculator) }
+
+    describe "#strategy_type" do
+      context "with an order without a bucket" do
+        it "returns the regular charging strategy class" do
+          expect(service.strategy_type).to eq(RegularChargingStrategy)
+        end
+      end
+
+      context "with an order with a non-farmer bucket" do
+        let(:bucket) { build(:bucket, name: "foo") }
+
+        it "returns the regular charging strategy type" do
+          expect(service.strategy_type).to eq(RegularChargingStrategy)
+        end
+      end
+
+      context "with an order with a farmer bucket" do
+        let(:bucket) { build(:bucket, name: "Farmer exemptions") }
+
+        it "returns the farmer charging strategy type" do
+          expect(service.strategy_type).to eq(FarmerChargingStrategy)
+        end
+      end
+    end
+
+    # These methods should all pass through to the calculator:
+
+    describe "#calculate_registration_charge" do
+      it { expect(service.calculate_registration_charge).to eq calculator.calculate_registration_charge }
+    end
+
+    describe "#calculate_compliance_charges" do
+      it { expect(service.calculate_compliance_charges).to eq calculator.calculate_compliance_charges }
+    end
+
+    describe "#calculate_total_compliance_charge" do
+      it { expect(service.calculate_total_compliance_charge).to eq calculator.calculate_total_compliance_charge }
+    end
+
+    describe "#calculate_total_charge" do
+      it { expect(service.calculate_total_charge).to eq calculator.calculate_total_charge }
+    end
+
+    describe "#charge_details" do
+      it { expect(service.charge_details).to eq charge_detail }
+    end
+  end
+end

--- a/spec/services/waste_exemptions_engine/order_calculator_spec.rb
+++ b/spec/services/waste_exemptions_engine/order_calculator_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+
+  RSpec.describe OrderCalculator do
+    include_context "with bands and charges"
+    include_context "with an order with exemptions"
+
+    subject(:calculator) { described_class.new(strategy: RegularChargingStrategy, order:) }
+    let(:order) { build(:order, exemptions:) }
+
+    let(:exemptions) { multiple_bands_multiple_exemptions }
+
+    describe "#calculate_registration_charge" do
+      context "with an empty order" do
+        let(:exemptions) { [] }
+
+        it { expect(calculator.calculate_registration_charge).to be_zero }
+      end
+
+      context "with an order with a single exemption" do
+        let(:exemptions) { single_band_single_exemption }
+
+        it { expect(calculator.calculate_registration_charge).to eq registration_charge_amount }
+      end
+
+      context "with an order with multiple exemptions in multiple bands" do
+        let(:exemptions) { multiple_bands_multiple_exemptions }
+
+        it { expect(calculator.calculate_registration_charge).to eq registration_charge_amount }
+      end
+    end
+
+    describe "#calculate_compliance_charges" do
+      context "with an empty order" do
+        let(:exemptions) { [] }
+
+        it { expect(calculator.calculate_compliance_charges).to be_empty }
+      end
+
+      context "with an order with a single exemption" do
+        let(:exemptions) { single_band_single_exemption }
+
+        it do
+          band_detail = calculator.calculate_compliance_charges.first
+          aggregate_failures do
+            expect(band_detail.band_id).to eq band_1.id
+            expect(band_detail.initial_compliance_charge_amount).to eq band_1.initial_compliance_charge.charge_amount
+            expect(band_detail.additional_compliance_charge_amount).to be_zero
+          end
+        end
+      end
+
+      context "with an order with exemptions in multiple bands" do
+        let(:exemptions) { multiple_bands_multiple_exemptions }
+        let(:band_details) { calculator.calculate_compliance_charges }
+        let(:band_1_details) { band_details.select { |b| b.band_id == band_1.id }.first }
+        let(:band_2_details) { band_details.select { |b| b.band_id == band_2.id }.first }
+        let(:band_3_details) { band_details.select { |b| b.band_id == band_3.id }.first }
+
+        it do
+          aggregate_failures do
+            expect(band_1_details.initial_compliance_charge_amount).to be_zero
+            expect(band_1_details.additional_compliance_charge_amount).to eq(
+              3 * band_1.additional_compliance_charge.charge_amount
+            )
+
+            expect(band_2_details.initial_compliance_charge_amount).to be_zero
+            expect(band_2_details.additional_compliance_charge_amount).to eq(
+              2 * band_2.additional_compliance_charge.charge_amount
+            )
+
+            expect(band_3_details.initial_compliance_charge_amount).to eq(
+              band_3.initial_compliance_charge.charge_amount
+            )
+            expect(band_3_details.additional_compliance_charge_amount).to be_zero
+          end
+        end
+      end
+    end
+
+    describe "#calculate_total_compliance_charge" do
+      context "with an empty order" do
+        let(:exemptions) { [] }
+
+        it { expect(calculator.calculate_total_compliance_charge).to be_zero }
+      end
+
+      context "with an order with a single exemption" do
+        let(:exemptions) { single_band_single_exemption }
+
+        it do
+          expect(calculator.calculate_total_compliance_charge).to eq(
+            band_1.initial_compliance_charge.charge_amount
+          )
+        end
+      end
+
+      context "with an order with exemptions in multiple bands" do
+        let(:exemptions) { multiple_bands_multiple_exemptions }
+
+        it do
+          expect(calculator.calculate_total_compliance_charge).to eq(
+            (3 * band_1.additional_compliance_charge.charge_amount) +
+            (2 * band_2.additional_compliance_charge.charge_amount) +
+            band_3.initial_compliance_charge.charge_amount
+          )
+        end
+      end
+    end
+
+    describe "#calculate_total_charge" do
+      context "with an empty order" do
+        let(:exemptions) { [] }
+
+        it { expect(calculator.calculate_total_charge).to be_zero }
+      end
+
+      context "with an order with a single exemption" do
+        let(:exemptions) { single_band_single_exemption }
+
+        it do
+          expect(calculator.calculate_total_charge).to eq(
+            registration_charge_amount +
+            band_1.initial_compliance_charge.charge_amount
+          )
+        end
+      end
+
+      context "with an order with exemptions in multiple bands" do
+        let(:exemptions) { multiple_bands_multiple_exemptions }
+
+        it do
+          expect(calculator.calculate_total_charge).to eq(
+            registration_charge_amount +
+            (3 * band_1.additional_compliance_charge.charge_amount) +
+            (2 * band_2.additional_compliance_charge.charge_amount) +
+            band_3.initial_compliance_charge.charge_amount
+          )
+        end
+      end
+    end
+
+    describe "#charge_details" do
+      it { expect(calculator.charge_details).to be_a(ChargeDetail) }
+      it { expect(calculator.charge_details.band_charge_details.length).to eq 3 }
+    end
+  end
+end

--- a/spec/services/waste_exemptions_engine/regular_charging_strategy_spec.rb
+++ b/spec/services/waste_exemptions_engine/regular_charging_strategy_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe RegularChargingStrategy do
+    include_context "with bands and charges"
+    include_context "with an order with exemptions"
+
+    describe "#charge_details" do
+      it_behaves_like "non-bucket charging strategy #charge_details"
+    end
+  end
+end

--- a/spec/support/factories/band.rb
+++ b/spec/support/factories/band.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :band, class: "WasteExemptionsEngine::Band" do
-    name { "Band #{Faker::Lorem.unique.word}" }
-    sequence(:sequence) { Faker::Number.unique.between(from: 1, to: 99) } # reserved word
+    sequence(:name) { |n| "Band #{Faker::Lorem.word}_#{n}" }
+    sequence(:sequence) { Faker::Number.unique.between(from: 1, to: 9999) } # "sequence" is a reserved word
 
     initial_compliance_charge { association :charge, :initial_compliance_charge }
     additional_compliance_charge { association :charge, :additional_compliance_charge }

--- a/spec/support/factories/band_charge_detail.rb
+++ b/spec/support/factories/band_charge_detail.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :band_charge_detail, class: "WasteExemptionsEngine::BandChargeDetail" do
+    initial_compliance_charge_amount { Faker::Number.between(from: 7, to: 20) }
+    additional_compliance_charge_amount { Faker::Number.between(from: 5, to: 10) }
+  end
+end

--- a/spec/support/factories/charge.rb
+++ b/spec/support/factories/charge.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :charge, class: "WasteExemptionsEngine::Charge" do
-    name { "#{Faker::Lorem.unique.word} charge" }
+    sequence(:name) { |n| "#{Faker::Lorem.word}_#{n} charge" }
     charge_type { %w[registration_charge initial_compliance_charge additional_compliance_charge].sample }
     charge_amount { Faker::Number.between(from: 10_000, to: 99_900) }
 

--- a/spec/support/factories/charge_detail.rb
+++ b/spec/support/factories/charge_detail.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :charge_detail, class: "WasteExemptionsEngine::ChargeDetail" do
+    registration_charge_amount { Faker::Number.between(from: 6, to: 11) }
+    band_charge_details do
+      [
+        build(:band_charge_detail,
+              initial_compliance_charge_amount: Faker::Number.between(from: 7, to: 20),
+              additional_compliance_charge_amount: Faker::Number.between(from: 5, to: 10)),
+        build(:band_charge_detail,
+              initial_compliance_charge_amount: Faker::Number.between(from: 7, to: 20),
+              additional_compliance_charge_amount: Faker::Number.between(from: 5, to: 10)),
+        build(:band_charge_detail,
+              initial_compliance_charge_amount: Faker::Number.between(from: 7, to: 20),
+              additional_compliance_charge_amount: Faker::Number.between(from: 5, to: 10))
+      ]
+    end
+  end
+end

--- a/spec/support/factories/order.rb
+++ b/spec/support/factories/order.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :order, class: "WasteExemptionsEngine::Order" do
+
+    trait :with_exemptions do
+      exemptions { build_list(:exemption, 3, band: build(:band)) }
+    end
+
+    trait :with_bucket do
+      association :bucket
+    end
+  end
+end

--- a/spec/support/shared_contexts/bands_and_charges.rb
+++ b/spec/support/shared_contexts/bands_and_charges.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with bands and charges" do
+  let!(:registration_charge_entity) { create(:charge, :registration_charge) }
+  let(:registration_charge_amount) { registration_charge_entity.charge_amount }
+
+  # rubocop:disable RSpec/IndexedLet,RSpec/LetSetup
+  let!(:band_1) do
+    create(:band,
+           initial_compliance_charge: build(:charge, :initial_compliance_charge, charge_amount: 5),
+           additional_compliance_charge: build(:charge, :additional_compliance_charge, charge_amount: 4))
+  end
+  let!(:band_2) do
+    create(:band,
+           initial_compliance_charge: build(:charge, :initial_compliance_charge, charge_amount: 7),
+           additional_compliance_charge: build(:charge, :additional_compliance_charge, charge_amount: 5))
+  end
+  let!(:band_3) do
+    create(:band,
+           initial_compliance_charge: build(:charge, :initial_compliance_charge, charge_amount: 10),
+           additional_compliance_charge: build(:charge, :additional_compliance_charge, charge_amount: 7))
+  end
+  # rubocop:enable RSpec/IndexedLet,RSpec/LetSetup
+end

--- a/spec/support/shared_contexts/order_with_exemptions.rb
+++ b/spec/support/shared_contexts/order_with_exemptions.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with an order with exemptions" do
+  let(:single_band_single_exemption) { [create(:exemption, band: band_1)] }
+  let(:single_band_multiple_exemptions) { create_list(:exemption, 3, band: band_1) }
+  let(:multiple_bands_multiple_exemptions) do
+    [
+      build_list(:exemption, 3, band: band_1),
+      build_list(:exemption, 2, band: band_2),
+      build_list(:exemption, 1, band: band_3)
+    ].flatten
+  end
+
+  let(:order) { create(:order, exemptions:) }
+end

--- a/spec/support/shared_examples/services/non_bucket_charging_strategy_charge_details.rb
+++ b/spec/support/shared_examples/services/non_bucket_charging_strategy_charge_details.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "non-bucket charging strategy #charge_details" do
+  subject(:charge_details) { described_class.new(order).charge_details }
+
+  let(:band_charges) { charge_details.band_charge_details }
+  let(:total_compliance_charge_amount) do
+    band_charges.sum { |bc| bc.initial_compliance_charge_amount + bc.additional_compliance_charge_amount }
+  end
+
+  context "with an empty order" do
+    let(:exemptions) { [] }
+
+    it { expect(charge_details.registration_charge_amount).to be_zero }
+    it { expect(band_charges).to be_empty }
+    it { expect(charge_details.total_compliance_charge_amount).to be_zero }
+    it { expect(charge_details.total_charge_amount).to be_zero }
+  end
+
+  context "with an order with a single exemption" do
+    let(:exemptions) { single_band_single_exemption }
+
+    it { expect(charge_details.registration_charge_amount).to eq(registration_charge_amount) }
+    it { expect(band_charges.length).to eq 1 }
+
+    it do
+      aggregate_failures do
+        expect(band_charges.first.initial_compliance_charge_amount).to eq(band_1.initial_compliance_charge.charge_amount)
+        expect(band_charges.first.additional_compliance_charge_amount).to be_zero
+        expect(band_charges.first.total_compliance_charge_amount).to eq(band_1.initial_compliance_charge.charge_amount)
+      end
+    end
+
+    it { expect(charge_details.total_compliance_charge_amount).to eq total_compliance_charge_amount }
+    it { expect(charge_details.total_charge_amount).to eq registration_charge_amount + total_compliance_charge_amount }
+  end
+
+  context "with an order with multiple exemptions in multiple bands" do
+    let(:exemptions) { multiple_bands_multiple_exemptions }
+
+    it { expect(charge_details.registration_charge_amount).to eq(registration_charge_amount) }
+    it { expect(band_charges.length).to eq 3 }
+
+    it { expect(band_charges[0].initial_compliance_charge_amount).to be_zero }
+    it { expect(band_charges[0].additional_compliance_charge_amount).to eq(3 * band_1.additional_compliance_charge.charge_amount) }
+
+    it { expect(band_charges[1].initial_compliance_charge_amount).to be_zero }
+    it { expect(band_charges[1].additional_compliance_charge_amount).to eq(2 * band_2.additional_compliance_charge.charge_amount) }
+
+    it { expect(band_charges[2].initial_compliance_charge_amount).to eq(band_3.initial_compliance_charge.charge_amount) }
+    it { expect(band_charges[2].additional_compliance_charge_amount).to be_zero }
+
+    it { expect(charge_details.total_compliance_charge_amount).to eq total_compliance_charge_amount }
+    it { expect(charge_details.total_charge_amount).to eq registration_charge_amount + total_compliance_charge_amount }
+  end
+end


### PR DESCRIPTION
This change introduces the following models and services:
- Order model to encapsulate a set of registration exemptions
- ChargeDetail model to capture the actual charges applied to a specific order
- BandChargeDetail to capture the actual per-band charges applied to a specific order
- Abstract ChargingStrategy base class to determine which charges to apply to a given order
- Concrete RegularChargingStrategy for use when the order does not include a Farmer exemptions bucket
- Concrete FarmerChargingStrategy for use when the order includes a Farmer exemptions bucket
- OrderCalculator to apply the strategy to the order (once only) and make various charge details available to the caller
- OrderCalculatorService to determine which strategy to apply to a given order and apply it
https://eaflood.atlassian.net/browse/RUBY-3049