### PR TITLE
implement message delivery status call back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       TZ: UTC
       WEX_GOVPAY_CALLBACK_WEBHOOK_SIGNING_SECRET: foo
       WEX_GOVPAY_BACK_OFFICE_CALLBACK_WEBHOOK_SIGNING_SECRET: foo2
+      NOTIFY_CALLBACK_BEARER_TOKEN: test-notify-bearer-token
 
 
     # Service containers to run with `runner-job`

--- a/app/controllers/waste_exemptions_engine/notify_callbacks_controller.rb
+++ b/app/controllers/waste_exemptions_engine/notify_callbacks_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class NotifyCallbacksController < ::WasteExemptionsEngine::ApplicationController
+    protect_from_forgery with: :null_session
+
+    def process_callback
+      validate_bearer_token!
+
+      request.body.rewind
+      body = request.body.read
+      payload = JSON.parse(body)
+
+      NotifyCallbackJob.perform_later(payload)
+    rescue StandardError => e
+      Rails.logger.error "Notify callback error: #{e}"
+      Airbrake.notify(e)
+    ensure
+      head :ok
+    end
+
+    private
+
+    def validate_bearer_token!
+      expected_token = ENV.fetch("NOTIFY_CALLBACK_BEARER_TOKEN", nil)
+      raise "Notify callback bearer token not configured" if expected_token.blank?
+
+      auth_header = request.headers["Authorization"]
+      raise "Missing Authorization header" if auth_header.blank?
+
+      token = auth_header.sub(/\ABearer\s+/, "")
+      return if ActiveSupport::SecurityUtils.secure_compare(token, expected_token)
+
+      raise "Invalid bearer token"
+    end
+  end
+end

--- a/app/controllers/waste_exemptions_engine/notify_callbacks_controller.rb
+++ b/app/controllers/waste_exemptions_engine/notify_callbacks_controller.rb
@@ -11,6 +11,7 @@ module WasteExemptionsEngine
     def process_callback
       validate_bearer_token!
 
+      # need to rewind in case already read
       request.body.rewind
       body = request.body.read
       payload = JSON.parse(body)

--- a/app/controllers/waste_exemptions_engine/notify_callbacks_controller.rb
+++ b/app/controllers/waste_exemptions_engine/notify_callbacks_controller.rb
@@ -2,6 +2,10 @@
 
 module WasteExemptionsEngine
   class NotifyCallbacksController < ::WasteExemptionsEngine::ApplicationController
+    class TokenNotConfiguredError < StandardError; end
+    class MissingAuthorizationError < StandardError; end
+    class InvalidTokenError < StandardError; end
+
     protect_from_forgery with: :null_session
 
     def process_callback
@@ -23,15 +27,15 @@ module WasteExemptionsEngine
 
     def validate_bearer_token!
       expected_token = ENV.fetch("NOTIFY_CALLBACK_BEARER_TOKEN", nil)
-      raise "Notify callback bearer token not configured" if expected_token.blank?
+      raise TokenNotConfiguredError, "Notify callback bearer token not configured" if expected_token.blank?
 
       auth_header = request.headers["Authorization"]
-      raise "Missing Authorization header" if auth_header.blank?
+      raise MissingAuthorizationError, "Missing Authorization header" if auth_header.blank?
 
       token = auth_header.sub(/\ABearer\s+/, "")
       return if ActiveSupport::SecurityUtils.secure_compare(token, expected_token)
 
-      raise "Invalid bearer token"
+      raise InvalidTokenError, "Invalid bearer token"
     end
   end
 end

