### PR TITLE
RUBY 4063 wex multiple site improve the ux on the site page

### DIFF
--- a/app/controllers/concerns/waste_exemptions_engine/can_redirect_sites_form_to_last_page.rb
+++ b/app/controllers/concerns/waste_exemptions_engine/can_redirect_sites_form_to_last_page.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  module CanRedirectSitesFormToLastPage
+    extend ActiveSupport::Concern
+
+    private
+
+    def form_path
+      return new_sites_form_path(token: @transient_registration.token, page: "last") if @transient_registration.workflow_state == "sites_form"
+
+      super
+    end
+  end
+end

--- a/app/controllers/concerns/waste_exemptions_engine/can_redirect_sites_form_to_last_page.rb
+++ b/app/controllers/concerns/waste_exemptions_engine/can_redirect_sites_form_to_last_page.rb
@@ -7,7 +7,10 @@ module WasteExemptionsEngine
     private
 
     def form_path
-      return new_sites_form_path(token: @transient_registration.token, page: "last") if @transient_registration.workflow_state == "sites_form"
+      if @transient_registration.workflow_state == "sites_form"
+        return new_sites_form_path(token: @transient_registration.token,
+                                   page: "last")
+      end
 
       super
     end

--- a/app/controllers/waste_exemptions_engine/site_address_lookup_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/site_address_lookup_forms_controller.rb
@@ -2,6 +2,8 @@
 
 module WasteExemptionsEngine
   class SiteAddressLookupFormsController < AddressLookupFormsController
+    include CanRedirectSitesFormToLastPage
+
     def new
       super(SiteAddressLookupForm, "site_address_lookup_form")
     end

--- a/app/controllers/waste_exemptions_engine/site_grid_reference_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/site_grid_reference_forms_controller.rb
@@ -2,6 +2,8 @@
 
 module WasteExemptionsEngine
   class SiteGridReferenceFormsController < FormsController
+    include CanRedirectSitesFormToLastPage
+
     def new
       super(SiteGridReferenceForm, "site_grid_reference_form")
     end

--- a/app/controllers/waste_exemptions_engine/sites_forms_controller.rb
+++ b/app/controllers/waste_exemptions_engine/sites_forms_controller.rb
@@ -2,6 +2,8 @@
 
 module WasteExemptionsEngine
   class SitesFormsController < FormsController
+    include CanRedirectSitesFormToLastPage
+
     def new
       super(SitesForm, "sites_form")
       return unless @sites_form

--- a/app/forms/waste_exemptions_engine/sites_form.rb
+++ b/app/forms/waste_exemptions_engine/sites_form.rb
@@ -4,7 +4,7 @@ require "kaminari"
 
 module WasteExemptionsEngine
   class SitesForm < BaseForm
-    def site_addresses(page = nil)
+    def site_addresses(page = 1)
       Kaminari.paginate_array(site_addresses_scope.to_a)
               .page(page_to_display(page))
               .per(sites_per_page)
@@ -19,9 +19,10 @@ module WasteExemptionsEngine
     end
 
     def page_to_display(page = nil)
-      return last_page if page.blank?
+      return last_page if page == "last"
 
-      page.to_i.clamp(1, last_page)
+      page_number = page.presence || 1
+      page_number.to_i.clamp(1, last_page)
     end
 
     def can_continue?

--- a/spec/forms/waste_exemptions_engine/sites_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/sites_form_spec.rb
@@ -109,12 +109,16 @@ module WasteExemptionsEngine
                     address_type: "site")
       end
 
-      it "defaults to the last page when no page is requested" do
-        expect(form.page_to_display).to eq(3)
+      it "defaults to the first page when no page is requested" do
+        expect(form.page_to_display).to eq(1)
       end
 
       it "returns the requested page when it is within range" do
         expect(form.page_to_display(2)).to eq(2)
+      end
+
+      it "returns the last page when explicitly requested" do
+        expect(form.page_to_display("last")).to eq(3)
       end
 
       it "clamps an out of range page to the last page" do

--- a/spec/requests/waste_exemptions_engine/site_address_lookup_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_address_lookup_forms_spec.rb
@@ -7,10 +7,21 @@ module WasteExemptionsEngine
     before { VCR.insert_cassette("postcode_valid", allow_playback_repeats: true) }
     after { VCR.eject_cassette }
 
