### PR TITLE
RUBY-4266 Update defra_ruby_validators

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       defra_ruby_companies_house
       defra_ruby_email
       defra_ruby_govpay
-      defra_ruby_validators (~> 3.0)
+      defra_ruby_validators
       ffi-geos (~> 1.2.0)
       high_voltage (~> 3.1)
       kaminari

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     defra_ruby_govpay (1.1.0)
       rest-client (~> 2.1)
     defra_ruby_style (0.4.1)
-    defra_ruby_validators (3.0.0)
+    defra_ruby_validators (3.0.1)
       activemodel
       defra_ruby_companies_house
       i18n

--- a/waste_exemptions_engine.gemspec
+++ b/waste_exemptions_engine.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
 
   # Validations
   # A defra created gem of shared validators
-  s.add_dependency "defra_ruby_validators", "~> 3.0"
+  s.add_dependency "defra_ruby_validators"
 
   # Use the companies house gem to access the Companies House API
   s.add_dependency "defra_ruby_companies_house"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4266
Removes the pinned defra_ruby_validators dependency constraint and updates defra_ruby_validators.