--- a/app/jobs/waste_exemptions_engine/notify_callback_job.rb
+++ b/app/jobs/waste_exemptions_engine/notify_callback_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class NotifyCallbackJob < ApplicationJob
+    self.log_arguments = false
+
+    def perform(callback_payload)
+      result = NotifyCallbackHandlerService.run(callback_payload)
+
+      Rails.logger.info "Processed Notify callback for notification_id: #{result[:notification_id]}, " \
+                        "status: #{result[:status]}"
+    rescue StandardError => e
+      notification_id = callback_payload["id"] || callback_payload["notification_id"]
+      Rails.logger.error "Error running NotifyCallbackJob for notification_id #{notification_id}: #{e}"
+      Airbrake.notify(e, notification_id: notification_id)
+    end
+  end
+end

--- a/app/models/waste_exemptions_engine/communication_log.rb
+++ b/app/models/waste_exemptions_engine/communication_log.rb
@@ -6,8 +6,10 @@ module WasteExemptionsEngine
     self.table_name = "communication_logs"
 
     MESSAGE_TYPES = %w[letter email text].freeze
+    STATUSES = %w[sent sending delivered permanent-failure temporary-failure technical-failure returned].freeze
 
     validates :message_type, presence: true, inclusion: { in: MESSAGE_TYPES }
+    validates :status, inclusion: { in: STATUSES }, allow_nil: true
 
     belongs_to :registration
   end

--- a/app/services/waste_exemptions_engine/notify_callback_handler_service.rb
+++ b/app/services/waste_exemptions_engine/notify_callback_handler_service.rb
@@ -2,7 +2,7 @@
 
 module WasteExemptionsEngine
   class NotifyCallbackHandlerService < BaseService
-    NOTIFICATION_STATUSES = %w[delivered permanent-failure technical-failure returned].freeze
+    TERMINAL_STATUSES = %w[delivered permanent-failure technical-failure returned].freeze
 
     def run(callback_payload)
       @payload = callback_payload.deep_symbolize_keys
@@ -44,7 +44,7 @@ module WasteExemptionsEngine
         return { notification_id: notification_id, status: "not_found" }
       end
 
-      if NOTIFICATION_STATUSES.include?(communication_log.status)
+      if TERMINAL_STATUSES.include?(communication_log.status)
         Rails.logger.info "Ignoring Notify callback for notification_id #{notification_id}: " \
                           "already in terminal status '#{communication_log.status}'"
         return { notification_id: notification_id, status: communication_log.status }

--- a/app/services/waste_exemptions_engine/notify_callback_handler_service.rb
+++ b/app/services/waste_exemptions_engine/notify_callback_handler_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module WasteExemptionsEngine
+  class NotifyCallbackHandlerService < BaseService
+    NOTIFICATION_STATUSES = %w[delivered permanent-failure technical-failure returned].freeze
+
+    def run(callback_payload)
+      @payload = callback_payload.deep_symbolize_keys
+
+      if @payload.key?(:notification_type)
+        process_delivery_receipt
+      elsif @payload.key?(:notification_id) && !@payload.key?(:status)
+        process_returned_letter
+      else
+        raise ArgumentError, "Unrecognised Notify callback payload"
+      end
+    end
+
+    private
+
+    def process_delivery_receipt
+      notification_id = @payload[:id]
+      new_status = @payload[:status]
+
+      raise ArgumentError, "Missing id in delivery receipt" if notification_id.blank?
+      raise ArgumentError, "Missing status in delivery receipt" if new_status.blank?
+
+      update_communication_log(notification_id, new_status)
+    end
+
+    def process_returned_letter
+      notification_id = @payload[:notification_id]
+
+      raise ArgumentError, "Missing notification_id in returned letter" if notification_id.blank?
+
+      update_communication_log(notification_id, "returned")
+    end
+
+    def update_communication_log(notification_id, new_status)
+      communication_log = CommunicationLog.find_by(notification_id: notification_id)
+
+      unless communication_log
+        Rails.logger.warn "CommunicationLog not found for notification_id: #{notification_id}"
+        return { notification_id: notification_id, status: "not_found" }
+      end
+
+      if NOTIFICATION_STATUSES.include?(communication_log.status)
+        Rails.logger.info "Ignoring Notify callback for notification_id #{notification_id}: " \
+                          "already in terminal status '#{communication_log.status}'"
+        return { notification_id: notification_id, status: communication_log.status }
+      end
+
+      communication_log.update!(status: new_status)
+
+      { notification_id: notification_id, status: new_status }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -556,6 +556,9 @@ WasteExemptionsEngine::Engine.routes.draw do
   # GOV.uk pay webhook callback route
   post "/govpay_payment_update", to: "govpay_webhook_callbacks#process_webhook", as: "process_govpay_webhook"
 
