### PR TITLE
[RUBY-4286] Trim whitespace from grid reference on submission

### DIFF
--- a/app/forms/waste_exemptions_engine/site_grid_reference_form.rb
+++ b/app/forms/waste_exemptions_engine/site_grid_reference_form.rb
@@ -19,6 +19,7 @@ module WasteExemptionsEngine
     end
 
     def submit(params)
+      params[:grid_reference] = params[:grid_reference]&.strip
       self.grid_reference = params[:grid_reference]
       self.description = params[:description]
 

--- a/spec/forms/waste_exemptions_engine/site_grid_reference_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/site_grid_reference_form_spec.rb
@@ -143,10 +143,12 @@ module WasteExemptionsEngine
           params = { grid_reference: "  ST 58337 72855  ", description: "A site description" }
           transient_registration = form.transient_registration
 
-          expect(form.submit(params)).to be(true)
+          aggregate_failures do
+            expect(form.submit(params)).to be(true)
 
-          transient_registration.reload
-          expect(transient_registration.site_address.grid_reference).to eq("ST 58337 72855")
+            transient_registration.reload
+            expect(transient_registration.site_address.grid_reference).to eq("ST 58337 72855")
+          end
         end
       end
 

--- a/spec/forms/waste_exemptions_engine/site_grid_reference_form_spec.rb
+++ b/spec/forms/waste_exemptions_engine/site_grid_reference_form_spec.rb
@@ -138,6 +138,18 @@ module WasteExemptionsEngine
         end
       end
 
+      context "when the grid reference has leading or trailing whitespace" do
+        it "strips whitespace and submits successfully" do
+          params = { grid_reference: "  ST 58337 72855  ", description: "A site description" }
+          transient_registration = form.transient_registration
+
+          expect(form.submit(params)).to be(true)
+
+          transient_registration.reload
+          expect(transient_registration.site_address.grid_reference).to eq("ST 58337 72855")
+        end
+      end
+
       context "when creating a new multisite site" do
         let(:transient_registration) do
           create(:new_charged_registration,


### PR DESCRIPTION
WEX - Remove whitespace from grid reference field on site-grid-reference page
https://eaflood.atlassian.net/browse/RUBY-4286