### PR TITLE
Feature/ruby 4332 wex security enable bundler cooldown give new gems a few days to be vetted

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   versioning-strategy: lockfile-only
+  cooldown:
+    default-days: 7
   ignore:
   - dependency-name: aasm
     versions:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 7
 
 # Declare your gem's dependencies in waste_exemptions_engine.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,4 +553,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.23
+  4.0.13

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,10 +208,10 @@ GEM
       retriable (~> 3.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    govuk_design_system_formbuilder (6.1.0)
-      actionview (>= 6.1)
-      activemodel (>= 6.1)
-      activesupport (>= 6.1)
+    govuk_design_system_formbuilder (6.2.0)
+      actionview (>= 7.2)
+      activemodel (>= 7.2)
+      activesupport (>= 7.2)
       html-attributes-utils (~> 1)
     hashdiff (1.2.1)
     hashery (2.1.2)
@@ -229,7 +229,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.8)
+    json (2.19.9)
     jwt (3.2.0)
       base64
     kaminari (1.2.2)
@@ -269,7 +269,7 @@ GEM
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -306,7 +306,7 @@ GEM
       ruby-rc4
       ttfunk
     pg (1.6.3)
-    phonelib (0.10.21)
+    phonelib (0.10.22)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -436,9 +436,10 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
-    rubocop-rspec (3.9.0)
+    rubocop-rspec (3.10.2)
       lint_roller (~> 1.1)
-      rubocop (~> 1.81)
+      regexp_parser (>= 2.0)
+      rubocop (~> 1.86, >= 1.86.2)
     rubocop-rspec_rails (2.32.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
@@ -505,7 +506,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.1)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/spec/requests/waste_exemptions_engine/govpay_forms_spec.rb
+++ b/spec/requests/waste_exemptions_engine/govpay_forms_spec.rb
@@ -298,7 +298,7 @@ module WasteExemptionsEngine
         context "when the payment does not have a successful registration associated with it" do
           it "redirects to new_start_form_path" do
             get payment_callback_govpay_forms_path(token, payment.payment_uuid)
-            expect(response.location).to match(%r{/start})
+            expect(response.location).to include("/start")
           end
 
           it "does not log an error" do

--- a/spec/support/shared_examples/requests/skip_to_manual_address.rb
+++ b/spec/support/shared_examples/requests/skip_to_manual_address.rb
@@ -4,6 +4,7 @@ RSpec.shared_examples "skip to manual address" do |form_factory, address_type:|
   let(:form) { build(form_factory) }
   let(:manual_address_request_path) { send("skip_to_manual_address_#{form_factory}s_path", token: form.token) }
   let(:manual_address_form_path) { send("#{address_type}_address_manual_forms_path", token: form.token) }
+
   status_code = WasteExemptionsEngine::ApplicationController::SUCCESSFUL_REDIRECTION_CODE
 
   describe "GET #{form_factory} skip to manual address" do


### PR DESCRIPTION
Enable Bundler and Dependbot Cooldown 
https://eaflood.atlassian.net/browse/RUBY-4332


- Enable dependabot cooldown to allow new gems a few days for vetting
- Enable Bundler cooldown for new gems versions
- Updated gem dependencies