+  # GOV.UK Notify callback route
+  post "/notify_callback", to: "notify_callbacks#process_callback", as: "notify_callback"
+
   # Static pages with HighVoltage
   resources :pages, only: [:show], controller: "pages"
 

--- a/db/migrate/20260519173129_add_index_to_communication_logs_notification_id.rb
+++ b/db/migrate/20260519173129_add_index_to_communication_logs_notification_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToCommunicationLogsNotificationId < ActiveRecord::Migration[7.2]
+  def change
+    add_index :communication_logs, :notification_id
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_14_163943) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_19_173129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -168,6 +168,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_14_163943) do
     t.string "subject"
     t.text "body"
     t.string "status", default: "sent"
+    t.index ["notification_id"], name: "index_communication_logs_on_notification_id"
   end
 
   create_table "companies", force: :cascade do |t|

--- a/spec/fixtures/files/notify/delivery_receipt_callback.json
+++ b/spec/fixtures/files/notify/delivery_receipt_callback.json
@@ -1,0 +1,12 @@
+{
+  "id": "740e5834-3a29-46b4-9a6f-16142fde533a",
+  "reference": "WEX999999",
+  "to": "recipient@example.com",
+  "status": "delivered",
+  "created_at": "2026-05-14T12:15:30.000000Z",
+  "completed_at": "2026-05-14T12:15:30.000000Z",
+  "sent_at": "2026-05-14T12:15:30.000000Z",
+  "notification_type": "email",
+  "template_id": "f33517ff-2a88-4f6e-b855-c550268ce08a",
+  "template_version": 1
+}

--- a/spec/fixtures/files/notify/returned_letter_callback.json
+++ b/spec/fixtures/files/notify/returned_letter_callback.json
@@ -1,0 +1,12 @@
+{
+  "notification_id": "740e5834-3a29-46b4-9a6f-16142fde533a",
+  "reference": "WEX999999",
+  "date_sent": "2026-05-14T12:15:30.000000Z",
+  "sent_by": "sender@example.com",
+  "template_name": "confirmation_letter",
+  "template_id": "f33517ff-2a88-4f6e-b855-c550268ce08a",
+  "template_version": 1,
+  "spreadsheet_file_name": null,
+  "spreadsheet_row_number": null,
+  "upload_letter_file_name": null
+}

--- a/spec/jobs/waste_exemptions_engine/notify_callback_job_spec.rb
+++ b/spec/jobs/waste_exemptions_engine/notify_callback_job_spec.rb
@@ -44,38 +44,34 @@ module WasteExemptionsEngine
           allow(Rails.logger).to receive(:error)
         end
 
-        it "notifies Airbrake" do
-          perform_now
+        context "with a delivery receipt callback payload" do
+          it "notifies Airbrake" do
+            perform_now
 
-          expect(Airbrake).to have_received(:notify).with(
-            an_instance_of(StandardError),
-            hash_including(notification_id: "test-uuid")
-          )
+            expect(Airbrake).to have_received(:notify).with(
+              an_instance_of(StandardError),
+              hash_including(notification_id: "test-uuid")
+            )
+          end
+
+          it "logs the error" do
+            perform_now
+
+            expect(Rails.logger).to have_received(:error).with(/Error running NotifyCallbackJob/)
+          end
         end
 