+    let(:form) { build(:site_address_lookup_form) }
+
     it_behaves_like "GET form", :site_address_lookup_form, "/site-address-lookup"
     it_behaves_like "POST form", :site_address_lookup_form, "/site-address-lookup" do
       let(:form_data) { { site_address: { uprn: "340116" } } }
       let(:invalid_form_data) { [{ site_address: { uprn: nil } }] }
+    end
+
+    it "redirects to the last sites page after adding a looked-up multisite address" do
+      form.transient_registration.update!(is_multisite_registration: true)
+
+      post site_address_lookup_forms_path(token: form.token),
+           params: { site_address_lookup_form: { site_address: { uprn: "340116" } } }
+
+      expect(response).to redirect_to(new_sites_form_path(token: form.token, page: "last"))
     end
   end
 end

--- a/spec/requests/waste_exemptions_engine/site_grid_reference_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/site_grid_reference_forms_spec.rb
@@ -118,6 +118,16 @@ module WasteExemptionsEngine
           end
         end
       end
+
+      context "when the registration is multisite" do
+        before { form.transient_registration.update!(is_multisite_registration: true) }
+
+        it "redirects to the last sites page after adding a site" do
+          post site_grid_reference_request_path, params: { site_grid_reference_form: form_data }
+
+          expect(response).to redirect_to(new_sites_form_path(token: form.token, page: "last"))
+        end
+      end
     end
 
     context "when editing an existing registration" do

--- a/spec/requests/waste_exemptions_engine/sites_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/sites_forms_spec.rb
@@ -54,8 +54,17 @@ module WasteExemptionsEngine
                  grid_reference: "ST 33333 33333")
         end
 
-        it "defaults to the last numbered page when no page is provided" do
+        it "shows the first page when no page is provided" do
           get request_path
+
+          aggregate_failures do
+            expect(response.body).to include("Site 1 description")
+            expect(response.body).not_to include("Site 3 description")
+          end
+        end
+
+        it "shows the last numbered page when page=last is provided" do
+          get request_path, params: { page: "last" }
 
           aggregate_failures do
             expect(response.body).to include("Site 3 description")
@@ -112,7 +121,7 @@ module WasteExemptionsEngine
               delete request_path
             end.to change { transient_registration.addresses.where(address_type: "site").count }.by(-1)
 
-            expect(response).to redirect_to(new_sites_form_path(form.token, page: nil))
+            expect(response).to redirect_to(new_sites_form_path(token: form.token, page: "last"))
           end
         end
 
@@ -122,9 +131,9 @@ module WasteExemptionsEngine
         end
 
         context "with page parameter" do
-          it "redirects without a page parameter so the last page is shown" do
+          it "redirects to the explicit last page" do
             delete request_path, params: { page: 2 }
-            expect(response).to redirect_to(new_sites_form_path(form.token))
+            expect(response).to redirect_to(new_sites_form_path(token: form.token, page: "last"))
           end
         end
 
@@ -172,7 +181,7 @@ module WasteExemptionsEngine
 
         it "redirects back to sites page with error" do
           delete invalid_request_path
-          expect(response).to redirect_to(new_sites_form_path(form.token, page: nil))
+          expect(response).to redirect_to(new_sites_form_path(token: form.token, page: "last"))
         end
 
         it "does not remove any sites" do
@@ -195,7 +204,7 @@ module WasteExemptionsEngine
 
         it "redirects back to sites page" do
           delete other_site_request_path
-          expect(response).to redirect_to(new_sites_form_path(form.token, page: nil))
+          expect(response).to redirect_to(new_sites_form_path(token: form.token, page: "last"))
         end
       end
 


### PR DESCRIPTION
- [RUBY-4063] Fix multisite sites form pagination bug where users could get stuck on the last Sites page after the previous pagination change.

- Restore normal pagination behaviour on the Sites page
- Only redirect to the last page when returning to `sites_form` after:
    - adding a site via grid reference
    - adding a site via address lookup
    - deleting a site


[RUBY-4063]: https://eaflood.atlassian.net/browse/RUBY-4063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