-        it "logs the error" do
-          perform_now
+        context "with a returned letter callback payload" do
+          let(:callback_payload) { { "notification_id" => "letter-uuid", "template_name" => "confirmation" } }
 
-          expect(Rails.logger).to have_received(:error).with(/Error running NotifyCallbackJob/)
-        end
-      end
+          it "extracts notification_id from the returned letter payload" do
+            perform_now
 
-      context "with a returned letter payload" do
-        let(:callback_payload) { { "notification_id" => "letter-uuid", "template_name" => "confirmation" } }
-
-        before do
-          allow(NotifyCallbackHandlerService).to receive(:run).and_raise(StandardError.new("Test error"))
-          allow(Airbrake).to receive(:notify)
-          allow(Rails.logger).to receive(:error)
-        end
-
-        it "extracts notification_id from the returned letter payload" do
-          perform_now
-
-          expect(Airbrake).to have_received(:notify).with(
-            an_instance_of(StandardError),
-            hash_including(notification_id: "letter-uuid")
-          )
+            expect(Airbrake).to have_received(:notify).with(
+              an_instance_of(StandardError),
+              hash_including(notification_id: "letter-uuid")
+            )
+          end
         end
       end
     end

--- a/spec/jobs/waste_exemptions_engine/notify_callback_job_spec.rb
+++ b/spec/jobs/waste_exemptions_engine/notify_callback_job_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe NotifyCallbackJob do
+    describe ".perform_later" do
+      subject(:perform_later) { described_class.perform_later(callback_payload) }
+
+      let(:callback_payload) { { "id" => "test-uuid", "status" => "delivered", "notification_type" => "email" } }
+
+      it { expect { perform_later }.not_to raise_error }
+
+      it { expect { perform_later }.to have_enqueued_job(described_class).exactly(:once) }
+    end
+
+    describe ".perform_now" do
+      subject(:perform_now) { described_class.perform_now(callback_payload) }
+
+      let(:callback_payload) { { "id" => "test-uuid", "status" => "delivered", "notification_type" => "email" } }
+      let(:service_result) { { notification_id: "test-uuid", status: "delivered" } }
+
+      before do
+        allow(NotifyCallbackHandlerService).to receive(:run).and_return(service_result)
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it "calls NotifyCallbackHandlerService with the payload" do
+        perform_now
+
+        expect(NotifyCallbackHandlerService).to have_received(:run).with(callback_payload)
+      end
+
+      it "logs the result" do
+        perform_now
+
+        expect(Rails.logger).to have_received(:info).with(/notification_id: test-uuid, status: delivered/)
+      end
+
+      context "when the handler raises an error" do
+        before do
+          allow(NotifyCallbackHandlerService).to receive(:run).and_raise(StandardError.new("Test error"))
+          allow(Airbrake).to receive(:notify)
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it "notifies Airbrake" do
+          perform_now
+
+          expect(Airbrake).to have_received(:notify).with(
+            an_instance_of(StandardError),
+            hash_including(notification_id: "test-uuid")
+          )
+        end
+
+        it "logs the error" do
+          perform_now
+
+          expect(Rails.logger).to have_received(:error).with(/Error running NotifyCallbackJob/)
+        end
+      end
+
+      context "with a returned letter payload" do
+        let(:callback_payload) { { "notification_id" => "letter-uuid", "template_name" => "confirmation" } }
+
+        before do
+          allow(NotifyCallbackHandlerService).to receive(:run).and_raise(StandardError.new("Test error"))
+          allow(Airbrake).to receive(:notify)
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it "extracts notification_id from the returned letter payload" do
+          perform_now
+
+          expect(Airbrake).to have_received(:notify).with(
+            an_instance_of(StandardError),
+            hash_including(notification_id: "letter-uuid")
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/waste_exemptions_engine/notify_callbacks_spec.rb
+++ b/spec/requests/waste_exemptions_engine/notify_callbacks_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe "NotifyCallbacks" do
+
+    describe "POST /notify_callback" do
+      subject(:callback_request) { post notify_callback_path, headers: headers, params: callback_body }
+
+      let(:callback_body) { file_fixture("notify/delivery_receipt_callback.json").read }
+      let(:bearer_token) { "test-bearer-token-123" }
+      let(:valid_headers) do
+        {
+          "Authorization" => "Bearer #{bearer_token}",
+          "Content-Type" => "application/json"
+        }
+      end
+
+      before do
+        allow(Airbrake).to receive(:notify)
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("NOTIFY_CALLBACK_BEARER_TOKEN", nil).and_return(bearer_token)
+      end
+
+      shared_examples "fails validation" do
+        it { expect { callback_request }.not_to have_enqueued_job(NotifyCallbackJob) }
+
+        it "notifies Airbrake" do
+          callback_request
+          expect(Airbrake).to have_received(:notify)
+        end
+
+        it "returns HTTP 200" do
+          callback_request
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "with no Authorization header" do
+        let(:headers) { { "Content-Type" => "application/json" } }
+
+        before { callback_request }
+
+        it_behaves_like "fails validation"
+      end
+
+      context "with an invalid bearer token" do
+        let(:headers) do
+          {
+            "Authorization" => "Bearer wrong-token",
+            "Content-Type" => "application/json"
+          }
+        end
+
+        before { callback_request }
+
+        it_behaves_like "fails validation"
+      end
+
+      context "with no configured bearer token" do
+        let(:headers) { valid_headers }
+
+        before do
+          allow(ENV).to receive(:fetch).with("NOTIFY_CALLBACK_BEARER_TOKEN", nil).and_return(nil)
+          callback_request
+        end
+
+        it_behaves_like "fails validation"
+      end
+
+      context "with a valid bearer token" do
+        let(:headers) { valid_headers }
+
+        it "returns HTTP 200" do
+          callback_request
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "does not notify Airbrake" do
+          callback_request
+
+          expect(Airbrake).not_to have_received(:notify)
+        end
+
+        it "enqueues a NotifyCallbackJob" do
+          expect { callback_request }.to have_enqueued_job(NotifyCallbackJob).exactly(:once)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/waste_exemptions_engine/notify_callback_handler_service_spec.rb
+++ b/spec/services/waste_exemptions_engine/notify_callback_handler_service_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe NotifyCallbackHandlerService do
+    let(:registration) { create(:registration) }
+    let(:communication_log) do
+      log = create(:communication_log, notification_id: notification_id, status: "sent")
+      registration.communication_logs << log
+      log
+    end
+    let(:notification_id) { "740e5834-3a29-46b4-9a6f-16142fde533a" }
+
+    describe ".run" do
+      context "with a delivery receipt callback" do
+        let(:payload) do
+          {
+            "id" => notification_id,
+            "reference" => "WEX999999",
+            "to" => "recipient@example.com",
+            "status" => "delivered",
+            "notification_type" => "email"
+          }
+        end
+
+        before { communication_log }
+
+        it "updates the communication log status" do
+          expect { described_class.run(payload) }
+            .to change { communication_log.reload.status }
+            .from("sent")
+            .to("delivered")
+        end
+
+        it "returns the notification_id and new status" do
+          result = described_class.run(payload)
+
+          expect(result).to eq(notification_id: notification_id, status: "delivered")
+        end
+
+        %w[permanent-failure temporary-failure technical-failure].each do |status|
+          context "when status is #{status}" do
+            let(:payload) do
+              {
+                "id" => notification_id,
+                "status" => status,
+                "notification_type" => "email"
+              }
+            end
+
+            it "updates the communication log status to #{status}" do
+              expect { described_class.run(payload) }
+                .to change { communication_log.reload.status }
+                .from("sent")
+                .to(status)
+            end
+          end
+        end
+
+        context "when the communication log is not found" do
+          let(:payload) do
+            {
+              "id" => "unknown-uuid",
+              "status" => "delivered",
+              "notification_type" => "email"
+            }
+          end
+
+          it "returns not_found status" do
+            result = described_class.run(payload)
+
+            expect(result).to eq(notification_id: "unknown-uuid", status: "not_found")
+          end
+
+          it "logs a warning" do
+            allow(Rails.logger).to receive(:warn)
+
+            described_class.run(payload)
+
+            expect(Rails.logger).to have_received(:warn).with(/not found/)
+          end
+        end
+
+        context "when the communication log already has a terminal status" do
+          before { communication_log.update!(status: "delivered") }
+
+          it "does not change the status" do
+            expect { described_class.run(payload) }
+              .not_to change { communication_log.reload.status }
+          end
+
+          it "returns the existing terminal status" do
+            result = described_class.run(payload)
+
+            expect(result).to eq(notification_id: notification_id, status: "delivered")
+          end
+        end
+
+        context "when id is missing" do
+          let(:payload) { { "status" => "delivered", "notification_type" => "email" } }
+
+          it "raises an ArgumentError" do
+            expect { described_class.run(payload) }.to raise_error(ArgumentError, /Missing id/)
+          end
+        end
+
+        context "when status is missing" do
+          let(:payload) { { "id" => notification_id, "notification_type" => "email" } }
+
+          it "raises an ArgumentError" do
+            expect { described_class.run(payload) }.to raise_error(ArgumentError, /Missing status/)
+          end
+        end
+      end
+
+      context "with a returned letter callback" do
+        let(:payload) do
+          {
+            "notification_id" => notification_id,
+            "reference" => "WEX999999",
+            "date_sent" => "2026-05-14T12:15:30.000000Z",
+            "template_name" => "confirmation_letter",
+            "template_id" => "f33517ff-2a88-4f6e-b855-c550268ce08a",
+            "template_version" => 1
+          }
+        end
+
+        before { communication_log }
+
+        it "updates the communication log status to returned" do
+          expect { described_class.run(payload) }
+            .to change { communication_log.reload.status }
+            .from("sent")
+            .to("returned")
+        end
+
+        it "returns the notification_id and returned status" do
+          result = described_class.run(payload)
+
+          expect(result).to eq(notification_id: notification_id, status: "returned")
+        end
+
+        context "when notification_id is blank" do
+          let(:payload) { { "notification_id" => "", "template_name" => "confirmation_letter" } }
+
+          it "raises an ArgumentError" do
+            expect { described_class.run(payload) }.to raise_error(ArgumentError, /Missing notification_id/)
+          end
+        end
+      end
+
+      context "with an unrecognised payload" do
+        let(:payload) { { "foo" => "bar" } }
+
+        it "raises an ArgumentError" do
+          expect { described_class.run(payload) }.to raise_error(ArgumentError, /Unrecognised/)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/factories/communication_log.rb
+++ b/spec/support/factories/communication_log.rb
@@ -5,5 +5,7 @@ FactoryBot.define do
     message_type { %w[letter email text].sample }
     template_id { SecureRandom.hex(12) }
     template_label { Faker::Lorem.word }
+    notification_id { SecureRandom.uuid }
+    status { "sent" }
   end
 end

--- a/spec/support/helpers/model_properties.rb
+++ b/spec/support/helpers/model_properties.rb
@@ -31,6 +31,10 @@ module Helpers
       template_id
       template_label
       sent_to
+      notification_id
+      status
+      subject
+      body
     ].freeze
 
     EXEMPTION = %i[


### PR DESCRIPTION
WEX - Implement message delivery status call back
https://eaflood.atlassian.net/browse/RUBY-4284

- Add index to communication_logs on notification_id
- Implement message delivery status callback and update communication log
- Add NotifyCallbackJob and corresponding specs for message delivery status handling
- Implement NotifyCallbacksController and associated routes for handling GOV.UK Notify callbacks